### PR TITLE
Restore watchlist dark theme contrast

### DIFF
--- a/app/routes/lists+/.$username+/.$list-type+/grid/watchlist-grid.tsx
+++ b/app/routes/lists+/.$username+/.$list-type+/grid/watchlist-grid.tsx
@@ -7,6 +7,7 @@ import {
 	CellStyleModule,
 	ClientSideRowModelApiModule,
 	ClientSideRowModelModule,
+	colorSchemeDark,
 	DateEditorModule,
 	DateFilterModule,
 	type ColDef,
@@ -57,16 +58,20 @@ ModuleRegistry.registerModules([
 	TooltipModule,
 ])
 
-const watchlistTheme = themeQuartz.withParams({
+const watchlistTheme = themeQuartz.withPart(colorSchemeDark).withParams({
 	accentColor: '#ff9900',
 	backgroundColor: '#222222',
-	browserColorScheme: 'dark',
+	cellTextColor: '#e7e7e7',
 	fontFamily: 'var(--veud-font-sans)',
 	fontSize: 16,
+	foregroundColor: '#e7e7e7',
 	headerBackgroundColor: '#121212',
+	headerTextColor: '#ff9900',
 	oddRowBackgroundColor: '#2e2f2b',
 	rowBorder: false,
 	selectedRowBackgroundColor: 'rgba(64, 128, 99, 0.36)',
+	tooltipBackgroundColor: '#121212',
+	tooltipTextColor: '#e7e7e7',
 })
 
 export function getWatchlistRowId(params: { data: WatchlistRow }) {

--- a/tests/e2e/list-reliability.test.ts
+++ b/tests/e2e/list-reliability.test.ts
@@ -709,6 +709,72 @@ test('list grid fits the viewport and leaves missing scores blank', async ({
 	).toBeLessThanOrEqual(844)
 })
 
+test('watchlist metadata cells and header hints retain the dark theme contrast', async ({
+	page,
+	login,
+}) => {
+	const user = await login()
+	const listType = await prisma.listType.findUniqueOrThrow({
+		where: { name: 'liveaction' },
+	})
+	const watchlist = await prisma.watchlist.create({
+		data: {
+			name: 'metadata-contrast-list',
+			header: 'Metadata contrast list',
+			position: 1,
+			displayedColumns:
+				'position, title, airYear, startSeason, startYear, releaseStart, releaseEnd, startDate, finishedDate',
+			ownerId: user.id,
+			typeId: listType.id,
+		},
+	})
+	await prisma.entry.create({
+		data: {
+			watchlistId: watchlist.id,
+			position: 1,
+			title: 'Metadata contrast entry',
+			type: 'TV Series',
+			airYear: '2024',
+			startSeason: 'Fall',
+			startYear: '2024',
+			releaseStart: new Date('2024-10-01T00:00:00.000Z'),
+			releaseEnd: new Date('2025-03-31T00:00:00.000Z'),
+			history: JSON.stringify({
+				started: '2024-10-02T00:00:00.000Z',
+				finished: '2025-04-01T00:00:00.000Z',
+			}),
+		},
+	})
+
+	await page.goto(`/lists/${user.username}/liveaction/${watchlist.name}`)
+	const row = page
+		.locator('.ag-row')
+		.filter({ hasText: 'Metadata contrast entry' })
+	await expect(row).toBeVisible()
+
+	for (const column of [
+		'airYear',
+		'startSeason',
+		'startYear',
+		'releaseStart',
+		'releaseEnd',
+		'started',
+		'finished',
+	]) {
+		await expect(row.locator(`[col-id="${column}"]`)).toHaveCSS(
+			'color',
+			'rgb(231, 231, 231)',
+		)
+	}
+
+	const airYearHeader = page.locator('.ag-header-cell[col-id="airYear"]')
+	await airYearHeader.hover()
+	const headerHint = page.locator('.ag-tooltip').filter({ hasText: 'Air Year' })
+	await expect(headerHint).toBeVisible()
+	await expect(headerHint).toHaveCSS('color', 'rgb(231, 231, 231)')
+	await expect(headerHint).toHaveCSS('background-color', 'rgb(18, 18, 18)')
+})
+
 test('list landing keeps every list reachable inside the viewport', async ({
 	page,
 	login,


### PR DESCRIPTION
## What changed

- Apply AG Grid's complete dark color scheme to the desktop watchlist.
- Restore Veud's light cell text, orange headers, and dark header-tooltip treatment.
- Add a browser regression covering the metadata and date columns from Air Year through Finished Date.

## Why

The AG Grid v36 migration kept the grid's dark backgrounds but did not apply its dark foreground palette, allowing default cell and tooltip text to fall back to black.

## Validation

- Typecheck and ESLint
- Production build
- 16 watchlist reliability browser tests
- 17 accessibility browser tests