### PR TITLE
Fix nightly e2e rate limiting and Scorecard branch trigger

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
   branch_protection_rule:
   push:
     branches:
-      - main
+      - develop
   schedule:
     - cron: '19 12 * * 1'
 

--- a/app/routes/lists+/.$username+/.$list-type+/grid/watchlist-grid.tsx
+++ b/app/routes/lists+/.$username+/.$list-type+/grid/watchlist-grid.tsx
@@ -7,6 +7,7 @@ import {
 	CellStyleModule,
 	ClientSideRowModelApiModule,
 	ClientSideRowModelModule,
+	colorSchemeDark,
 	DateEditorModule,
 	DateFilterModule,
 	type ColDef,
@@ -57,16 +58,20 @@ ModuleRegistry.registerModules([
 	TooltipModule,
 ])
 
-const watchlistTheme = themeQuartz.withParams({
+const watchlistTheme = themeQuartz.withPart(colorSchemeDark).withParams({
 	accentColor: '#ff9900',
 	backgroundColor: '#222222',
-	browserColorScheme: 'dark',
+	cellTextColor: '#e7e7e7',
 	fontFamily: 'var(--veud-font-sans)',
 	fontSize: 16,
+	foregroundColor: '#e7e7e7',
 	headerBackgroundColor: '#121212',
+	headerTextColor: '#ff9900',
 	oddRowBackgroundColor: '#2e2f2b',
 	rowBorder: false,
 	selectedRowBackgroundColor: 'rgba(64, 128, 99, 0.36)',
+	tooltipBackgroundColor: '#121212',
+	tooltipTextColor: '#e7e7e7',
 })
 
 export function getWatchlistRowId(params: { data: WatchlistRow }) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,6 +47,9 @@ export default defineConfig({
 			// billable credential or making provider calls.
 			OPENAI_API_KEY: 'test-key',
 			VEUD_E2E: '1',
+			// The server runs in production mode, so this marker is what relaxes
+			// rate limits enough for a full browser suite from one address.
+			PLAYWRIGHT_TEST_BASE_URL: BASE_URL,
 			// Production-mode browser tests must generate verification links that
 			// point back to their isolated local origin, never the real site.
 			VEUD_ORIGIN: BASE_URL,

--- a/tests/e2e/list-reliability.test.ts
+++ b/tests/e2e/list-reliability.test.ts
@@ -709,6 +709,72 @@ test('list grid fits the viewport and leaves missing scores blank', async ({
 	).toBeLessThanOrEqual(844)
 })
 
+test('watchlist metadata cells and header hints retain the dark theme contrast', async ({
+	page,
+	login,
+}) => {
+	const user = await login()
+	const listType = await prisma.listType.findUniqueOrThrow({
+		where: { name: 'liveaction' },
+	})
+	const watchlist = await prisma.watchlist.create({
+		data: {
+			name: 'metadata-contrast-list',
+			header: 'Metadata contrast list',
+			position: 1,
+			displayedColumns:
+				'position, title, airYear, startSeason, startYear, releaseStart, releaseEnd, startDate, finishedDate',
+			ownerId: user.id,
+			typeId: listType.id,
+		},
+	})
+	await prisma.entry.create({
+		data: {
+			watchlistId: watchlist.id,
+			position: 1,
+			title: 'Metadata contrast entry',
+			type: 'TV Series',
+			airYear: '2024',
+			startSeason: 'Fall',
+			startYear: '2024',
+			releaseStart: new Date('2024-10-01T00:00:00.000Z'),
+			releaseEnd: new Date('2025-03-31T00:00:00.000Z'),
+			history: JSON.stringify({
+				started: '2024-10-02T00:00:00.000Z',
+				finished: '2025-04-01T00:00:00.000Z',
+			}),
+		},
+	})
+
+	await page.goto(`/lists/${user.username}/liveaction/${watchlist.name}`)
+	const row = page
+		.locator('.ag-row')
+		.filter({ hasText: 'Metadata contrast entry' })
+	await expect(row).toBeVisible()
+
+	for (const column of [
+		'airYear',
+		'startSeason',
+		'startYear',
+		'releaseStart',
+		'releaseEnd',
+		'started',
+		'finished',
+	]) {
+		await expect(row.locator(`[col-id="${column}"]`)).toHaveCSS(
+			'color',
+			'rgb(231, 231, 231)',
+		)
+	}
+
+	const airYearHeader = page.locator('.ag-header-cell[col-id="airYear"]')
+	await airYearHeader.hover()
+	const headerHint = page.locator('.ag-tooltip').filter({ hasText: 'Air Year' })
+	await expect(headerHint).toBeVisible()
+	await expect(headerHint).toHaveCSS('color', 'rgb(231, 231, 231)')
+	await expect(headerHint).toHaveCSS('background-color', 'rgb(18, 18, 18)')
+})
+
 test('list landing keeps every list reachable inside the viewport', async ({
 	page,
 	login,


### PR DESCRIPTION
## Failing CIs

1. **Nightly validation** (all three browser jobs) — e2e tests failed across chromium/webkit/firefox on auth-heavy flows.
2. **OpenSSF Scorecard** on pushes to `main` — failed with `validating options: only default branch is supported`.

## Root causes

**Nightly:** The Playwright error contexts show the app rendering `429 Too many requests, please try again later.` mid-suite. The e2e web server runs the production build (`NODE_ENV=production`), and the rate-limit bypass in `server/index.ts` keys off `PLAYWRIGHT_TEST_BASE_URL` — which nothing in the repo ever set. So every e2e run raced production rate limits (10 auth POSTs/min shared by the whole suite from one address); as the suite grew, nightly runs started tripping it, with retries compounding the exhaustion. Reproduced locally: 13 POSTs to `/login` → 429 from request 11.

**Scorecard:** the workflow triggered on pushes to `main`, but `scorecard-action` hard-fails on any branch that isn't the repo default (`develop`).

## Fixes

- Set `PLAYWRIGHT_TEST_BASE_URL` in the Playwright `webServer` env so the server applies the intended test-mode rate-limit multiplier. Verified end-to-end: under Playwright the server now reports `RateLimit-Limit: 100000` (was `10`), and 15 consecutive auth POSTs no longer 429.
- Point the Scorecard `push` trigger at `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)