### PR TITLE
Open Tip of My Tongue to anonymous visitors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ node_modules
 # Local / deployment env files with secrets (the checked-in .env.example is kept)
 .env.*
 !.env.example
+
+# Claude Code local config
+.claude/
+CLAUDE.md

--- a/app/components/site-search.tsx
+++ b/app/components/site-search.tsx
@@ -98,9 +98,7 @@ export function SiteSearch({
 							<small>
 								{aiAvailable
 									? 'Describe it or add an image.'
-									: isSignedIn
-										? 'Search from remembered details.'
-										: 'Search details · sign in for AI.'}
+									: 'Search from remembered details.'}
 							</small>
 						</span>
 					</label>
@@ -129,7 +127,7 @@ export function SiteSearch({
 								<strong>Describe what you want</strong>
 								<small>
 									{discoveryAiAvailable
-										? 'Turn a request into editable filters.'
+										? 'Find titles that match your description.'
 										: 'Currently unavailable.'}
 								</small>
 							</span>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -178,9 +178,7 @@ export async function loader({ request, url }: LoaderFunctionArgs) {
 			user,
 			unreadNotificationCount,
 			listTypes,
-			aiSearchAvailable: Boolean(
-				userId && isAiCapabilityConfigured('tip-of-tongue'),
-			),
+			aiSearchAvailable: isAiCapabilityConfigured('tip-of-tongue'),
 			aiDiscoveryAvailable: Boolean(
 				userId && isAiCapabilityConfigured('natural-language-discovery'),
 			),

--- a/app/routes/discover.route.test.ts
+++ b/app/routes/discover.route.test.ts
@@ -139,22 +139,48 @@ test('signed-in discovery returns unseen personalized results', async () => {
 	])
 })
 
-test('anonymous memory search stays catalog-local even when AI is configured', async () => {
-	await Promise.all(
-		Array.from({ length: 5 }, (_, index) =>
-			prisma.media.create({
-				data: {
-					kind: 'movie',
-					title: `Silver Observatory Match ${index + 1}`,
-					description:
-						'A child finds a silver observatory hidden beneath a desert town.',
-					catalogPopularity: 100 - index,
-				},
-			}),
-		),
-	)
+test('anonymous memory search uses AI suggestions when configured', async () => {
+	const expected = await prisma.media.create({
+		data: {
+			kind: 'movie',
+			title: 'Silver Observatory Match',
+			description:
+				'A child finds a silver observatory hidden beneath a desert town.',
+			catalogPopularity: 100,
+		},
+	})
 	vi.stubEnv('OPENAI_API_KEY', 'configured-key')
-	const fetchMock = vi.fn<typeof fetch>()
+	const suggestions = Array.from({ length: 5 }, (_, index) => ({
+		title:
+			index === 0
+				? 'Silver Observatory Match'
+				: `Unavailable catalog suggestion ${index + 1}`,
+		alternateTitle: null,
+		year: null,
+		kind: 'movie',
+		reason:
+			'Silver Observatory Match may match the silver observatory and desert.',
+		matchedClues: ['silver', 'observatory', 'desert'],
+	}))
+	const fetchMock = vi.fn<typeof fetch>(
+		async () =>
+			new Response(
+				JSON.stringify({
+					output: [
+						{
+							type: 'message',
+							content: [
+								{
+									type: 'output_text',
+									text: JSON.stringify({ suggestions }),
+								},
+							],
+						},
+					],
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			),
+	)
 	vi.stubGlobal('fetch', fetchMock)
 
 	const result = await loader({
@@ -164,15 +190,15 @@ test('anonymous memory search stays catalog-local even when AI is configured', a
 		params: {},
 	} as any)
 
-	expect(fetchMock).not.toHaveBeenCalled()
-	expect(result.data.aiSearchAvailable).toBe(false)
-	expect(result.data.memorySearchSource).toBe('catalog-match')
-	expect(result.data.memorySearchFallbackReason).toBe('sign-in-required')
-	expect(result.data.items).toHaveLength(5)
+	expect(fetchMock).toHaveBeenCalled()
+	expect(result.data.aiSearchAvailable).toBe(true)
+	expect(result.data.memorySearchSource).toBe('ai')
+	expect(result.data.memorySearchFallbackReason).toBe(null)
 	expect(result.data.items).toEqual(
 		expect.arrayContaining([
 			expect.objectContaining({
-				title: 'Silver Observatory Match 1',
+				id: expected.id,
+				title: 'Silver Observatory Match',
 				memoryMatch: expect.objectContaining({
 					matchedClues: expect.arrayContaining([
 						'silver',

--- a/app/routes/discover.tsx
+++ b/app/routes/discover.tsx
@@ -49,6 +49,7 @@ import {
 	NaturalLanguageDiscoveryPlanSchema,
 	type NaturalLanguageDiscoveryPlan,
 } from '#app/utils/natural-language-discovery.ts'
+import { anonymousRateLimitKey } from '#app/utils/proxy-security.server.ts'
 import { getRecommendationGraph } from '#app/utils/recommendation-graph.server.ts'
 import { getTipOfTongueMatches } from '#app/utils/tip-of-tongue.server.ts'
 import '#app/styles/discover.scss'
@@ -367,8 +368,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 						kind: filters.kind,
 					},
 					{
-						allowAi: Boolean(viewerId),
-						rateLimitKey: viewerId ? `viewer:${viewerId}` : undefined,
+						allowAi: true,
+						rateLimitKey: viewerId
+							? `viewer:${viewerId}`
+							: anonymousRateLimitKey(request.headers),
 					},
 				)
 			: filters.mode === 'memory'
@@ -428,15 +431,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
 		memorySearchSource: memorySearch?.source ?? null,
 		memorySearchFallbackReason: memorySearch?.fallbackReason ?? null,
 		memoryQueryTooShort,
-		aiSearchAvailable: Boolean(
-			viewerId && isAiCapabilityConfigured('tip-of-tongue'),
-		),
+		aiSearchAvailable: isAiCapabilityConfigured('tip-of-tongue'),
 		naturalDiscoveryAvailable: Boolean(
 			viewerId && isAiCapabilityConfigured('natural-language-discovery'),
 		),
-		imageSearchAvailable: Boolean(
-			viewerId && isAiCapabilityConfigured('image-tip-of-tongue'),
-		),
+		imageSearchAvailable: isAiCapabilityConfigured('image-tip-of-tongue'),
 		genres,
 		statuses,
 		watchlists,
@@ -469,7 +468,7 @@ function memorySearchStatus(data: {
 	if (data.memorySearchSource === 'ai') return 'AI match'
 	switch (data.memorySearchFallbackReason) {
 		case 'sign-in-required':
-			return 'Local match · sign in for AI'
+			return 'Local match'
 		case 'rate-limited':
 			return 'Local match · AI limit reached'
 		case 'ai-unavailable':
@@ -628,7 +627,7 @@ export default function DiscoverRoute() {
 				method={data.filters.mode === 'describe' ? 'post' : 'get'}
 				className={`discover-search-panel ${data.filters.mode !== 'standard' ? 'discover-search-panel--memory' : ''}`}
 				onSubmit={event => {
-					if (data.filters.mode !== 'memory' || !data.isSignedIn) return
+					if (data.filters.mode !== 'memory') return
 					event.preventDefault()
 					imageFetcher.submit(new FormData(event.currentTarget), {
 						method: 'post',
@@ -669,7 +668,7 @@ export default function DiscoverRoute() {
 								rows={5}
 								autoFocus
 							/>
-							{data.filters.mode === 'memory' && data.isSignedIn ? (
+							{data.filters.mode === 'memory' && data.imageSearchAvailable ? (
 								<label className="discover-memory-attachment">
 									<span>Add an image</span>
 									<input

--- a/app/routes/resources+/home-memory-search.route.test.ts
+++ b/app/routes/resources+/home-memory-search.route.test.ts
@@ -3,7 +3,7 @@ import { prisma } from '#app/utils/db.server.ts'
 import { BASE_URL } from '#tests/utils.ts'
 import { action } from './home-memory-search.ts'
 
-test('anonymous home memory search returns grounded catalog matches without AI', async () => {
+test('anonymous home memory search asks AI and stays catalog-grounded', async () => {
 	const matches = await Promise.all(
 		Array.from({ length: 5 }, (_, index) =>
 			prisma.media.create({
@@ -18,7 +18,33 @@ test('anonymous home memory search returns grounded catalog matches without AI',
 		),
 	)
 	vi.stubEnv('OPENAI_API_KEY', 'configured-key')
-	const fetchMock = vi.fn<typeof fetch>()
+	const suggestions = matches.map((match, index) => ({
+		title: match.title,
+		alternateTitle: null,
+		year: null,
+		kind: 'movie',
+		reason: `Amber Lighthouse ${index + 1} matches the lighthouse and journal.`,
+		matchedClues: ['isolated', 'lighthouse', 'journal'],
+	}))
+	const fetchMock = vi.fn<typeof fetch>(
+		async () =>
+			new Response(
+				JSON.stringify({
+					output: [
+						{
+							type: 'message',
+							content: [
+								{
+									type: 'output_text',
+									text: JSON.stringify({ suggestions }),
+								},
+							],
+						},
+					],
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			),
+	)
 	vi.stubGlobal('fetch', fetchMock)
 	const formData = new FormData()
 	formData.set(
@@ -37,7 +63,7 @@ test('anonymous home memory search returns grounded catalog matches without AI',
 
 	expect(response.data.ok).toBe(true)
 	if (!response.data.ok) throw new Error(response.data.error)
-	expect(fetchMock).not.toHaveBeenCalled()
+	expect(fetchMock).toHaveBeenCalled()
 	expect(response.data.items).toHaveLength(5)
 	expect(response.data.items.map(item => item.id)).toEqual(
 		expect.arrayContaining(matches.map(item => item.id)),

--- a/app/routes/resources+/home-memory-search.ts
+++ b/app/routes/resources+/home-memory-search.ts
@@ -4,6 +4,7 @@ import {
 	getDiscoveryResultsForMediaIds,
 	parseDiscoveryQuery,
 } from '#app/utils/discovery.server.ts'
+import { anonymousRateLimitKey } from '#app/utils/proxy-security.server.ts'
 import { getTipOfTongueMatches } from '#app/utils/tip-of-tongue.server.ts'
 
 const AnonymousMemorySearchSchema = z.object({
@@ -24,7 +25,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 	const result = await getTipOfTongueMatches(
 		{ memory: fields.data.q, kind: fields.data.kind },
-		{ allowAi: false },
+		{ allowAi: true, rateLimitKey: anonymousRateLimitKey(request.headers) },
 	)
 	const filters = parseDiscoveryQuery(
 		new URLSearchParams({

--- a/app/routes/resources+/image-tip-of-tongue.ts
+++ b/app/routes/resources+/image-tip-of-tongue.ts
@@ -5,11 +5,12 @@ import {
 } from '@remix-run/form-data-parser'
 import { data as json, type ActionFunctionArgs } from 'react-router'
 import { z } from 'zod'
-import { requireUserId } from '#app/utils/auth.server.ts'
+import { getUserId } from '#app/utils/auth.server.ts'
 import {
 	getDiscoveryResultsForMediaIds,
 	parseDiscoveryQuery,
 } from '#app/utils/discovery.server.ts'
+import { anonymousRateLimitKey } from '#app/utils/proxy-security.server.ts'
 import {
 	getImageTipOfTongueMatches,
 	getTipOfTongueMatches,
@@ -22,7 +23,10 @@ const FieldsSchema = z.object({
 })
 
 export async function action({ request }: ActionFunctionArgs) {
-	const ownerId = await requireUserId(request)
+	const ownerId = await getUserId(request)
+	const rateLimitKey = ownerId
+		? `viewer:${ownerId}`
+		: anonymousRateLimitKey(request.headers)
 	const contentLength = Number(request.headers.get('content-length') ?? '0')
 	if (Number.isFinite(contentLength) && contentLength > 6.5 * 1024 * 1024) {
 		return json(
@@ -77,11 +81,11 @@ export async function action({ request }: ActionFunctionArgs) {
 		const result = hasImage
 			? await getImageTipOfTongueMatches(
 					{ image, ...fields.data },
-					{ rateLimitKey: `viewer:${ownerId}` },
+					{ rateLimitKey },
 				)
 			: await getTipOfTongueMatches(
 					{ memory: fields.data.prompt, kind: fields.data.kind },
-					{ allowAi: true, rateLimitKey: `viewer:${ownerId}` },
+					{ allowAi: true, rateLimitKey },
 				)
 		const filters = parseDiscoveryQuery(
 			new URLSearchParams({ kind: fields.data.kind, mode: 'memory' }),

--- a/app/utils/proxy-security.server.ts
+++ b/app/utils/proxy-security.server.ts
@@ -29,3 +29,13 @@ export function rateLimitClientKey({
 	}
 	return requestAddress || socketAddress || 'unknown'
 }
+
+// Route handlers only see request headers, so anonymous AI budgets key off the
+// proxied client address and fall back to one shared bucket when none is sent.
+export function anonymousRateLimitKey(headers: Headers) {
+	const cloudflareIp = headers.get('cf-connecting-ip')?.trim()
+	if (cloudflareIp && net.isIP(cloudflareIp)) return `anonymous:${cloudflareIp}`
+	const forwardedIp = headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+	if (forwardedIp && net.isIP(forwardedIp)) return `anonymous:${forwardedIp}`
+	return 'anonymous:shared'
+}


### PR DESCRIPTION
Anonymous visitors previously always fell back to catalog-only matching because every Tip of My Tongue AI gate required a signed-in viewer, undercutting the AI search as a draw for new users.

## Changes

- Run the TOMT AI path for signed-out visitors on the anonymous home demo, `/discover` memory mode, and the global advanced search, including image clues.
- Key anonymous AI budgets to a per-address rate-limit bucket (`anonymous:<ip>`, shared fallback) via a new `anonymousRateLimitKey` helper, mirroring the vetted Cloudflare header handling in `proxy-security.server.ts`.
- Drop the signed-in requirement from `aiSearchAvailable`/`imageSearchAvailable` flags and the related "sign in for AI" UI copy.
- Clarify the advanced-search "Describe what you want" hint: "Find titles that match your description."
- Update route tests to pin the new anonymous AI behavior; also ignore local Claude configuration files.

Verified with the affected Vitest suites (20 passing) and the anonymous-home + discover Playwright suites (8 passing).