### PR TITLE
Restore Scorecard trigger to main

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
   branch_protection_rule:
   push:
     branches:
-      - develop
+      - main
   schedule:
     - cron: '19 12 * * 1'
 

--- a/app/components/site-search.tsx
+++ b/app/components/site-search.tsx
@@ -127,7 +127,7 @@ export function SiteSearch({
 								<strong>Describe what you want</strong>
 								<small>
 									{discoveryAiAvailable
-										? 'Find titles that match your description.'
+										? 'Find titles that match what you describe.'
 										: 'Currently unavailable.'}
 								</small>
 							</span>


### PR DESCRIPTION
With the default branch set back to `main`, scorecard-action fails on any other branch. This reverts the #80 trigger change on `develop` so the next promotion carries the correct config to `main`. Dependabot is unaffected (its `target-branch: develop` is explicit).

Also fixes the Browser failure that #91 introduced: the new describe-mode hint contained the word "description", so the advanced-search checkbox collided with `getByLabel('Description')` in the collections suite. The hint now reads "Find titles that match what you describe."