### PR TITLE
Preview busy calendar days with full day pages

### DIFF
--- a/app/components/release-calendar-item.tsx
+++ b/app/components/release-calendar-item.tsx
@@ -1,0 +1,177 @@
+import { Form, Link } from 'react-router'
+import { Button } from '#app/components/ui/button.tsx'
+
+export const releaseCalendarKindLabels = {
+	all: 'All media',
+	movie: 'Movies',
+	tv: 'TV',
+	anime: 'Anime',
+	manga: 'Manga',
+} as const
+
+export function displayCalendarDay(value: string) {
+	return new Date(`${value}T00:00:00.000Z`).toLocaleDateString('en-US', {
+		weekday: 'long',
+		month: 'short',
+		day: 'numeric',
+		timeZone: 'UTC',
+	})
+}
+
+function displayTime(value: Date | string, allDay: boolean, timeZone: string) {
+	if (allDay) return 'All day'
+	return new Date(value).toLocaleTimeString('en-US', {
+		hour: 'numeric',
+		minute: '2-digit',
+		timeZone,
+		timeZoneName: 'short',
+	})
+}
+
+function reminderLeadLabel(leadMinutes: number) {
+	if (leadMinutes === 0) return 'At release'
+	if (leadMinutes === 60) return '1 hour before'
+	if (leadMinutes === 1440) return '1 day before'
+	return `${leadMinutes} minutes before`
+}
+
+export type ReleaseCalendarItemView = {
+	id: string
+	mediaId: string
+	title: string
+	kind: string
+	type: string | null
+	imageUrl: string | null
+	releaseAt: Date | string
+	allDay: boolean
+	eventType: 'premiere' | 'episode' | 'chapter' | 'release'
+	eventLabel: string
+	eventName: string | null
+	trackerCount: number
+	viewerTracking: {
+		status: string
+		statusLabel: string
+		score: number | null
+	} | null
+	viewerReminder: {
+		id: string
+		leadMinutes: number
+	} | null
+}
+
+export function ReleaseCalendarItem({
+	item,
+	timeZone,
+	isSignedIn,
+}: {
+	item: ReleaseCalendarItemView
+	timeZone: string
+	isSignedIn: boolean
+}) {
+	return (
+		<article
+			key={item.id}
+			className="grid gap-3 p-4 transition-colors hover:bg-veud-ink/35 sm:grid-cols-[6.75rem_4rem_minmax(0,1fr)]"
+		>
+			<div className="sm:pt-1">
+				<div className="font-black tabular-nums text-veud-mint">
+					{displayTime(item.releaseAt, item.allDay, timeZone)}
+				</div>
+				<div className="mt-1 text-[0.68rem] font-bold uppercase tracking-[0.12em] text-veud-sage">
+					{item.type ||
+						releaseCalendarKindLabels[
+							item.kind as keyof typeof releaseCalendarKindLabels
+						] ||
+						item.kind}
+				</div>
+			</div>
+			<Link
+				to={`/media/${item.mediaId}`}
+				className="h-24 w-16 overflow-hidden rounded-lg bg-veud-ink shadow-md"
+			>
+				{item.imageUrl ? (
+					<img
+						src={item.imageUrl}
+						alt=""
+						loading="lazy"
+						className="h-full w-full object-cover"
+					/>
+				) : (
+					<span className="flex h-full items-center justify-center px-2 text-center text-[0.65rem] text-veud-sage">
+						No poster
+					</span>
+				)}
+			</Link>
+			<div className="min-w-0 flex-1">
+				<Link
+					to={`/media/${item.mediaId}`}
+					className="block text-base font-black leading-5 text-veud-yellow hover:underline"
+				>
+					{item.title}
+				</Link>
+				<div className="mt-1 flex flex-wrap items-center gap-2">
+					<span
+						className={`rounded-full px-2 py-0.5 text-xs font-bold ${item.eventType === 'premiere' ? 'bg-veud-amber/15 text-veud-gold' : item.eventType === 'chapter' ? 'bg-violet-300/15 text-violet-200' : 'bg-veud-mint/10 text-veud-mint'}`}
+					>
+						{item.eventLabel}
+					</span>
+					{item.eventName ? (
+						<span className="line-clamp-1 text-xs text-veud-copy">
+							{item.eventName}
+						</span>
+					) : null}
+				</div>
+				<div className="mt-2 flex flex-wrap gap-1.5 text-[0.7rem] text-veud-mint">
+					{item.viewerTracking ? (
+						<span className="rounded-full bg-veud-mint/10 px-2 py-0.5 font-bold text-veud-mint">
+							{item.viewerTracking.statusLabel}
+							{item.viewerTracking.score !== null
+								? ` · ${item.viewerTracking.score.toLocaleString('en-US', { maximumFractionDigits: 1 })}/10`
+								: ''}
+						</span>
+					) : null}
+					<span className="rounded-full bg-veud-ink px-2 py-0.5">
+						{item.trackerCount}{' '}
+						{item.trackerCount === 1 ? 'member' : 'members'} tracking
+					</span>
+				</div>
+				{isSignedIn ? (
+					item.viewerReminder ? (
+						<Form method="post" className="mt-3">
+							<input
+								type="hidden"
+								name="intent"
+								value="release-reminder-delete"
+							/>
+							<input type="hidden" name="mediaId" value={item.mediaId} />
+							<Button
+								type="submit"
+								variant="ghost"
+								size="sm"
+								aria-label={`Remove reminder for ${item.title}`}
+								className="text-veud-mint"
+							>
+								Reminder on ·{' '}
+								{reminderLeadLabel(item.viewerReminder.leadMinutes)}
+							</Button>
+						</Form>
+					) : (
+						<Form method="post" className="mt-3">
+							<input type="hidden" name="intent" value="release-reminder-save" />
+							<input type="hidden" name="mediaId" value={item.mediaId} />
+							<input type="hidden" name="leadMinutes" value="60" />
+							<Button
+								type="submit"
+								variant="outline"
+								size="sm"
+								aria-label={`Set reminder for ${item.title}`}
+							>
+								Remind me · 1 hour before
+							</Button>
+						</Form>
+					)
+				) : null}
+			</div>
+		</article>
+	)
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -78,6 +78,7 @@ export default [
 		path: 'collections/:collectionId',
 	}),
 	appRoute('routes/calendar.tsx', { path: 'calendar' }),
+	appRoute('routes/calendar.$day.tsx', { path: 'calendar/:day' }),
 	appRoute('routes/assistant.tsx', { path: 'assistant' }),
 	appRoute('routes/credits.tsx', { path: 'credits' }),
 	appRoute('routes/discover.tsx', { path: 'discover' }),

--- a/app/routes/calendar.$day.tsx
+++ b/app/routes/calendar.$day.tsx
@@ -1,0 +1,173 @@
+import {
+	data as json,
+	Link,
+	type ActionFunctionArgs,
+	type LoaderFunctionArgs,
+	type MetaFunction,
+	useLoaderData,
+} from 'react-router'
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
+import {
+	displayCalendarDay,
+	ReleaseCalendarItem,
+} from '#app/components/release-calendar-item.tsx'
+import { Button } from '#app/components/ui/button.tsx'
+import { VeudPage, VeudPageHeader } from '#app/components/ui/veud-layout.tsx'
+import { getUserId } from '#app/utils/auth.server.ts'
+import { getHints } from '#app/utils/client-hints.tsx'
+import {
+	getReleaseCalendar,
+	parseReleaseCalendarQuery,
+	type ReleaseCalendarQuery,
+} from '#app/utils/release-calendar.server.ts'
+import { releaseReminderAction } from './calendar.server.ts'
+
+const DAY_PARAM = /^\d{4}-\d{2}-\d{2}$/
+
+function dayHref(filters: ReleaseCalendarQuery, week: string, date: string) {
+	const search = new URLSearchParams({
+		kind: filters.kind,
+		scope: filters.scope,
+		week,
+	})
+	return `/calendar/${date}?${search.toString()}`
+}
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+	const day = params.day ?? ''
+	if (
+		!DAY_PARAM.test(day) ||
+		Number.isNaN(new Date(`${day}T00:00:00.000Z`).getTime())
+	) {
+		throw new Response('Not found', { status: 404 })
+	}
+	const viewerId = await getUserId(request)
+	const timeZone = getHints(request).timeZone
+	const url = new URL(request.url)
+	const search = new URLSearchParams(url.searchParams)
+	search.set('start', day)
+	const filters = parseReleaseCalendarQuery(search, new Date(), timeZone)
+	const calendar = await getReleaseCalendar(filters, viewerId, timeZone, {
+		days: 1,
+	})
+	const week = url.searchParams.get('week')
+	return json({
+		...calendar,
+		day,
+		// The overflow link that brought the visitor here remembers its week so
+		// the back link returns to the exact view they left.
+		weekStart: week && DAY_PARAM.test(week) ? week : null,
+	})
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+	return releaseReminderAction(request)
+}
+
+export default function ReleaseCalendarDayRoute() {
+	const data = useLoaderData<typeof loader>()
+	const day = data.days[0]
+	const weekHref = `/calendar?${new URLSearchParams({
+		start: data.weekStart ?? data.day,
+		kind: data.filters.kind,
+		scope: data.filters.scope,
+	}).toString()}`
+
+	return (
+		<VeudPage>
+			<VeudPageHeader
+				eyebrow="Release calendar"
+				title={displayCalendarDay(data.day)}
+				actions={
+					<div className="space-y-3 sm:text-right">
+						<div className="text-sm font-semibold text-veud-mint">
+							{data.total} scheduled {data.total === 1 ? 'release' : 'releases'}
+						</div>
+						<Button asChild variant="outline" size="sm">
+							<Link to={weekHref}>← Back to week view</Link>
+						</Button>
+					</div>
+				}
+			/>
+
+			<nav
+				aria-label="Calendar days"
+				className="flex flex-wrap items-center justify-between gap-3"
+			>
+				<Button asChild variant="outline">
+					<Link
+						to={dayHref(
+							data.filters,
+							data.weekStart ?? data.previousStart,
+							data.previousStart,
+						)}
+					>
+						← {displayCalendarDay(data.previousStart)}
+					</Link>
+				</Button>
+				<Button asChild variant="outline">
+					<Link
+						to={dayHref(
+							data.filters,
+							data.weekStart ?? data.nextStart,
+							data.nextStart,
+						)}
+					>
+						{displayCalendarDay(data.nextStart)} →
+					</Link>
+				</Button>
+			</nav>
+
+			<section
+				aria-labelledby={`calendar-day-${data.day}`}
+				className={`grid overflow-hidden rounded-2xl border bg-veud-surface shadow-lg shadow-black/10 ${data.day === data.today ? 'border-veud-gold ring-1 ring-veud-gold/25' : 'border-veud-border'}`}
+			>
+				<header className="flex items-center justify-between gap-3 border-b border-veud-border/70 px-4 py-3">
+					<h2
+						id={`calendar-day-${data.day}`}
+						className="text-lg font-[var(--veud-font-display)] font-black text-veud-yellow"
+					>
+						Every release this day
+					</h2>
+					{data.day === data.today ? (
+						<span className="rounded-full bg-veud-gold/15 px-2 py-1 text-xs font-bold text-veud-gold">
+							Today
+						</span>
+					) : null}
+				</header>
+				{day?.items.length ? (
+					<div className="divide-y divide-veud-border/50">
+						{day.items.map(item => (
+							<ReleaseCalendarItem
+								key={item.id}
+								item={item}
+								timeZone={data.timeZone}
+								isSignedIn={data.isSignedIn}
+							/>
+						))}
+					</div>
+				) : (
+					<p className="flex items-center px-4 py-5 text-sm text-veud-sage">
+						Nothing scheduled
+					</p>
+				)}
+			</section>
+		</VeudPage>
+	)
+}
+
+export const meta: MetaFunction<typeof loader> = ({ loaderData }) => [
+	{
+		title: loaderData
+			? `Releases on ${displayCalendarDay(loaderData.day)} · Veud`
+			: 'Release calendar · Veud',
+	},
+	{
+		name: 'description',
+		content: 'Every movie, TV, anime, and manga release scheduled for the day.',
+	},
+]
+
+export function ErrorBoundary() {
+	return <GeneralErrorBoundary />
+}

--- a/app/routes/calendar.day.route.test.ts
+++ b/app/routes/calendar.day.route.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from 'vitest'
+import { prisma } from '#app/utils/db.server.ts'
+import { BASE_URL } from '#tests/utils.ts'
+import { loader } from './calendar.$day.tsx'
+
+test('day page lists every release for the day in schedule order', async () => {
+	await Promise.all(
+		['A', 'B', 'C', 'D', 'E', 'F', 'G'].map(letter =>
+			prisma.media.create({
+				data: {
+					kind: 'anime',
+					title: `Full Day ${letter}`,
+					releaseStart: new Date('2026-07-21T00:00:00.000Z'),
+				},
+			}),
+		),
+	)
+
+	const result = await loader({
+		request: new Request(`${BASE_URL}/calendar/2026-07-21?week=2026-07-20`),
+		params: { day: '2026-07-21' },
+	} as any)
+
+	expect(result.data.day).toBe('2026-07-21')
+	expect(result.data.weekStart).toBe('2026-07-20')
+	expect(result.data.days).toHaveLength(1)
+	const titles = result.data.days[0]!.items.map(item => item.title)
+	expect(titles).toEqual(
+		['A', 'B', 'C', 'D', 'E', 'F', 'G'].map(letter => `Full Day ${letter}`),
+	)
+	expect(result.data.days[0]!.totalCount).toBe(7)
+	expect(result.data.previousStart).toBe('2026-07-20')
+	expect(result.data.nextStart).toBe('2026-07-22')
+})
+
+test('day page rejects malformed dates', async () => {
+	await expect(
+		loader({
+			request: new Request(`${BASE_URL}/calendar/not-a-day`),
+			params: { day: 'not-a-day' },
+		} as any),
+	).rejects.toMatchObject({ status: 404 })
+})

--- a/app/routes/calendar.route.test.ts
+++ b/app/routes/calendar.route.test.ts
@@ -293,3 +293,75 @@ test('calendar actions set and remove the viewer reminder shown on a release', a
 		}),
 	).toBe(0)
 })
+
+test('busy days preview five releases prioritizing viewer and popular titles', async () => {
+	const { viewer, watching, cookie } = await viewerFixture()
+	const titles = ['A', 'B', 'C', 'D', 'E', 'F', 'G'].map(
+		letter => `Busy Day ${letter}`,
+	)
+	const media = await Promise.all(
+		titles.map(title =>
+			prisma.media.create({
+				data: {
+					kind: 'anime',
+					title,
+					releaseStart: new Date('2026-07-21T00:00:00.000Z'),
+				},
+			}),
+		),
+	)
+	const tracked = media[titles.indexOf('Busy Day G')]!
+	const popular = media[titles.indexOf('Busy Day F')]!
+	// Keep the viewer's tracking private so the anonymous view can only see
+	// community interest, not the viewer's own priority.
+	await prisma.watchlist.update({
+		where: { id: watching.id },
+		data: { isPublic: false },
+	})
+	await prisma.trackingState.create({
+		data: {
+			ownerId: viewer.id,
+			mediaId: tracked.id,
+			status: 'watching',
+			statusWatchlistId: watching.id,
+		},
+	})
+	const fan = await prisma.user.create({
+		data: {
+			email: `calendar_fan_${viewer.username}@example.com`,
+			username: `calendar_fan_${viewer.username}`,
+		},
+	})
+	await prisma.trackingState.create({
+		data: { ownerId: fan.id, mediaId: popular.id, status: 'watching' },
+	})
+
+	const result = await loader({
+		request: new Request(`${BASE_URL}/calendar?start=2026-07-20`, {
+			headers: { cookie },
+		}),
+		params: {},
+	} as any)
+	const day = result.data.days.find(entry => entry.date === '2026-07-21')
+	expect(day?.totalCount).toBe(7)
+	expect(day?.items).toHaveLength(5)
+	const shownTitles = day!.items.map(item => item.title)
+	// Viewer-tracked and community-tracked titles survive the cut even though
+	// alphabetical time ordering would have dropped them.
+	expect(shownTitles).toContain('Busy Day G')
+	expect(shownTitles).toContain('Busy Day F')
+	// The preview itself stays in schedule order.
+	expect(shownTitles).toEqual([...shownTitles].sort())
+
+	const anonymous = await loader({
+		request: new Request(`${BASE_URL}/calendar?start=2026-07-20`),
+		params: {},
+	} as any)
+	const anonymousDay = anonymous.data.days.find(
+		entry => entry.date === '2026-07-21',
+	)
+	expect(anonymousDay?.items.map(item => item.title)).toContain('Busy Day F')
+	expect(anonymousDay?.items.map(item => item.title)).not.toContain(
+		'Busy Day G',
+	)
+})

--- a/app/routes/calendar.server.ts
+++ b/app/routes/calendar.server.ts
@@ -1,0 +1,65 @@
+import { data as json } from 'react-router'
+import { z } from 'zod'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import {
+	releaseReminderLeadMinutes,
+	removeReleaseReminder,
+	saveReleaseReminder,
+	type ReleaseReminderLeadMinutes,
+} from '#app/utils/release-reminders.server.ts'
+
+const ReminderLeadSchema = z.coerce
+	.number()
+	.int()
+	.refine(value =>
+		releaseReminderLeadMinutes.includes(value as ReleaseReminderLeadMinutes),
+	)
+	.transform(value => value as ReleaseReminderLeadMinutes)
+
+const ReminderActionSchema = z.discriminatedUnion('intent', [
+	z.object({
+		intent: z.literal('release-reminder-save'),
+		mediaId: z.string().min(1).max(100),
+		leadMinutes: ReminderLeadSchema,
+	}),
+	z.object({
+		intent: z.literal('release-reminder-delete'),
+		mediaId: z.string().min(1).max(100),
+	}),
+])
+
+// Both the weekly calendar and the per-day pages post reminder toggles to
+// their own URL, so they share this action.
+export async function releaseReminderAction(request: Request) {
+	const viewerId = await requireUserId(request)
+	const parsed = ReminderActionSchema.safeParse(
+		Object.fromEntries(await request.formData()),
+	)
+	if (!parsed.success) {
+		throw new Response('Invalid reminder action', { status: 400 })
+	}
+	const media = await prisma.media.findUnique({
+		where: { id: parsed.data.mediaId },
+		select: { id: true },
+	})
+	if (!media) throw new Response('Media not found', { status: 404 })
+
+	if (parsed.data.intent === 'release-reminder-save') {
+		const leadMinutes = parsed.data.leadMinutes
+		const reminder = await prisma.$transaction(transaction =>
+			saveReleaseReminder(transaction, {
+				ownerId: viewerId,
+				mediaId: media.id,
+				leadMinutes,
+			}),
+		)
+		return json({ ok: true, reminderId: reminder.id })
+	}
+
+	await removeReleaseReminder(prisma, {
+		ownerId: viewerId,
+		mediaId: media.id,
+	})
+	return json({ ok: true })
+}

--- a/app/routes/calendar.tsx
+++ b/app/routes/calendar.tsx
@@ -7,54 +7,25 @@ import {
 	type MetaFunction,
 	useLoaderData,
 } from 'react-router'
-import { z } from 'zod'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
+import {
+	displayCalendarDay,
+	ReleaseCalendarItem,
+	releaseCalendarKindLabels,
+} from '#app/components/release-calendar-item.tsx'
 import { Button } from '#app/components/ui/button.tsx'
 import { Input } from '#app/components/ui/input.tsx'
 import { Label } from '#app/components/ui/label.tsx'
 import { VeudPage, VeudPageHeader } from '#app/components/ui/veud-layout.tsx'
-import { getUserId, requireUserId } from '#app/utils/auth.server.ts'
+import { getUserId } from '#app/utils/auth.server.ts'
 import { getHints } from '#app/utils/client-hints.tsx'
-import { prisma } from '#app/utils/db.server.ts'
 import {
 	getReleaseCalendar,
 	parseReleaseCalendarQuery,
+	releaseCalendarDayPreviewLimit,
 	type ReleaseCalendarQuery,
 } from '#app/utils/release-calendar.server.ts'
-import {
-	releaseReminderLeadMinutes,
-	removeReleaseReminder,
-	saveReleaseReminder,
-	type ReleaseReminderLeadMinutes,
-} from '#app/utils/release-reminders.server.ts'
-
-const ReminderLeadSchema = z.coerce
-	.number()
-	.int()
-	.refine(value =>
-		releaseReminderLeadMinutes.includes(value as ReleaseReminderLeadMinutes),
-	)
-	.transform(value => value as ReleaseReminderLeadMinutes)
-
-const ReminderActionSchema = z.discriminatedUnion('intent', [
-	z.object({
-		intent: z.literal('release-reminder-save'),
-		mediaId: z.string().min(1).max(100),
-		leadMinutes: ReminderLeadSchema,
-	}),
-	z.object({
-		intent: z.literal('release-reminder-delete'),
-		mediaId: z.string().min(1).max(100),
-	}),
-])
-
-const kindLabels: Record<ReleaseCalendarQuery['kind'], string> = {
-	all: 'All media',
-	movie: 'Movies',
-	tv: 'TV',
-	anime: 'Anime',
-	manga: 'Manga',
-}
+import { releaseReminderAction } from './calendar.server.ts'
 
 function calendarHref(filters: ReleaseCalendarQuery, start: string) {
 	const search = new URLSearchParams({
@@ -65,6 +36,15 @@ function calendarHref(filters: ReleaseCalendarQuery, start: string) {
 	return `/calendar?${search.toString()}`
 }
 
+function calendarDayHref(filters: ReleaseCalendarQuery, date: string) {
+	const search = new URLSearchParams({
+		kind: filters.kind,
+		scope: filters.scope,
+		week: filters.start,
+	})
+	return `/calendar/${date}?${search.toString()}`
+}
+
 function calendarExportHref(filters: ReleaseCalendarQuery) {
 	const search = new URLSearchParams({
 		start: filters.start,
@@ -72,15 +52,6 @@ function calendarExportHref(filters: ReleaseCalendarQuery) {
 		scope: filters.scope,
 	})
 	return `/resources/calendar.ics?${search.toString()}`
-}
-
-function displayDay(value: string) {
-	return new Date(`${value}T00:00:00.000Z`).toLocaleDateString('en-US', {
-		weekday: 'long',
-		month: 'short',
-		day: 'numeric',
-		timeZone: 'UTC',
-	})
 }
 
 function displayRange(start: string, end: string) {
@@ -100,16 +71,6 @@ function displayRange(start: string, end: string) {
 	})}`
 }
 
-function displayTime(value: Date | string, allDay: boolean, timeZone: string) {
-	if (allDay) return 'All day'
-	return new Date(value).toLocaleTimeString('en-US', {
-		hour: 'numeric',
-		minute: '2-digit',
-		timeZone,
-		timeZoneName: 'short',
-	})
-}
-
 export async function loader({ request }: LoaderFunctionArgs) {
 	const viewerId = await getUserId(request)
 	const timeZone = getHints(request).timeZone
@@ -118,47 +79,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
 		new Date(),
 		timeZone,
 	)
-	return json(await getReleaseCalendar(filters, viewerId, timeZone))
+	return json(
+		await getReleaseCalendar(filters, viewerId, timeZone, {
+			dayPreviewLimit: releaseCalendarDayPreviewLimit,
+		}),
+	)
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-	const viewerId = await requireUserId(request)
-	const parsed = ReminderActionSchema.safeParse(
-		Object.fromEntries(await request.formData()),
-	)
-	if (!parsed.success) {
-		throw new Response('Invalid reminder action', { status: 400 })
-	}
-	const media = await prisma.media.findUnique({
-		where: { id: parsed.data.mediaId },
-		select: { id: true },
-	})
-	if (!media) throw new Response('Media not found', { status: 404 })
-
-	if (parsed.data.intent === 'release-reminder-save') {
-		const leadMinutes = parsed.data.leadMinutes
-		const reminder = await prisma.$transaction(transaction =>
-			saveReleaseReminder(transaction, {
-				ownerId: viewerId,
-				mediaId: media.id,
-				leadMinutes,
-			}),
-		)
-		return json({ ok: true, reminderId: reminder.id })
-	}
-
-	await removeReleaseReminder(prisma, {
-		ownerId: viewerId,
-		mediaId: media.id,
-	})
-	return json({ ok: true })
-}
-
-function reminderLeadLabel(leadMinutes: number) {
-	if (leadMinutes === 0) return 'At release'
-	if (leadMinutes === 60) return '1 hour before'
-	if (leadMinutes === 1440) return '1 day before'
-	return `${leadMinutes} minutes before`
+	return releaseReminderAction(request)
 }
 
 export default function ReleaseCalendarRoute() {
@@ -209,7 +138,7 @@ export default function ReleaseCalendarRoute() {
 						defaultValue={data.filters.kind}
 						className="h-10 w-full rounded-xl border border-veud-border/65 bg-veud-ink/65 px-3 text-sm text-veud-cream shadow-inner shadow-black/15 focus:border-veud-mint focus:outline-none focus:ring-2 focus:ring-veud-mint/35"
 					>
-						{Object.entries(kindLabels).map(([value, label]) => (
+						{Object.entries(releaseCalendarKindLabels).map(([value, label]) => (
 							<option key={value} value={value}>
 								{label}
 							</option>
@@ -260,18 +189,18 @@ export default function ReleaseCalendarRoute() {
 					<section
 						key={day.date}
 						aria-labelledby={`calendar-day-${day.date}`}
-						className={`relative ml-10 grid overflow-hidden rounded-2xl border bg-veud-surface shadow-lg shadow-black/10 sm:ml-12 lg:ml-0 lg:grid-cols-[12rem_minmax(0,1fr)] ${day.date === data.today ? 'border-veud-gold ring-1 ring-veud-gold/25' : day.items.length ? 'border-veud-border' : 'border-veud-border/50 bg-veud-surface/65'}`}
+						className={`relative ml-10 grid overflow-hidden rounded-2xl border bg-veud-surface shadow-lg shadow-black/10 sm:ml-12 lg:ml-0 lg:grid-cols-[12rem_minmax(0,1fr)] ${day.date === data.today ? 'border-veud-gold ring-1 ring-veud-gold/25' : day.totalCount ? 'border-veud-border' : 'border-veud-border/50 bg-veud-surface/65'}`}
 					>
 						<span
 							aria-hidden="true"
-							className={`absolute -left-[2.05rem] top-5 h-3 w-3 rounded-full border-2 sm:-left-[2.35rem] lg:hidden ${day.date === data.today ? 'border-veud-gold bg-veud-gold' : day.items.length ? 'border-veud-mint bg-veud-surface' : 'border-veud-border bg-veud-ink'}`}
+							className={`absolute -left-[2.05rem] top-5 h-3 w-3 rounded-full border-2 sm:-left-[2.35rem] lg:hidden ${day.date === data.today ? 'border-veud-gold bg-veud-gold' : day.totalCount ? 'border-veud-mint bg-veud-surface' : 'border-veud-border bg-veud-ink'}`}
 						/>
 						<header className="flex items-center justify-between gap-3 border-b border-veud-border/70 px-4 py-3 lg:block lg:border-b-0 lg:border-r lg:px-5 lg:py-5">
 							<h2
 								id={`calendar-day-${day.date}`}
 								className="text-lg font-[var(--veud-font-display)] font-black text-veud-yellow lg:text-xl"
 							>
-								{displayDay(day.date)}
+								{displayCalendarDay(day.date)}
 							</h2>
 							<div className="flex items-center gap-2 lg:mt-2">
 								{day.date === data.today ? (
@@ -280,142 +209,35 @@ export default function ReleaseCalendarRoute() {
 									</span>
 								) : null}
 								<span className="text-xs font-semibold text-veud-sage">
-									{day.items.length}{' '}
-									{day.items.length === 1 ? 'release' : 'releases'}
+									{day.totalCount}{' '}
+									{day.totalCount === 1 ? 'release' : 'releases'}
 								</span>
 							</div>
 						</header>
 						{day.items.length ? (
 							<div className="divide-y divide-veud-border/50">
 								{day.items.map(item => (
-									<article
+									<ReleaseCalendarItem
 										key={item.id}
-										className="grid gap-3 p-4 transition-colors hover:bg-veud-ink/35 sm:grid-cols-[6.75rem_4rem_minmax(0,1fr)]"
-									>
-										<div className="sm:pt-1">
-											<div className="font-black tabular-nums text-veud-mint">
-												{displayTime(
-													item.releaseAt,
-													item.allDay,
-													data.timeZone,
-												)}
-											</div>
-											<div className="mt-1 text-[0.68rem] font-bold uppercase tracking-[0.12em] text-veud-sage">
-												{item.type ||
-													kindLabels[
-														item.kind as ReleaseCalendarQuery['kind']
-													] ||
-													item.kind}
-											</div>
-										</div>
-										<Link
-											to={`/media/${item.mediaId}`}
-											className="h-24 w-16 overflow-hidden rounded-lg bg-veud-ink shadow-md"
-										>
-											{item.imageUrl ? (
-												<img
-													src={item.imageUrl}
-													alt=""
-													loading="lazy"
-													className="h-full w-full object-cover"
-												/>
-											) : (
-												<span className="flex h-full items-center justify-center px-2 text-center text-[0.65rem] text-veud-sage">
-													No poster
-												</span>
-											)}
-										</Link>
-										<div className="min-w-0 flex-1">
-											<Link
-												to={`/media/${item.mediaId}`}
-												className="block text-base font-black leading-5 text-veud-yellow hover:underline"
-											>
-												{item.title}
-											</Link>
-											<div className="mt-1 flex flex-wrap items-center gap-2">
-												<span
-													className={`rounded-full px-2 py-0.5 text-xs font-bold ${item.eventType === 'premiere' ? 'bg-veud-amber/15 text-veud-gold' : item.eventType === 'chapter' ? 'bg-violet-300/15 text-violet-200' : 'bg-veud-mint/10 text-veud-mint'}`}
-												>
-													{item.eventLabel}
-												</span>
-												{item.eventName ? (
-													<span className="line-clamp-1 text-xs text-veud-copy">
-														{item.eventName}
-													</span>
-												) : null}
-											</div>
-											<div className="mt-2 flex flex-wrap gap-1.5 text-[0.7rem] text-veud-mint">
-												{item.viewerTracking ? (
-													<span className="rounded-full bg-veud-mint/10 px-2 py-0.5 font-bold text-veud-mint">
-														{item.viewerTracking.statusLabel}
-														{item.viewerTracking.score !== null
-															? ` · ${item.viewerTracking.score.toLocaleString('en-US', { maximumFractionDigits: 1 })}/10`
-															: ''}
-													</span>
-												) : null}
-												<span className="rounded-full bg-veud-ink px-2 py-0.5">
-													{item.trackerCount}{' '}
-													{item.trackerCount === 1 ? 'member' : 'members'}{' '}
-													tracking
-												</span>
-											</div>
-											{data.isSignedIn ? (
-												item.viewerReminder ? (
-													<Form method="post" className="mt-3">
-														<input
-															type="hidden"
-															name="intent"
-															value="release-reminder-delete"
-														/>
-														<input
-															type="hidden"
-															name="mediaId"
-															value={item.mediaId}
-														/>
-														<Button
-															type="submit"
-															variant="ghost"
-															size="sm"
-															aria-label={`Remove reminder for ${item.title}`}
-															className="text-veud-mint"
-														>
-															Reminder on ·{' '}
-															{reminderLeadLabel(
-																item.viewerReminder.leadMinutes,
-															)}
-														</Button>
-													</Form>
-												) : (
-													<Form method="post" className="mt-3">
-														<input
-															type="hidden"
-															name="intent"
-															value="release-reminder-save"
-														/>
-														<input
-															type="hidden"
-															name="mediaId"
-															value={item.mediaId}
-														/>
-														<input
-															type="hidden"
-															name="leadMinutes"
-															value="60"
-														/>
-														<Button
-															type="submit"
-															variant="outline"
-															size="sm"
-															aria-label={`Set reminder for ${item.title}`}
-														>
-															Remind me · 1 hour before
-														</Button>
-													</Form>
-												)
-											) : null}
-										</div>
-									</article>
+										item={item}
+										timeZone={data.timeZone}
+										isSignedIn={data.isSignedIn}
+									/>
 								))}
+								{day.totalCount > day.items.length ? (
+									<div className="p-3">
+										<Button
+											asChild
+											variant="ghost"
+											size="sm"
+											className="w-full justify-center text-veud-mint"
+										>
+											<Link to={calendarDayHref(data.filters, day.date)}>
+												View all {day.totalCount} releases →
+											</Link>
+										</Button>
+									</div>
+								) : null}
 							</div>
 						) : (
 							<p className="flex items-center px-4 py-5 text-sm text-veud-sage">

--- a/app/utils/release-calendar.server.ts
+++ b/app/utils/release-calendar.server.ts
@@ -13,6 +13,9 @@ export const releaseCalendarKinds = [
 	'manga',
 ] as const
 export const releaseCalendarScopes = ['all', 'mine'] as const
+// Busy days can schedule dozens of releases; the weekly view previews this
+// many per day and links to the full day page for the rest.
+export const releaseCalendarDayPreviewLimit = 5
 
 export type ReleaseCalendarQuery = {
 	start: string
@@ -263,15 +266,32 @@ function dateIsInRange(value: string, start: string, end: string) {
 }
 
 /** Build a deterministic seven-day release schedule from the canonical catalog. */
+// Choose which releases represent an overfull day: titles the viewer tracks
+// or has reminders for come first, then community interest, then air time.
+function dayPreviewPriority(left: ReleaseCalendarItem, right: ReleaseCalendarItem) {
+	return (
+		Number(Boolean(right.viewerTracking)) -
+			Number(Boolean(left.viewerTracking)) ||
+		Number(Boolean(right.viewerReminder)) -
+			Number(Boolean(left.viewerReminder)) ||
+		right.trackerCount - left.trackerCount ||
+		left.releaseAt.getTime() - right.releaseAt.getTime() ||
+		left.title.localeCompare(right.title) ||
+		left.id.localeCompare(right.id)
+	)
+}
+
 export async function getReleaseCalendar(
 	input: ReleaseCalendarQuery,
 	viewerId: string | null,
 	requestedTimeZone = 'UTC',
+	options: { days?: number; dayPreviewLimit?: number } = {},
 ) {
 	const now = new Date()
+	const spanDays = options.days ?? 7
 	const timeZone = normalizeTimeZone(requestedTimeZone)
 	const start = parseDateKey(input.start) ?? startOfWeek(now, timeZone)
-	const end = addDays(start, 7)
+	const end = addDays(start, spanDays)
 	const startKey = dateKey(start)
 	const endKey = dateKey(end)
 	const filters = {
@@ -518,21 +538,32 @@ export async function getReleaseCalendar(
 		filters,
 		timeZone,
 		start: dateKey(start),
-		end: dateKey(addDays(start, 6)),
-		previousStart: dateKey(addDays(start, -7)),
+		end: dateKey(addDays(start, spanDays - 1)),
+		previousStart: dateKey(addDays(start, -spanDays)),
 		nextStart: dateKey(end),
 		todayStart: dateKey(startOfWeek(now, timeZone)),
 		today: dateKeyInTimeZone(now, timeZone),
 		isSignedIn: Boolean(viewerId),
 		total: items.length,
-		days: Array.from({ length: 7 }, (_, index) => {
+		days: Array.from({ length: spanDays }, (_, index) => {
 			const date = dateKey(addDays(start, index))
-			return {
-				date,
-				items: items.filter(
-					item => eventDateKey(item.releaseAt, item.allDay, timeZone) === date,
-				),
-			}
+			const dayItems = items.filter(
+				item => eventDateKey(item.releaseAt, item.allDay, timeZone) === date,
+			)
+			const limit = options.dayPreviewLimit
+			const preview =
+				limit && dayItems.length > limit
+					? [...dayItems]
+							.sort(dayPreviewPriority)
+							.slice(0, limit)
+							.sort(
+								(left, right) =>
+									left.releaseAt.getTime() - right.releaseAt.getTime() ||
+									left.title.localeCompare(right.title) ||
+									left.id.localeCompare(right.id),
+							)
+					: dayItems
+			return { date, items: preview, totalCount: dayItems.length }
 		}),
 	}
 }

--- a/tests/e2e/accessibility.test.ts
+++ b/tests/e2e/accessibility.test.ts
@@ -21,6 +21,7 @@ for (const [name, path] of [
 	['home', '/'],
 	['discover', '/discover'],
 	['calendar', '/calendar'],
+	['calendar day', '/calendar/2026-07-21'],
 	['reviews', '/reviews'],
 	['collections', '/collections'],
 	['credits', '/credits'],

--- a/tests/e2e/calendar.test.ts
+++ b/tests/e2e/calendar.test.ts
@@ -144,3 +144,46 @@ test('member can browse a release week and focus on tracked titles', async ({
 			.catch(() => {})
 	}
 })
+
+test('busy calendar days link to a full day page', async ({ page }) => {
+	const titles = ['A', 'B', 'C', 'D', 'E', 'F'].map(
+		letter => `Overflow Day ${letter}`,
+	)
+	const media = await Promise.all(
+		titles.map(title =>
+			prisma.media.create({
+				data: {
+					kind: 'movie',
+					title,
+					releaseStart: new Date('2026-07-21T00:00:00.000Z'),
+				},
+			}),
+		),
+	)
+
+	try {
+		await page.goto('/calendar?start=2026-07-20&kind=movie')
+		const day = page.locator('section[aria-labelledby="calendar-day-2026-07-21"]')
+		await expect(day.getByText('6 releases', { exact: true })).toBeVisible()
+		await expect(day.getByRole('article')).toHaveCount(5)
+
+		await day.getByRole('link', { name: /View all 6 releases/ }).click()
+		await expect(page).toHaveURL(/\/calendar\/2026-07-21/)
+		await expect(
+			page.getByRole('heading', { name: /Tuesday, Jul 21/ }),
+		).toBeVisible()
+		await expect(page.getByRole('article')).toHaveCount(6)
+		for (const title of titles) {
+			await expect(
+				page.getByRole('link', { name: title, exact: true }),
+			).toBeVisible()
+		}
+
+		await page.getByRole('link', { name: /Back to week view/ }).click()
+		await expect(page).toHaveURL(/\/calendar\?start=2026-07-20/)
+	} finally {
+		await prisma.media
+			.deleteMany({ where: { id: { in: media.map(item => item.id) } } })
+			.catch(() => {})
+	}
+})

--- a/tests/e2e/responsive-routes.test.ts
+++ b/tests/e2e/responsive-routes.test.ts
@@ -61,6 +61,7 @@ test.describe('mobile route audit', () => {
 		['home', '/', /Veud|Trending/i],
 		['discover', '/discover', /Discover/i],
 		['calendar', '/calendar', /Release calendar/i],
+		['calendar day', '/calendar/2026-07-21', /Jul 21/i],
 		['reviews', '/reviews', /Reviews/i],
 		['collections', '/collections', /Collections/i],
 		['credits', '/credits', /Data sources & credits/i],


### PR DESCRIPTION
Busy calendar days could schedule dozens of releases and clutter the weekly view.

## Changes

- **Preview cap:** each day on `/calendar` now shows at most **5** releases. Selection prioritizes what the visitor cares about most: titles they track → titles they have reminders for → most community-tracked → earliest air time. The preview itself still renders in schedule order, so days read like a timetable.
- **Overflow:** capped days show a "View all N releases →" link, and the day header always shows the true count.
- **Dedicated day pages:** new `/calendar/:day` route lists every release for that day chronologically, with previous/next-day navigation, a back link to the exact originating week (`week` param), kind/scope filters preserved, working reminder toggles, and a 404 for malformed dates.
- The release card and reminder action moved to shared modules (`release-calendar-item.tsx`, `calendar.server.ts`) used by both routes; the `.ics` export and home widget remain uncapped.

## Validation

Static gates, full unit suite (585 passing incl. new preview-selection and day-route tests), and Playwright: calendar (incl. a new week → day page → back flow test), release-reminders, navigation, accessibility, and responsive sweeps with the day page added to both route audits.