### PR TITLE
Complete PostgreSQL search parity and scale gates

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -104,7 +104,7 @@ jobs:
   postgres:
     name: PostgreSQL load validation
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     services:
       postgres:
         image: postgres:16.14-alpine@sha256:7a396fd264a2067788b6551122b50f162bf6136312c7fc9d74381cb92c648382
@@ -133,6 +133,6 @@ jobs:
         run: npm ci
 
       - name: Run PostgreSQL load validation
-        run: npm run validate:release:postgres
+        run: npm run validate:scale:postgres
         env:
           DATABASE_URL: postgresql://veud:veud@localhost:5432/veud_nightly_test

--- a/app/routes/collections+/$collectionId.tsx
+++ b/app/routes/collections+/$collectionId.tsx
@@ -39,6 +39,7 @@ import {
 } from '#app/utils/media-collections.ts'
 import { splitLegacyThumbnail } from '#app/utils/media-detail.ts'
 import { requireUserWithRole } from '#app/utils/permissions.server.ts'
+import { prismaSearchFilter } from '#app/utils/prisma-search.server.ts'
 
 const CollectionItemActionSchema = z.discriminatedUnion('intent', [
 	z.object({
@@ -151,7 +152,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		? await prisma.media.findMany({
 				where: {
 					id: existingMediaIds.length ? { notIn: existingMediaIds } : undefined,
-					title: { contains: query },
+					title: prismaSearchFilter('contains', query),
 				},
 				orderBy: [{ title: 'asc' }, { id: 'asc' }],
 				take: 12,

--- a/app/routes/collections+/collections.route.test.ts
+++ b/app/routes/collections+/collections.route.test.ts
@@ -225,6 +225,128 @@ test('private collections are owner-only while public collections are discoverab
 	expect(moderatedOwnerView.data.collection.id).toBe(collection.id)
 })
 
+test('mixed-case collection search preserves visibility and owner-only media picking', async () => {
+	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
+	const [neutralOwner, creatorOwner] = await Promise.all([
+		createUser('search_neutral'),
+		createUser(`CrEaToR_${suffix}`),
+	])
+	const neutralCookie = await cookieFor(neutralOwner.id)
+	const titleMarker = `TiTlE MaRkEr ${suffix}`
+	const descriptionMarker = `DeScRiPtIoN MaRkEr ${suffix}`
+	const publicTitle = await prisma.mediaCollection.create({
+		data: {
+			ownerId: neutralOwner.id,
+			title: titleMarker,
+			isPublic: true,
+		},
+	})
+	await prisma.mediaCollection.createMany({
+		data: [
+			{
+				ownerId: neutralOwner.id,
+				title: `${titleMarker} private`,
+				isPublic: false,
+			},
+			{
+				ownerId: neutralOwner.id,
+				title: `${titleMarker} hidden`,
+				isPublic: true,
+				moderationStatus: 'hidden',
+			},
+		],
+	})
+	const publicDescription = await prisma.mediaCollection.create({
+		data: {
+			ownerId: neutralOwner.id,
+			title: `Description result ${suffix}`,
+			description: descriptionMarker,
+			isPublic: true,
+		},
+	})
+	await prisma.mediaCollection.createMany({
+		data: [
+			{
+				ownerId: neutralOwner.id,
+				title: `Private description result ${suffix}`,
+				description: descriptionMarker,
+				isPublic: false,
+			},
+			{
+				ownerId: neutralOwner.id,
+				title: `Hidden description result ${suffix}`,
+				description: descriptionMarker,
+				isPublic: true,
+				moderationStatus: 'hidden',
+			},
+		],
+	})
+	const publicCreator = await prisma.mediaCollection.create({
+		data: {
+			ownerId: creatorOwner.id,
+			title: `Creator result ${suffix}`,
+			isPublic: true,
+		},
+	})
+	await prisma.mediaCollection.createMany({
+		data: [
+			{
+				ownerId: creatorOwner.id,
+				title: `Private creator result ${suffix}`,
+				isPublic: false,
+			},
+			{
+				ownerId: creatorOwner.id,
+				title: `Hidden creator result ${suffix}`,
+				isPublic: true,
+				moderationStatus: 'hidden',
+			},
+		],
+	})
+
+	for (const [query, expectedId] of [
+		[`tItLe mArKeR ${suffix.toUpperCase()}`, publicTitle.id],
+		[`dEsCrIpTiOn mArKeR ${suffix.toUpperCase()}`, publicDescription.id],
+		[`cReAtOr_${suffix.toUpperCase()}`, publicCreator.id],
+	] as const) {
+		const url = new URL(`${BASE_URL}/collections`)
+		url.searchParams.set('q', query)
+		const result = await indexLoader({
+			request: new Request(url),
+			params: {},
+		} as any)
+		expect(result.data.collections.map(collection => collection.id)).toEqual([
+			expectedId,
+		])
+	}
+
+	const mediaMarker = `MeDiA PiCkEr ${suffix}`
+	const [existingMedia, availableMedia] = await Promise.all([
+		prisma.media.create({
+			data: { kind: 'movie', title: `${mediaMarker} existing` },
+		}),
+		prisma.media.create({
+			data: { kind: 'movie', title: `${mediaMarker} available` },
+		}),
+	])
+	await prisma.mediaCollectionItem.create({
+		data: {
+			collectionId: publicTitle.id,
+			mediaId: existingMedia.id,
+			position: 1,
+		},
+	})
+	const detailUrl = new URL(`${BASE_URL}/collections/${publicTitle.id}`)
+	detailUrl.searchParams.set('q', `mEdIa pIcKeR ${suffix.toUpperCase()}`)
+	const ownerView = await detailLoader({
+		request: new Request(detailUrl, { headers: { cookie: neutralCookie } }),
+		params: { collectionId: publicTitle.id },
+	} as any)
+	expect(ownerView.data.searchResults.map(media => media.id)).toEqual([
+		availableMedia.id,
+	])
+})
+
 test('owners can add, reorder, and remove canonical media without duplicates', async () => {
 	const [owner, other] = await Promise.all([
 		createUser('ordered_owner'),

--- a/app/routes/collections+/index.tsx
+++ b/app/routes/collections+/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '#app/utils/collection-discovery.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { normalizeCollectionTag } from '#app/utils/media-collections.ts'
+import { prismaSearchFilter } from '#app/utils/prisma-search.server.ts'
 
 const PAGE_SIZE = 24
 type CollectionSort = 'recent' | 'popular' | 'trending' | 'for-you'
@@ -140,9 +141,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
 				? [
 						{
 							OR: [
-								{ title: { contains: query } },
-								{ description: { contains: query } },
-								{ owner: { username: { contains: query } } },
+								{ title: prismaSearchFilter('contains', query) },
+								{ description: prismaSearchFilter('contains', query) },
+								{
+									owner: {
+										username: prismaSearchFilter('contains', query),
+									},
+								},
 							],
 						},
 					]

--- a/app/routes/moderation.route.test.ts
+++ b/app/routes/moderation.route.test.ts
@@ -54,8 +54,9 @@ async function createUser(
 	return { user, cookie: await getSessionCookieHeader(session) }
 }
 
-function loaderArgs(cookie: string) {
+function loaderArgs(cookie: string, query = '') {
 	const url = new URL(`${BASE_URL}/moderation`)
+	if (query) url.searchParams.set('q', query)
 	return {
 		request: new Request(url, { headers: { cookie } }),
 		url,
@@ -100,6 +101,32 @@ test('the dashboard is private to moderators and returns a no-store queue', asyn
 	expect(response.data.canAssignRoles).toBe(false)
 })
 
+test('moderators can find display names without matching their casing', async () => {
+	const moderator = await createUser('case_moderator', 'moderator', [
+		{ action: 'read', entity: 'report', access: 'any' },
+	])
+	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
+	const member = await prisma.user.create({
+		data: {
+			email: `case_target_${suffix}@example.com`,
+			username: `unrelated_${suffix}`,
+			name: `MiXeD Display ${suffix}`,
+		},
+	})
+	await prisma.user.create({
+		data: {
+			email: `case_other_${suffix}@example.com`,
+			username: `other_${suffix}`,
+			name: `Different member ${suffix}`,
+		},
+	})
+
+	const response = await moderationLoader(
+		loaderArgs(moderator.cookie, `mIxEd dIsPlAy ${suffix.toUpperCase()}`),
+	)
+	expect(response.data.members.map(result => result.id)).toEqual([member.id])
+})
+
 test('members can submit one private report while moderators can resolve its workflow', async () => {
 	const reporter = await createUser('reporter', 'user', [
 		{ action: 'create', entity: 'report', access: 'own' },
@@ -127,7 +154,8 @@ test('members can submit one private report while moderators can resolve its wor
 	expect(submitted.data).toEqual(
 		expect.objectContaining({ ok: true, duplicate: false }),
 	)
-	if (!submitted.data.ok) throw new Error('Expected report submission to succeed')
+	if (!submitted.data.ok)
+		throw new Error('Expected report submission to succeed')
 	const reportId = submitted.data.reportId
 
 	const duplicate = await reportAction(

--- a/app/routes/moderation.tsx
+++ b/app/routes/moderation.tsx
@@ -35,6 +35,7 @@ import {
 	moderationTargetLabels,
 } from '#app/utils/moderation.ts'
 import { requireUserWithPermission } from '#app/utils/permissions.server.ts'
+import { prismaSearchFilter } from '#app/utils/prisma-search.server.ts'
 
 const DashboardQuerySchema = z.object({
 	view: z.enum(['queue', 'members', 'team', 'audit']).catch('queue'),
@@ -176,8 +177,10 @@ export async function loader({ request, url }: LoaderFunctionArgs) {
 				? prisma.user.findMany({
 						where: {
 							OR: [
-								{ username: { contains: filters.q } },
-								{ name: { contains: filters.q } },
+								{
+									username: prismaSearchFilter('contains', filters.q),
+								},
+								{ name: prismaSearchFilter('contains', filters.q) },
 							],
 						},
 						orderBy: [{ lastActiveAt: 'desc' }, { username: 'asc' }],

--- a/app/utils/discovery.server.test.ts
+++ b/app/utils/discovery.server.test.ts
@@ -229,6 +229,46 @@ test('discovery searches canonical metadata and exposes normalized genres', asyn
 	])
 })
 
+test('genre filters match mixed-case delimited tokens without substrings', async () => {
+	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
+	const storedGenre = `MiXeDgEnRe${suffix}`
+	const [singleton, first, middle, last, prefixed, suffixed] =
+		await Promise.all(
+			[
+				['Genre Exact', storedGenre],
+				['Genre First', `${storedGenre}, Drama`],
+				['Genre Middle', `Drama, ${storedGenre}, Mystery`],
+				['Genre Last', `Drama, ${storedGenre}`],
+				['Genre Prefixed', `Super${storedGenre}`],
+				['Genre Suffixed', `${storedGenre}Extended`],
+			].map(([title, genres]) =>
+				prisma.media.create({
+					data: {
+						kind: 'movie',
+						title: `${title} ${suffix}`,
+						genres,
+					},
+				}),
+			),
+		)
+
+	const result = await getDiscoveryResults(
+		filters({
+			kind: 'movie',
+			genre: `mIxEdGeNrE${suffix.toUpperCase()}`,
+			sort: 'title',
+		}),
+		null,
+	)
+	expect(result.total).toBe(4)
+	expect(new Set(result.items.map(item => item.id))).toEqual(
+		new Set([singleton.id, first.id, middle.id, last.id]),
+	)
+	expect(result.items.map(item => item.id)).not.toEqual(
+		expect.arrayContaining([prefixed.id, suffixed.id]),
+	)
+})
+
 test('discovery matches mixed-case canonical and alternate titles', async () => {
 	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
 	const media = await prisma.media.create({

--- a/app/utils/discovery.server.ts
+++ b/app/utils/discovery.server.ts
@@ -583,7 +583,12 @@ async function getGenrePreferences(viewerId: string | null) {
 function genreWhere(genre: string): Prisma.MediaWhereInput {
 	return {
 		OR: [
-			{ genres: { equals: genre } },
+			{
+				AND: [
+					{ genres: prismaSearchFilter('startsWith', genre) },
+					{ genres: prismaSearchFilter('endsWith', genre) },
+				],
+			},
 			{ genres: prismaSearchFilter('startsWith', `${genre},`) },
 			{ genres: prismaSearchFilter('contains', `, ${genre},`) },
 			{ genres: prismaSearchFilter('endsWith', `, ${genre}`) },

--- a/app/utils/media-recommendations.server.test.ts
+++ b/app/utils/media-recommendations.server.test.ts
@@ -20,44 +20,57 @@ test('similar titles prioritize exact genre overlap and exclude tracked works', 
 		createUser('recommendation_second'),
 		createUser('recommendation_third'),
 	])
-	const [source, focusedMatch, broadMatch, popularWeakMatch, wrongKind] =
-		await Promise.all([
-			prisma.media.create({
-				data: {
-					kind: 'anime',
-					title: 'Recommendation Source',
-					genres: 'Action, Fantasy',
-				},
-			}),
-			prisma.media.create({
-				data: {
-					kind: 'anime',
-					title: 'Focused Match',
-					genres: 'action, Fantasy',
-				},
-			}),
-			prisma.media.create({
-				data: {
-					kind: 'anime',
-					title: 'Broad Match',
-					genres: 'Action, Fantasy, Adventure',
-				},
-			}),
-			prisma.media.create({
-				data: {
-					kind: 'anime',
-					title: 'Popular Weak Match',
-					genres: 'Action',
-				},
-			}),
-			prisma.media.create({
-				data: {
-					kind: 'movie',
-					title: 'Wrong Kind Match',
-					genres: 'Action, Fantasy',
-				},
-			}),
-		])
+	const [
+		source,
+		focusedMatch,
+		broadMatch,
+		popularWeakMatch,
+		wrongKind,
+		substringOnly,
+	] = await Promise.all([
+		prisma.media.create({
+			data: {
+				kind: 'anime',
+				title: 'Recommendation Source',
+				genres: 'Action, Fantasy',
+			},
+		}),
+		prisma.media.create({
+			data: {
+				kind: 'anime',
+				title: 'Focused Match',
+				genres: 'aCTION, fANTASY',
+			},
+		}),
+		prisma.media.create({
+			data: {
+				kind: 'anime',
+				title: 'Broad Match',
+				genres: 'Action, Fantasy, Adventure',
+			},
+		}),
+		prisma.media.create({
+			data: {
+				kind: 'anime',
+				title: 'Popular Weak Match',
+				genres: 'Action',
+			},
+		}),
+		prisma.media.create({
+			data: {
+				kind: 'movie',
+				title: 'Wrong Kind Match',
+				genres: 'Action, Fantasy',
+			},
+		}),
+		prisma.media.create({
+			data: {
+				kind: 'anime',
+				title: 'Substring-only Match',
+				genres: 'Live Action, Dark Fantasy',
+			},
+		}),
+	])
 	await prisma.trackingState.createMany({
 		data: [
 			{
@@ -126,6 +139,7 @@ test('similar titles prioritize exact genre overlap and exclude tracked works', 
 	expect(anonymous.items[0]?.matchedGenres).toEqual(['Action', 'Fantasy'])
 	expect(anonymous.items.some(item => item.id === source.id)).toBe(false)
 	expect(anonymous.items.some(item => item.id === wrongKind.id)).toBe(false)
+	expect(anonymous.items.some(item => item.id === substringOnly.id)).toBe(false)
 
 	const personalized = await getSimilarMediaRecommendations(source, viewer.id)
 	expect(personalized.items.map(item => item.title)).toEqual([

--- a/app/utils/media-recommendations.server.ts
+++ b/app/utils/media-recommendations.server.ts
@@ -1,6 +1,7 @@
 import { type Prisma } from '@prisma/client'
 import { prisma } from './db.server.ts'
 import { catalogPopularityScore, splitGenres } from './discovery.server.ts'
+import { prismaSearchFilter } from './prisma-search.server.ts'
 
 export const MEDIA_RECOMMENDATION_LIMIT = 6
 const MEDIA_RECOMMENDATION_CANDIDATE_LIMIT = 200
@@ -75,7 +76,8 @@ function scoreFor(media: RecommendationMedia) {
 
 function publicTrackingStates(media: RecommendationMedia) {
 	return media.trackingStates.filter(
-		state => state.statusWatchlistId === null || state.statusWatchlist?.isPublic,
+		state =>
+			state.statusWatchlistId === null || state.statusWatchlist?.isPublic,
 	)
 }
 
@@ -149,7 +151,7 @@ export async function getSimilarMediaRecommendations(
 							{ genres: { not: null } },
 							{
 								OR: sourceGenres.map(genre => ({
-									genres: { contains: genre },
+									genres: prismaSearchFilter('contains', genre),
 								})),
 							},
 						]

--- a/app/utils/prisma-search.server.test.ts
+++ b/app/utils/prisma-search.server.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from 'vitest'
-import { prismaSearchFilter } from './prisma-search.server.ts'
+import {
+	escapeSqlLikeLiteral,
+	isPostgresDatasource,
+	prismaSearchFilter,
+} from './prisma-search.server.ts'
 
 test('adds insensitive mode only for PostgreSQL datasources', () => {
 	expect(
@@ -28,4 +32,10 @@ test('keeps SQLite and unknown datasource filters provider-portable', () => {
 	expect(prismaSearchFilter('contains', 'Mixed Case', 'not a url')).toEqual({
 		contains: 'Mixed Case',
 	})
+})
+
+test('identifies PostgreSQL URLs and escapes exact ILIKE literals', () => {
+	expect(isPostgresDatasource('postgresql://veud@localhost/veud')).toBe(true)
+	expect(isPostgresDatasource('file:./test.db')).toBe(false)
+	expect(escapeSqlLikeLiteral('100%_sure!')).toBe('100!%!_sure!!')
 })

--- a/app/utils/prisma-search.server.ts
+++ b/app/utils/prisma-search.server.ts
@@ -13,7 +13,7 @@ type PrismaSearchFilter<Operation extends PrismaSearchOperation> = Record<
 	mode?: 'insensitive'
 }
 
-function isPostgresDatasource(databaseUrl: string | undefined) {
+export function isPostgresDatasource(databaseUrl: string | undefined) {
 	if (!databaseUrl) return false
 	try {
 		const protocol = new URL(databaseUrl).protocol.toLowerCase()
@@ -21,6 +21,16 @@ function isPostgresDatasource(databaseUrl: string | undefined) {
 	} catch {
 		return /^postgres(?:ql)?:\/\//i.test(databaseUrl)
 	}
+}
+
+/**
+ * Escape a literal value for a LIKE/ILIKE predicate that declares `ESCAPE '!'`.
+ *
+ * Keeping this separate from Prisma's string filters is useful for the few raw
+ * indexed predicates that need exact case-insensitive PostgreSQL matching.
+ */
+export function escapeSqlLikeLiteral(value: string) {
+	return value.replace(/[!%_]/g, character => `!${character}`)
 }
 
 /**

--- a/app/utils/recommendation-graph.server.test.ts
+++ b/app/utils/recommendation-graph.server.test.ts
@@ -57,7 +57,7 @@ test('recommendation graph separates canonical, social, collection, and taste ev
 			['Graph Connected', null],
 			['Graph Circle', null],
 			['Graph Collection', null],
-			['Graph Taste', genre],
+			['Graph Taste', genre.toUpperCase()],
 			['Graph Private', null],
 			['Graph Hidden', genre],
 		].map(([title, genres]) =>

--- a/app/utils/recommendation-graph.server.ts
+++ b/app/utils/recommendation-graph.server.ts
@@ -1,6 +1,7 @@
 import { type Prisma } from '@prisma/client'
 import { prisma } from './db.server.ts'
 import { catalogPopularityScore, splitGenres } from './discovery.server.ts'
+import { prismaSearchFilter } from './prisma-search.server.ts'
 import {
 	type RecommendationGraph,
 	type RecommendationGraphItem,
@@ -484,7 +485,7 @@ export async function getRecommendationGraph(
 								baseWhere,
 								{
 									OR: preferredGenres.map(genre => ({
-										genres: { contains: genre.label },
+										genres: prismaSearchFilter('contains', genre.label),
 									})),
 								},
 							],

--- a/app/utils/tracking-command.server.test.ts
+++ b/app/utils/tracking-command.server.test.ts
@@ -142,7 +142,7 @@ test('builds a local preview and requires explicit application', async () => {
 	).toBe(0)
 })
 
-test('resolves a mixed-case partial catalog title in a tracking command', async () => {
+test('prefers a mixed-case exact title over more-popular partial matches', async () => {
 	vi.stubEnv('OPENAI_API_KEY', 'test-key')
 	const owner = await prisma.user.create({
 		data: {
@@ -154,7 +154,15 @@ test('resolves a mixed-case partial catalog title in a tracking command', async 
 		data: {
 			kind: 'movie',
 			title: 'The MiXeD CaSe Command Clock',
+			catalogPopularity: 1,
 		},
+	})
+	await prisma.media.createMany({
+		data: Array.from({ length: 20 }, (_, index) => ({
+			kind: 'movie',
+			title: `THE MIXED CASE COMMAND CLOCK ${index + 1} THE MIXED CASE COMMAND CLOCK`,
+			catalogPopularity: 1_000 - index,
+		})),
 	})
 	const preview = await createTrackingCommandPreview(prisma, {
 		ownerId: owner.id,
@@ -165,7 +173,7 @@ test('resolves a mixed-case partial catalog title in a tracking command', async 
 				summary: 'Favorite one title.',
 				operations: [
 					{
-						title: 'mIxEd CaSe CoMmAnD cLoCk',
+						title: 'tHe mIxEd CaSe CoMmAnD cLoCk',
 						kind: 'movie',
 						destination: null,
 						score: null,
@@ -183,6 +191,137 @@ test('resolves a mixed-case partial catalog title in a tracking command', async 
 	}
 	expect(stored.operations.map(operation => operation.mediaId)).toEqual([
 		media.id,
+	])
+})
+
+test('still resolves a unique mixed-case partial catalog title', async () => {
+	vi.stubEnv('OPENAI_API_KEY', 'test-key')
+	const owner = await prisma.user.create({
+		data: {
+			email: 'partial-command@example.com',
+			username: 'partial_command',
+		},
+	})
+	const media = await prisma.media.create({
+		data: {
+			kind: 'movie',
+			title: 'The Partial Command Clock',
+		},
+	})
+	const preview = await createTrackingCommandPreview(prisma, {
+		ownerId: owner.id,
+		requestText: 'Favorite Partial Command Clock',
+		rateLimitKey: owner.id,
+		fetchImpl: vi.fn<typeof fetch>(async () =>
+			aiResponse({
+				summary: 'Favorite one title.',
+				operations: [
+					{
+						title: 'pArTiAl cOmMaNd cLoCk',
+						kind: 'movie',
+						destination: null,
+						score: null,
+						progressUnit: null,
+						progressCurrent: null,
+						favorite: true,
+						collection: null,
+					},
+				],
+			}),
+		),
+	})
+	const stored = JSON.parse(preview.operations) as {
+		operations: Array<{ mediaId: string }>
+	}
+	expect(stored.operations.map(operation => operation.mediaId)).toEqual([
+		media.id,
+	])
+})
+
+test('keeps duplicate normalized canonical titles ambiguous', async () => {
+	vi.stubEnv('OPENAI_API_KEY', 'test-key')
+	const owner = await prisma.user.create({
+		data: {
+			email: 'ambiguous-command@example.com',
+			username: 'ambiguous_command',
+		},
+	})
+	await prisma.media.createMany({
+		data: [
+			{ kind: 'movie', title: 'Twin Case Clock' },
+			{ kind: 'movie', title: 'tWIN cASE cLOCK' },
+		],
+	})
+
+	const error = await createTrackingCommandPreview(prisma, {
+		ownerId: owner.id,
+		requestText: 'Favorite Twin Case Clock',
+		rateLimitKey: owner.id,
+		fetchImpl: vi.fn<typeof fetch>(async () =>
+			aiResponse({
+				summary: 'Favorite one title.',
+				operations: [
+					{
+						title: 'TWIN CASE CLOCK',
+						kind: 'movie',
+						destination: null,
+						score: null,
+						progressUnit: null,
+						progressCurrent: null,
+						favorite: true,
+						collection: null,
+					},
+				],
+			}),
+		),
+	}).catch(caught => caught)
+	expect(error).toBeInstanceOf(Response)
+	expect((error as Response).status).toBe(409)
+	expect(await (error as Response).text()).toContain('is ambiguous')
+})
+
+test('treats SQL wildcard characters literally in canonical exact titles', async () => {
+	vi.stubEnv('OPENAI_API_KEY', 'test-key')
+	const owner = await prisma.user.create({
+		data: {
+			email: 'literal-command@example.com',
+			username: 'literal_command',
+		},
+	})
+	const exact = await prisma.media.create({
+		data: { kind: 'movie', title: 'One 100%_Case Clock' },
+	})
+	await prisma.media.create({
+		data: { kind: 'movie', title: 'One 100XXCase Clock' },
+	})
+
+	const preview = await createTrackingCommandPreview(prisma, {
+		ownerId: owner.id,
+		requestText: 'Favorite the literal title',
+		rateLimitKey: owner.id,
+		fetchImpl: vi.fn<typeof fetch>(async () =>
+			aiResponse({
+				summary: 'Favorite one title.',
+				operations: [
+					{
+						title: 'oNe 100%_cAsE cLoCk',
+						kind: 'movie',
+						destination: null,
+						score: null,
+						progressUnit: null,
+						progressCurrent: null,
+						favorite: true,
+						collection: null,
+					},
+				],
+			}),
+		),
+	})
+	const stored = JSON.parse(preview.operations) as {
+		operations: Array<{ mediaId: string; mediaTitle: string }>
+	}
+	expect(stored.operations).toEqual([
+		expect.objectContaining({ mediaId: exact.id, mediaTitle: exact.title }),
 	])
 })
 

--- a/app/utils/tracking-command.server.ts
+++ b/app/utils/tracking-command.server.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { type Prisma, type PrismaClient } from '@prisma/client'
+import { Prisma, type PrismaClient } from '@prisma/client'
 import { z } from 'zod'
 import {
 	getTrackingActivityState,
@@ -14,7 +14,11 @@ import {
 } from './media-detail.ts'
 import { toggleMediaFavorite } from './media-favorites.server.ts'
 import { listTypeNameForMediaKind } from './media-kind.ts'
-import { prismaSearchFilter } from './prisma-search.server.ts'
+import {
+	escapeSqlLikeLiteral,
+	isPostgresDatasource,
+	prismaSearchFilter,
+} from './prisma-search.server.ts'
 import { setMediaTrackingStatus } from './tracking-status.server.ts'
 
 const MAX_OPERATIONS = 10
@@ -136,9 +140,21 @@ const ResolvedPlanSchema = z.object({
 type ResolvedOperation = z.infer<typeof ResolvedOperationSchema>
 
 type TrackingDb = PrismaClient | Prisma.TransactionClient
+type MediaCandidate = { id: string; title: string | null; kind: string }
 
 function hash(value: unknown) {
 	return createHash('sha256').update(JSON.stringify(value)).digest('hex')
+}
+
+function ambiguousMediaResponse(title: string, candidates: MediaCandidate[]) {
+	const choices = candidates
+		.slice(0, 4)
+		.map(candidate => `${candidate.title ?? 'Untitled'} (${candidate.kind})`)
+		.join(', ')
+	return new Response(
+		`“${title}” is ambiguous. Choose one explicitly by exact title and media type: ${choices}.`,
+		{ status: 409 },
+	)
 }
 
 async function resolveMedia(
@@ -147,6 +163,34 @@ async function resolveMedia(
 	kind: string | null,
 ) {
 	const normalized = normalizeCatalogTitle(title)
+	const canonicalCandidates = normalized
+		? isPostgresDatasource(process.env.DATABASE_URL)
+			? await db.$queryRaw<MediaCandidate[]>(Prisma.sql`
+					SELECT "id", "title", "kind"
+					FROM "Media"
+					WHERE "title" IS NOT NULL
+					AND "title" ILIKE ${escapeSqlLikeLiteral(title)} ESCAPE '!'
+					${kind ? Prisma.sql`AND "kind" = ${kind}` : Prisma.empty}
+					ORDER BY COALESCE("catalogPopularity", 0) DESC, "title" ASC, "id" ASC
+					LIMIT 4
+				`)
+			: await db.$queryRaw<MediaCandidate[]>(Prisma.sql`
+					SELECT "id", "title", "kind"
+					FROM "Media"
+					WHERE "title" IS NOT NULL
+					AND LOWER("title") = LOWER(${title})
+					${kind ? Prisma.sql`AND "kind" = ${kind}` : Prisma.empty}
+					ORDER BY COALESCE("catalogPopularity", 0) DESC, "title" ASC, "id" ASC
+					LIMIT 4
+				`)
+		: []
+	if (canonicalCandidates.length === 1) {
+		return canonicalCandidates[0]!
+	}
+	if (canonicalCandidates.length > 1) {
+		throw ambiguousMediaResponse(title, canonicalCandidates)
+	}
+
 	const exact = await db.media.findMany({
 		where: {
 			...(kind ? { kind } : {}),
@@ -189,15 +233,10 @@ async function resolveMedia(
 				select: { id: true, title: true, kind: true },
 			})
 	if (candidates.length !== 1) {
-		const choices = candidates
-			.map(candidate => `${candidate.title ?? 'Untitled'} (${candidate.kind})`)
-			.join(', ')
-		throw new Response(
-			candidates.length
-				? `“${title}” is ambiguous. Choose one explicitly by exact title and media type: ${choices}.`
-				: `Veud could not find “${title}” in the local catalog.`,
-			{ status: 409 },
-		)
+		if (candidates.length) throw ambiguousMediaResponse(title, candidates)
+		throw new Response(`Veud could not find “${title}” in the local catalog.`, {
+			status: 409,
+		})
 	}
 	return candidates[0]!
 }

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "validate:release:build": "npm run build && npm run bundle:check",
     "validate:release:browser": "cross-env CI=true PORT=4122 playwright test --project=chromium",
     "validate:release:browser:portable": "cross-env CI=true PORT=4122 playwright test --project=chromium --ignore-snapshots",
-    "validate:release:postgres": "npm run prisma:generate:postgres && npm run db:migrate:postgres && npm run db:verify:postgres && npm run db:smoke:postgres && npm run db:loadtest:postgres -- --commit --count 2000 --cleanup-after"
+    "validate:release:postgres": "npm run prisma:generate:postgres && npm run db:migrate:postgres && npm run db:verify:postgres && npm run db:smoke:postgres && npm run db:loadtest:postgres -- --commit --count 2000 --cleanup-after",
+    "validate:scale:postgres": "npm run prisma:generate:postgres && npm run db:migrate:postgres && npm run db:verify:postgres && npm run db:smoke:postgres && npm run db:loadtest:postgres -- --commit --count 100000 --member-count 1000 --tracking-per-member 100 --activity-per-member 20 --require-trigram-indexes --cleanup-after"
   },
   "eslintIgnore": [
     "/node_modules",

--- a/scripts/load-test-postgres-catalog.mjs
+++ b/scripts/load-test-postgres-catalog.mjs
@@ -6,6 +6,7 @@ import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import { PrismaClient } from '@prisma/client'
 import {
+	assertRequiredQueryIndexes,
 	assertSafeLoadDatabaseUrl,
 	bytesLabel,
 	representativeLoadShape,
@@ -18,6 +19,12 @@ const args = process.argv.slice(2)
 const prefix = 'load-catalog-'
 const syntheticBroadDescriptionNeedle = 'Shared synthetic load description'
 const syntheticDescriptionLead = `${syntheticBroadDescriptionNeedle} for indexed discovery.`
+const requiredTrigramIndexesByQuery = {
+	'canonical-title': 'Media_title_trgm_idx',
+	'tracking-exact-title': 'Media_title_trgm_idx',
+	'alternate-title': 'MediaTitle_normalized_trgm_idx',
+	'rare-description': 'Media_description_trgm_idx',
+}
 const usage = `Usage: npm run db:loadtest:postgres -- [options]
 
 Options:
@@ -526,6 +533,11 @@ async function queryMetrics(prisma, count, shape) {
 			[`%Catalog Work ${needle}%`],
 		],
 		[
+			'tracking-exact-title',
+			`SELECT id FROM "Media" WHERE title ILIKE $1 ESCAPE '!' LIMIT 4`,
+			[`Catalog Work ${needle}`],
+		],
+		[
 			'alternate-title',
 			'SELECT "mediaId" FROM "MediaTitle" WHERE normalized ILIKE $1 LIMIT 24',
 			[`%alternate load alias ${alternate}%`],
@@ -959,15 +971,17 @@ async function main() {
 			trackingWriteBatches,
 		)
 		const storageAfter = await databaseMetrics(prisma)
-		const requiredIndexes = new Set([
-			'Media_title_trgm_idx',
-			'Media_description_trgm_idx',
-			'MediaTitle_normalized_trgm_idx',
-		])
-		const usedIndexes = new Set(queries.flatMap(query => query.indexes))
-		const missingIndexes = [...requiredIndexes].filter(
-			index => !usedIndexes.has(index),
-		)
+		let queryIndexAssertionError
+		try {
+			assertRequiredQueryIndexes(queries, requiredTrigramIndexesByQuery)
+		} catch (error) {
+			queryIndexAssertionError = error
+		}
+		const missingQueryIndexes =
+			queryIndexAssertionError?.missingRequirements ?? []
+		const missingIndexes = [
+			...new Set(missingQueryIndexes.map(({ requiredIndex }) => requiredIndex)),
+		]
 		const insertedRows = loaded - checkpoint.initialRows
 		const insertMs = checkpoint.insertWallMs
 		const report = {
@@ -1003,6 +1017,7 @@ async function main() {
 			queries,
 			concurrency,
 			missingTrigramIndexes: missingIndexes,
+			missingQueryIndexes,
 		}
 		writePrivateJson(reportPath, report)
 		console.log(
@@ -1023,10 +1038,8 @@ async function main() {
 				`Cleanup removed ${cleaned.deletedMedia} media and ${cleaned.deletedMembers} member rows in ${cleaned.wallMs}ms.`,
 			)
 		}
-		if (requireIndexes && missingIndexes.length) {
-			throw new Error(
-				`Required trigram indexes were not used: ${missingIndexes.join(', ')}`,
-			)
+		if (requireIndexes && queryIndexAssertionError) {
+			throw queryIndexAssertionError
 		}
 	} finally {
 		await prisma.$disconnect()

--- a/scripts/postgres-load-utils.mjs
+++ b/scripts/postgres-load-utils.mjs
@@ -57,6 +57,63 @@ export function summarizeExplain(rows) {
 	}
 }
 
+export function assertRequiredQueryIndexes(queryPlans, requirements) {
+	if (!Array.isArray(queryPlans)) {
+		throw new Error('Query plans must be an array')
+	}
+	if (
+		!requirements ||
+		typeof requirements !== 'object' ||
+		Array.isArray(requirements)
+	) {
+		throw new Error('Query index requirements must be an object')
+	}
+
+	const missingRequirements = []
+	for (const [queryName, requiredIndex] of Object.entries(requirements)) {
+		if (
+			!queryName ||
+			typeof requiredIndex !== 'string' ||
+			!requiredIndex.trim()
+		) {
+			throw new Error('Query index requirements must map names to indexes')
+		}
+		const measurements = queryPlans.filter(plan => plan?.name === queryName)
+		const missingMeasurements = measurements.filter(
+			plan =>
+				!Array.isArray(plan.indexes) || !plan.indexes.includes(requiredIndex),
+		)
+		if (measurements.length && !missingMeasurements.length) continue
+		missingRequirements.push({
+			queryName,
+			requiredIndex,
+			measurementCount: measurements.length,
+			missingMeasurementCount: missingMeasurements.length,
+			observedIndexes: [
+				...new Set(
+					measurements.flatMap(plan =>
+						Array.isArray(plan.indexes) ? plan.indexes : [],
+					),
+				),
+			].sort(),
+		})
+	}
+	if (!missingRequirements.length) return
+
+	const failure = new Error(
+		`Required query indexes were not used by their matching queries: ${missingRequirements
+			.map(requirement => {
+				const observation = requirement.measurementCount
+					? `${requirement.missingMeasurementCount}/${requirement.measurementCount} measurements missing; observed ${requirement.observedIndexes.join(', ') || 'none'}`
+					: 'query was not measured'
+				return `${requirement.queryName} -> ${requirement.requiredIndex} (${observation})`
+			})
+			.join('; ')}`,
+	)
+	failure.missingRequirements = missingRequirements
+	throw failure
+}
+
 export function bytesLabel(value) {
 	const bytes = Number(value)
 	if (!Number.isFinite(bytes) || bytes < 0) return 'unknown'

--- a/scripts/postgres-load-utils.test.mjs
+++ b/scripts/postgres-load-utils.test.mjs
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import {
+	assertRequiredQueryIndexes,
 	assertSafeLoadDatabaseUrl,
 	bytesLabel,
 	representativeLoadShape,
@@ -63,6 +64,103 @@ test('summarizes nested explain plans without credentials or raw SQL', () => {
 		sharedReadBlocks: 0,
 	})
 	expect(bytesLabel(1_048_576)).toBe('1.00 MiB')
+})
+
+test('requires every measured search to use the index assigned to its query', () => {
+	expect(() =>
+		assertRequiredQueryIndexes(
+			[
+				{
+					name: 'canonical-title',
+					indexes: ['Media_title_trgm_idx'],
+				},
+				{
+					name: 'canonical-title',
+					indexes: ['Media_title_trgm_idx'],
+				},
+				{
+					name: 'alternate-title',
+					indexes: ['MediaTitle_normalized_trgm_idx'],
+				},
+				{
+					name: 'rare-description',
+					indexes: ['Media_description_trgm_idx'],
+				},
+			],
+			{
+				'canonical-title': 'Media_title_trgm_idx',
+				'alternate-title': 'MediaTitle_normalized_trgm_idx',
+				'rare-description': 'Media_description_trgm_idx',
+			},
+		),
+	).not.toThrow()
+})
+
+test('does not accept a required index used only by the wrong query', () => {
+	const requirements = {
+		'canonical-title': 'Media_title_trgm_idx',
+		'alternate-title': 'MediaTitle_normalized_trgm_idx',
+		'rare-description': 'Media_description_trgm_idx',
+	}
+	const plans = [
+		{
+			name: 'canonical-title',
+			indexes: ['MediaTitle_normalized_trgm_idx'],
+		},
+		{
+			name: 'alternate-title',
+			indexes: ['Media_description_trgm_idx'],
+		},
+		{
+			name: 'rare-description',
+			indexes: ['Media_title_trgm_idx'],
+		},
+	]
+
+	let failure
+	try {
+		assertRequiredQueryIndexes(plans, requirements)
+	} catch (error) {
+		failure = error
+	}
+
+	expect(failure).toBeInstanceOf(Error)
+	expect(failure.message).toContain('canonical-title -> Media_title_trgm_idx')
+	expect(failure.missingRequirements).toEqual([
+		expect.objectContaining({
+			queryName: 'canonical-title',
+			requiredIndex: 'Media_title_trgm_idx',
+		}),
+		expect.objectContaining({
+			queryName: 'alternate-title',
+			requiredIndex: 'MediaTitle_normalized_trgm_idx',
+		}),
+		expect.objectContaining({
+			queryName: 'rare-description',
+			requiredIndex: 'Media_description_trgm_idx',
+		}),
+	])
+})
+
+test('rejects an unmeasured required query and a partial duplicate measurement', () => {
+	expect(() =>
+		assertRequiredQueryIndexes(
+			[
+				{
+					name: 'canonical-title',
+					indexes: ['Media_title_trgm_idx'],
+				},
+				{
+					name: 'canonical-title',
+					indexes: [],
+				},
+			],
+			{
+				'canonical-title': 'Media_title_trgm_idx',
+				'alternate-title': 'MediaTitle_normalized_trgm_idx',
+			},
+		),
+	).toThrow(/1\/2 measurements missing.*alternate-title/s)
 })
 
 test('derives a bounded representative catalog and member load shape', () => {

--- a/scripts/smoke-postgres.ts
+++ b/scripts/smoke-postgres.ts
@@ -1,12 +1,15 @@
 #!/usr/bin/env -S npx tsx
 import 'dotenv/config'
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, type Prisma } from '@prisma/client'
 import {
 	applyLibraryImportBatch,
 	rollbackLibraryImportBatch,
 } from '#app/utils/library-import-commit.server.ts'
 import { type LibraryImportItem } from '#app/utils/library-import.ts'
-import { prismaSearchFilter } from '#app/utils/prisma-search.server.ts'
+import {
+	escapeSqlLikeLiteral,
+	prismaSearchFilter,
+} from '#app/utils/prisma-search.server.ts'
 import { searchUsersByUsername } from '#app/utils/user-search.server.ts'
 
 const requiredIndexes = new Set([
@@ -27,7 +30,10 @@ async function main() {
 	assertPostgresUrl(process.env.DATABASE_URL)
 	const prisma = new PrismaClient()
 	const suffix = `${Date.now()}-${process.pid}`
-	const username = `Postgres_Smoke_${suffix}`
+	const username = `PostgresSmoke${suffix}`
+	const displayName = `PostgreSQL smoke test ${suffix}`
+	const collectionTitleMarker = `PostgreSQL Collection Search ${suffix}`
+	const collectionDescriptionMarker = `Provider Search Boundary ${suffix}`
 	let userId: string | undefined
 	let mediaId: string | undefined
 
@@ -123,15 +129,16 @@ async function main() {
 			data: {
 				email: `${username}@example.com`,
 				username,
-				name: 'PostgreSQL smoke test',
+				name: displayName,
 			},
 		})
 		userId = user.id
 		const media = await prisma.media.create({
 			data: {
 				kind: 'movie',
-				title: 'PostgreSQL Catalog Smoke Test',
+				title: `PostgreSQL Catalog Smoke Test 100%_Literal ${suffix}`,
 				description: 'Temporary provider-scale search verification.',
+				genres: 'Space Opera',
 				titles: {
 					create: {
 						provider: 'tmdb',
@@ -148,11 +155,38 @@ async function main() {
 
 		const users = (await searchUsersByUsername(
 			prisma,
-			'postgres_smoke',
+			`pOsTgReSsMoKe${suffix}`,
 		)) as Array<{ id: string }>
 		if (!users.some(candidate => candidate.id === user.id)) {
 			throw new Error(
 				'Portable user search did not find the smoke-test account',
+			)
+		}
+		const mixedCaseDisplayNameMatches = await prisma.user.findMany({
+			where: {
+				OR: [
+					{
+						username: prismaSearchFilter(
+							'contains',
+							'definitely-not-the-username',
+						),
+					},
+					{
+						name: prismaSearchFilter(
+							'contains',
+							`pOsTgReSqL sMoKe TeSt ${suffix}`,
+						),
+					},
+				],
+			},
+			select: { id: true },
+		})
+		if (
+			mixedCaseDisplayNameMatches.length !== 1 ||
+			mixedCaseDisplayNameMatches[0]?.id !== user.id
+		) {
+			throw new Error(
+				'Case-insensitive PostgreSQL moderator-style member search returned the wrong rows',
 			)
 		}
 
@@ -173,6 +207,21 @@ async function main() {
 				'Case-insensitive PostgreSQL canonical-title search returned no rows',
 			)
 		}
+		const exactCanonicalMatches = await prisma.$queryRaw<Array<{ id: string }>>`
+			SELECT "id"
+			FROM "Media"
+			WHERE "title" ILIKE ${escapeSqlLikeLiteral(
+				`pOsTgReSqL cAtAlOg SmOkE tEsT 100%_lItErAl ${suffix}`,
+			)} ESCAPE '!'
+		`
+		if (
+			exactCanonicalMatches.length !== 1 ||
+			exactCanonicalMatches[0]?.id !== media.id
+		) {
+			throw new Error(
+				'Literal-escaped PostgreSQL exact-title search returned the wrong rows',
+			)
+		}
 		const mixedCaseAlternateMatches = await prisma.mediaTitle.count({
 			where: {
 				mediaId: media.id,
@@ -184,6 +233,103 @@ async function main() {
 				'Case-insensitive PostgreSQL alternate-title search returned no rows',
 			)
 		}
+		const mixedCaseGenreContainsMatches = await prisma.media.count({
+			where: {
+				id: media.id,
+				genres: prismaSearchFilter('contains', 'sPaCe OpErA'),
+			},
+		})
+		const mixedCaseSingletonGenreMatches = await prisma.media.count({
+			where: {
+				id: media.id,
+				AND: [
+					{ genres: prismaSearchFilter('startsWith', 'sPaCe OpErA') },
+					{ genres: prismaSearchFilter('endsWith', 'sPaCe OpErA') },
+				],
+			},
+		})
+		if (
+			mixedCaseGenreContainsMatches !== 1 ||
+			mixedCaseSingletonGenreMatches !== 1
+		) {
+			throw new Error(
+				'Case-insensitive PostgreSQL genre search returned no rows',
+			)
+		}
+
+		const visibleCollection = await prisma.mediaCollection.create({
+			data: {
+				ownerId: user.id,
+				title: collectionTitleMarker,
+				description: collectionDescriptionMarker,
+				isPublic: true,
+				moderationStatus: 'visible',
+			},
+			select: { id: true },
+		})
+		await prisma.mediaCollection.createMany({
+			data: [
+				{
+					ownerId: user.id,
+					title: collectionTitleMarker,
+					description: collectionDescriptionMarker,
+					isPublic: false,
+					moderationStatus: 'visible',
+				},
+				{
+					ownerId: user.id,
+					title: collectionTitleMarker,
+					description: collectionDescriptionMarker,
+					isPublic: true,
+					moderationStatus: 'hidden',
+				},
+			],
+		})
+		const assertVisibleCollectionSearch = async (
+			label: string,
+			search: Prisma.MediaCollectionWhereInput,
+		) => {
+			const matches = await prisma.mediaCollection.findMany({
+				where: {
+					AND: [{ isPublic: true, moderationStatus: 'visible' }, search],
+				},
+				select: { id: true },
+			})
+			if (matches.length !== 1 || matches[0]?.id !== visibleCollection.id) {
+				throw new Error(
+					`Case-insensitive PostgreSQL collection ${label} search escaped its visibility boundary`,
+				)
+			}
+		}
+		await assertVisibleCollectionSearch('title', {
+			OR: [
+				{
+					title: prismaSearchFilter(
+						'contains',
+						`pOsTgReSqL cOlLeCtIoN sEaRcH ${suffix}`,
+					),
+				},
+			],
+		})
+		await assertVisibleCollectionSearch('description', {
+			OR: [
+				{
+					description: prismaSearchFilter(
+						'contains',
+						`pRoViDeR sEaRcH bOuNdArY ${suffix}`,
+					),
+				},
+			],
+		})
+		await assertVisibleCollectionSearch('owner', {
+			OR: [
+				{
+					owner: {
+						username: prismaSearchFilter('contains', `pOsTgReSsMoKe${suffix}`),
+					},
+				},
+			],
+		})
 
 		const sourceKey = `postgres-smoke:${suffix}`
 		const importItem = {
@@ -248,7 +394,7 @@ async function main() {
 		}
 
 		console.log(
-			'PostgreSQL smoke test passed: schema, pg_trgm indexes, model writes, portable searches, and atomic import rollback are healthy.',
+			'PostgreSQL smoke test passed: schema, pg_trgm indexes, model writes, provider-aware media/member/collection/genre searches, visibility boundaries, and atomic import rollback are healthy.',
 		)
 	} finally {
 		if (mediaId) await prisma.media.deleteMany({ where: { id: mediaId } })


### PR DESCRIPTION
## Summary

- route remaining catalog, collection, moderation, and recommendation text filters through provider-aware case-insensitive search
- prefer literal-safe canonical exact title matches for tracking commands while preserving ambiguity safeguards
- expand PostgreSQL smoke coverage for mixed-case fields, visibility boundaries, genres, and literal `%` / `_` titles
- add an exact per-query index assertion and a representative 100k-media nightly/manual PostgreSQL scale gate

## Validation

- 156 test files / 670 unit tests
- lint, typecheck, icon validation, Prettier, and diff checks
- production build and bundle budgets
- Chromium 97/97
- PostgreSQL migration/drift/smoke/2,000-row release gate
- PostgreSQL 100,000-media / 1,000-member scale gate with exact query-to-index requirements
- independent adversarial review: no actionable findings