### PR TITLE
Promote bounded community aggregation to production

### DIFF
--- a/app/utils/discovery.server.test.ts
+++ b/app/utils/discovery.server.test.ts
@@ -315,6 +315,7 @@ test('discovery matches mixed-case canonical and alternate titles', async () => 
 
 test('anime and manga popularity use MAL rank without score or community reshuffling', async () => {
 	for (const kind of ['anime', 'manga'] as const) {
+		const communityMember = await createUser(`${kind}_rank_member`)
 		const [rankOne, rankTwo, unranked] = await Promise.all([
 			prisma.media.create({
 				data: {
@@ -360,6 +361,14 @@ test('anime and manga popularity use MAL rank without score or community reshuff
 				},
 			],
 		})
+		await prisma.trackingState.create({
+			data: {
+				ownerId: communityMember.id,
+				mediaId: rankTwo.id,
+				status: 'completed',
+				score: 10,
+			},
+		})
 
 		const result = await getDiscoveryResults(
 			filters({ kind, sort: 'popular' }),
@@ -370,7 +379,119 @@ test('anime and manga popularity use MAL rank without score or community reshuff
 			rankTwo.id,
 			unranked.id,
 		])
+		expect(result.items[1]).toEqual(
+			expect.objectContaining({
+				id: rankTwo.id,
+				communityScore: 10,
+				ratingCount: 1,
+				trackerCount: 1,
+			}),
+		)
 	}
+})
+
+test('TMDB popularity applies only the bounded public community boost', async () => {
+	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
+	const [publicMember, privateMember] = await Promise.all([
+		createUser('tmdb_public_boost'),
+		createUser('tmdb_private_boost'),
+	])
+	const listType = await prisma.listType.create({
+		data: {
+			name: `tmdb-boost-${suffix}`,
+			header: 'TMDB boost',
+			columns: '{}',
+			mediaType: '["movie"]',
+			completionType: '{}',
+		},
+	})
+	const privateList = await prisma.watchlist.create({
+		data: {
+			ownerId: privateMember.id,
+			typeId: listType.id,
+			name: 'private',
+			header: 'Private',
+			isPublic: false,
+		},
+	})
+	const [baseline, publicBoost, privateBoost] = await Promise.all(
+		['Baseline', 'Public', 'Private'].map(label =>
+			prisma.media.create({
+				data: {
+					kind: 'movie',
+					title: `TMDB ${label} boost ${suffix}`,
+				},
+			}),
+		),
+	)
+	await Promise.all([
+		prisma.catalogFeedItem.createMany({
+			data: [
+				{
+					provider: 'tmdb',
+					kind: 'movie',
+					feed: 'popular',
+					rank: 1,
+					rankingScore: 1,
+					rankingVersion: 999,
+					observedAt: new Date(),
+					mediaId: baseline.id,
+				},
+				{
+					provider: 'tmdb',
+					kind: 'movie',
+					feed: 'popular',
+					rank: 2,
+					rankingScore: 0.99999,
+					rankingVersion: 999,
+					observedAt: new Date(),
+					mediaId: publicBoost.id,
+				},
+				{
+					provider: 'tmdb',
+					kind: 'movie',
+					feed: 'popular',
+					rank: 3,
+					rankingScore: 0.99999,
+					rankingVersion: 999,
+					observedAt: new Date(),
+					mediaId: privateBoost.id,
+				},
+			],
+		}),
+		prisma.trackingState.create({
+			data: {
+				ownerId: publicMember.id,
+				mediaId: publicBoost.id,
+				status: 'completed',
+			},
+		}),
+		prisma.trackingState.create({
+			data: {
+				ownerId: privateMember.id,
+				mediaId: privateBoost.id,
+				status: 'completed',
+				statusWatchlistId: privateList.id,
+			},
+		}),
+	])
+
+	const result = await getDiscoveryResults(
+		filters({ kind: 'movie', sort: 'popular' }),
+		null,
+	)
+
+	expect(result.items.slice(0, 3).map(item => item.id)).toEqual([
+		publicBoost.id,
+		baseline.id,
+		privateBoost.id,
+	])
+	expect(
+		result.items.find(item => item.id === publicBoost.id)?.trackerCount,
+	).toBe(1)
+	expect(
+		result.items.find(item => item.id === privateBoost.id)?.trackerCount,
+	).toBe(0)
 })
 
 test('natural discovery enforces locally stored episode bounds', async () => {
@@ -527,10 +648,13 @@ test('top-rated pages use one stable global ranking without duplicates', async (
 })
 
 test('private-list tracking stays personal and does not affect discovery aggregates', async () => {
-	const [publicMember, privateMember] = await Promise.all([
-		createUser('public_discovery_member'),
-		createUser('private_discovery_member'),
-	])
+	const [publicMember, privateMember, listlessRater, listlessTracker] =
+		await Promise.all([
+			createUser('public_discovery_member'),
+			createUser('private_discovery_member'),
+			createUser('listless_discovery_rater'),
+			createUser('listless_discovery_tracker'),
+		])
 	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
 	const listType = await prisma.listType.create({
 		data: {
@@ -587,6 +711,21 @@ test('private-list tracking stays personal and does not affect discovery aggrega
 				score: 10,
 			},
 		}),
+		prisma.trackingState.create({
+			data: {
+				ownerId: listlessRater.id,
+				mediaId: publicTitle.id,
+				status: 'completed',
+				score: 6,
+			},
+		}),
+		prisma.trackingState.create({
+			data: {
+				ownerId: listlessTracker.id,
+				mediaId: publicTitle.id,
+				status: 'watching',
+			},
+		}),
 	])
 
 	const topRated = await getDiscoveryResults(
@@ -594,6 +733,13 @@ test('private-list tracking stays personal and does not affect discovery aggrega
 		null,
 	)
 	expect(topRated.items.map(item => item.id)).toEqual([publicTitle.id])
+	expect(topRated.items[0]).toEqual(
+		expect.objectContaining({
+			communityScore: 7,
+			ratingCount: 2,
+			trackerCount: 3,
+		}),
+	)
 
 	const ownerView = await getDiscoveryResults(
 		filters({ q: 'Discovery Privacy', sort: 'title' }),

--- a/app/utils/discovery.server.ts
+++ b/app/utils/discovery.server.ts
@@ -2,6 +2,11 @@ import { type Prisma } from '@prisma/client'
 import { z } from 'zod'
 import { normalizeCatalogTitle } from './catalog-sync.server.ts'
 import { prisma } from './db.server.ts'
+import { publicTrackingStateWhere } from './lists/visibility.ts'
+import {
+	getPublicTrackingSummariesByMediaId,
+	type PublicTrackingSummary,
+} from './media-community.server.ts'
 import { type NaturalLanguageDiscoveryPlan } from './natural-language-discovery.ts'
 import { prismaSearchFilter } from './prisma-search.server.ts'
 import { TMDB_FEED_RANKING_VERSION } from './tmdb-catalog-hydration.server.ts'
@@ -109,18 +114,8 @@ const discoveryMediaSelect = {
 			sourceRatingCount: true,
 		},
 	},
-	trackingStates: {
-		select: {
-			ownerId: true,
-			status: true,
-			statusWatchlistId: true,
-			statusWatchlist: { select: { isPublic: true } },
-			score: true,
-		},
-	},
 	_count: {
 		select: {
-			trackingStates: true,
 			reviews: true,
 			diaryEntries: true,
 		},
@@ -138,6 +133,11 @@ type RankedMedia = DiscoveryMedia & {
 	affinityScore: number
 	viewerTracking: DiscoveryResult['viewerTracking']
 	publicTrackerCount: number
+}
+
+type DiscoveryMediaPage = {
+	media: DiscoveryMedia[]
+	publicSummaries: Map<string, PublicTrackingSummary>
 }
 
 type Preference = { label: string; weight: number }
@@ -298,35 +298,42 @@ export async function getDiscoveryResultsForPlan(
 		getGenrePreferences(viewerId),
 	])
 	const { page, pageCount, skip } = pagination(total, input.page)
-	const media =
-		sort === 'popular' || sort === 'for-you'
-			? await popularMediaPage({
-					where,
-					page,
-					pageSize: DISCOVERY_PAGE_SIZE,
-					malKind:
-						plan.kinds.length === 1 &&
-						(plan.kinds[0] === 'anime' || plan.kinds[0] === 'manga')
-							? plan.kinds[0]
-							: null,
-				})
-			: sort === 'top-rated'
-				? await topRatedMediaPage({
-						where,
-						page,
-						pageSize: DISCOVERY_PAGE_SIZE,
-						preferences,
-						viewerId,
-					})
-				: await prisma.media.findMany({
-						where,
-						select: discoveryMediaSelect,
-						orderBy: discoveryOrderBy(sort),
-						skip,
-						take: DISCOVERY_PAGE_SIZE,
-					})
-	let ranked = rankableMedia(media, preferences, viewerId)
-	if (sort === 'top-rated') ranked = rankTopRated(ranked)
+	let ranked: RankedMedia[]
+	if (sort === 'popular' || sort === 'for-you') {
+		const pageResult = await popularMediaPage({
+			where,
+			page,
+			pageSize: DISCOVERY_PAGE_SIZE,
+			malKind:
+				plan.kinds.length === 1 &&
+				(plan.kinds[0] === 'anime' || plan.kinds[0] === 'manga')
+					? plan.kinds[0]
+					: null,
+		})
+		ranked = await rankableMediaWithViewer(
+			pageResult.media,
+			preferences,
+			viewerId,
+			pageResult.publicSummaries,
+		)
+	} else if (sort === 'top-rated') {
+		ranked = await topRatedMediaPage({
+			where,
+			page,
+			pageSize: DISCOVERY_PAGE_SIZE,
+			preferences,
+			viewerId,
+		})
+	} else {
+		const media = await prisma.media.findMany({
+			where,
+			select: discoveryMediaSelect,
+			orderBy: discoveryOrderBy(sort),
+			skip,
+			take: DISCOVERY_PAGE_SIZE,
+		})
+		ranked = await rankableMediaWithViewer(media, preferences, viewerId)
+	}
 	if (sort === 'for-you') ranked = rankForYou(ranked)
 	return {
 		filters: { ...input.filters, sort, page },
@@ -372,9 +379,8 @@ export async function getDiscoveryResultsForMediaIds(
 		}),
 		getGenrePreferences(viewerId),
 	])
-	const byId = new Map(
-		rankableMedia(media, preferences, viewerId).map(item => [item.id, item]),
-	)
+	const ranked = await rankableMediaWithViewer(media, preferences, viewerId)
+	const byId = new Map(ranked.map(item => [item.id, item]))
 	const items = orderedIds.flatMap(id => {
 		const item = byId.get(id)
 		return item ? [resultFromMedia(item, '')] : []
@@ -398,23 +404,6 @@ export function splitGenres(value: string | null | undefined) {
 
 function titleForSort(media: DiscoveryMedia) {
 	return (media.title ?? '').toLocaleLowerCase()
-}
-
-function publicTrackingStates(media: DiscoveryMedia) {
-	return media.trackingStates.filter(
-		state =>
-			state.statusWatchlistId === null || state.statusWatchlist?.isPublic,
-	)
-}
-
-function communityScore(media: DiscoveryMedia) {
-	const scores = publicTrackingStates(media)
-		.map(state => (state.score === null ? null : Number(state.score)))
-		.filter(
-			(score): score is number => score !== null && Number.isFinite(score),
-		)
-	if (!scores.length) return null
-	return scores.reduce((total, score) => total + score, 0) / scores.length
 }
 
 export function catalogPopularityScore(counts: {
@@ -621,10 +610,7 @@ function publicRatingWhere(): Prisma.MediaWhereInput {
 				trackingStates: {
 					some: {
 						score: { not: null },
-						OR: [
-							{ statusWatchlistId: null },
-							{ statusWatchlist: { isPublic: true } },
-						],
+						AND: [publicTrackingStateWhere],
 					},
 				},
 			},
@@ -720,9 +706,13 @@ async function popularMediaPage(input: {
 	page: number
 	pageSize: number
 	malKind?: 'anime' | 'manga' | null
-}) {
-	if (input.malKind)
-		return malPopularMediaPage({ ...input, kind: input.malKind })
+}): Promise<DiscoveryMediaPage> {
+	if (input.malKind) {
+		return {
+			media: await malPopularMediaPage({ ...input, kind: input.malKind }),
+			publicSummaries: new Map(),
+		}
+	}
 	const freshAfter = new Date(Date.now() - POPULAR_FEED_FRESHNESS_MS)
 	const feedSelect = {
 		mediaId: true,
@@ -763,10 +753,16 @@ async function popularMediaPage(input: {
 				take: 200,
 				select: feedSelect,
 			})
+	const publicSummaries = await getPublicTrackingSummariesByMediaId(
+		feedRows.map(row => row.mediaId),
+	)
 	const ranked = [...new Map(feedRows.map(row => [row.mediaId, row])).values()]
 		.sort((left, right) => {
 			const boundedCommunityBoost = (media: DiscoveryMedia) =>
-				Math.min(0.02, publicTrackingStates(media).length / 50_000)
+				Math.min(
+					0.02,
+					(publicSummaries.get(media.id)?.trackerCount ?? 0) / 50_000,
+				)
 			return (
 				(right.rankingScore ?? 0) +
 					boundedCommunityBoost(right.media) -
@@ -781,7 +777,7 @@ async function popularMediaPage(input: {
 	const rankedSlice =
 		start < ranked.length ? ranked.slice(start, start + input.pageSize) : []
 	const remaining = input.pageSize - rankedSlice.length
-	if (!remaining) return rankedSlice
+	if (!remaining) return { media: rankedSlice, publicSummaries }
 	const fallbackSkip = Math.max(0, start - ranked.length)
 	const fallback = await prisma.media.findMany({
 		where: {
@@ -795,7 +791,10 @@ async function popularMediaPage(input: {
 		skip: fallbackSkip,
 		take: remaining,
 	})
-	return [...rankedSlice, ...fallback]
+	return {
+		media: [...rankedSlice, ...fallback],
+		publicSummaries,
+	}
 }
 
 async function malPopularMediaPage(input: {
@@ -867,18 +866,32 @@ async function topRatedMediaPage(input: {
 		],
 		take: 1_000,
 	})
-	const ranked = rankTopRated(
-		rankableMedia(candidates, input.preferences, input.viewerId),
-	)
 	const start = (input.page - 1) * input.pageSize
-	return ranked.slice(start, start + input.pageSize)
+	const ranked = rankTopRated(
+		await rankableMedia(candidates, input.preferences),
+	)
+	return withViewerTracking(
+		ranked.slice(start, start + input.pageSize),
+		input.viewerId,
+	)
 }
 
-function rankableMedia(
+async function rankableMedia(
 	media: DiscoveryMedia[],
 	preferences: Preference[],
-	viewerId: string | null,
-) {
+	knownPublicSummaries: Map<string, PublicTrackingSummary> = new Map(),
+): Promise<RankedMedia[]> {
+	const publicSummaries = new Map(knownPublicSummaries)
+	const missingIds = media
+		.map(item => item.id)
+		.filter(mediaId => !publicSummaries.has(mediaId))
+	if (missingIds.length) {
+		const missingSummaries =
+			await getPublicTrackingSummariesByMediaId(missingIds)
+		for (const [mediaId, summary] of missingSummaries) {
+			publicSummaries.set(mediaId, summary)
+		}
+	}
 	const preferenceWeights = new Map(
 		preferences.map(preference => [
 			preference.label.toLocaleLowerCase(),
@@ -886,24 +899,20 @@ function rankableMedia(
 		]),
 	)
 	return media.map(item => {
-		const publicStates = publicTrackingStates(item)
-		const viewerState = viewerId
-			? item.trackingStates.find(state => state.ownerId === viewerId)
-			: null
+		const publicSummary = publicSummaries.get(item.id) ?? {
+			trackerCount: 0,
+			ratingCount: 0,
+			communityScore: null,
+		}
 		return {
 			...item,
-			viewerTracking: viewerState
-				? {
-						status: viewerState.status,
-						statusWatchlistId: viewerState.statusWatchlistId,
-					}
-				: null,
-			communityScore: communityScore(item),
-			ratingCount: publicStates.filter(state => state.score !== null).length,
-			publicTrackerCount: publicStates.length,
+			viewerTracking: null,
+			communityScore: publicSummary.communityScore,
+			ratingCount: publicSummary.ratingCount,
+			publicTrackerCount: publicSummary.trackerCount,
 			popularityScore: catalogPopularityScore({
 				...item._count,
-				trackingStates: publicStates.length,
+				trackingStates: publicSummary.trackerCount,
 			}),
 			affinityScore: splitGenres(item.genres).reduce(
 				(total, genre) =>
@@ -912,6 +921,51 @@ function rankableMedia(
 			),
 		}
 	})
+}
+
+async function withViewerTracking(
+	media: RankedMedia[],
+	viewerId: string | null,
+) {
+	if (!viewerId || !media.length) return media
+	const viewerStates = await prisma.trackingState.findMany({
+		where: {
+			ownerId: viewerId,
+			mediaId: { in: media.map(item => item.id) },
+		},
+		select: {
+			mediaId: true,
+			status: true,
+			statusWatchlistId: true,
+		},
+	})
+	const stateByMediaId = new Map(
+		viewerStates.map(state => [state.mediaId, state]),
+	)
+	return media.map(item => {
+		const viewerState = stateByMediaId.get(item.id)
+		return {
+			...item,
+			viewerTracking: viewerState
+				? {
+						status: viewerState.status,
+						statusWatchlistId: viewerState.statusWatchlistId,
+					}
+				: null,
+		}
+	})
+}
+
+async function rankableMediaWithViewer(
+	media: DiscoveryMedia[],
+	preferences: Preference[],
+	viewerId: string | null,
+	publicSummaries?: Map<string, PublicTrackingSummary>,
+) {
+	return withViewerTracking(
+		await rankableMedia(media, preferences, publicSummaries),
+		viewerId,
+	)
 }
 
 function pagination(total: number, requestedPage: number) {
@@ -969,7 +1023,7 @@ export async function getDiscoveryResults(
 				]),
 			).values(),
 		]
-		const ranked = rankForYou(rankableMedia(candidates, preferences, viewerId))
+		const ranked = rankForYou(await rankableMedia(candidates, preferences))
 		const { page, pageCount, skip } = pagination(ranked.length, filters.page)
 		return {
 			filters: { ...filters, page },
@@ -984,38 +1038,48 @@ export async function getDiscoveryResults(
 
 	const total = await prisma.media.count({ where })
 	const { page, pageCount, skip } = pagination(total, filters.page)
-	const media =
-		filters.sort === 'popular'
-			? await popularMediaPage({
-					where,
-					page,
-					pageSize: DISCOVERY_PAGE_SIZE,
-					malKind:
-						filters.kind === 'anime' || filters.kind === 'manga'
-							? filters.kind
-							: null,
-				})
-			: filters.sort === 'top-rated'
-				? await topRatedMediaPage({
-						where,
-						page,
-						pageSize: DISCOVERY_PAGE_SIZE,
-						preferences,
-						viewerId,
-					})
-				: await prisma.media.findMany({
-						where,
-						select: discoveryMediaSelect,
-						orderBy: discoveryOrderBy(filters.sort),
-						skip,
-						take: DISCOVERY_PAGE_SIZE,
-					})
-	const ranked = rankableMedia(media, preferences, viewerId)
+	let ranked: RankedMedia[]
+	if (filters.sort === 'popular') {
+		const pageResult = await popularMediaPage({
+			where,
+			page,
+			pageSize: DISCOVERY_PAGE_SIZE,
+			malKind:
+				filters.kind === 'anime' || filters.kind === 'manga'
+					? filters.kind
+					: null,
+		})
+		ranked = await rankableMediaWithViewer(
+			pageResult.media,
+			preferences,
+			viewerId,
+			pageResult.publicSummaries,
+		)
+	} else if (filters.sort === 'top-rated') {
+		ranked = await topRatedMediaPage({
+			where,
+			page,
+			pageSize: DISCOVERY_PAGE_SIZE,
+			preferences,
+			viewerId,
+		})
+	} else {
+		const media = await prisma.media.findMany({
+			where,
+			select: discoveryMediaSelect,
+			orderBy: discoveryOrderBy(filters.sort),
+			skip,
+			take: DISCOVERY_PAGE_SIZE,
+		})
+		ranked = await rankableMediaWithViewer(
+			media,
+			preferences,
+			filters.sort === 'for-you' ? null : viewerId,
+		)
+	}
 	return {
 		filters: { ...filters, page },
-		items: (filters.sort === 'top-rated' ? rankTopRated(ranked) : ranked).map(
-			item => resultFromMedia(item, normalizedQuery),
-		),
+		items: ranked.map(item => resultFromMedia(item, normalizedQuery)),
 		total,
 		pageCount,
 		preferredGenres: preferences.map(preference => preference.label),

--- a/app/utils/media-community.server.test.ts
+++ b/app/utils/media-community.server.test.ts
@@ -6,6 +6,7 @@ import {
 	buildStatusBreakdown,
 	getFollowedMediaTracking,
 	getMediaCommunityStatistics,
+	getPublicTrackingSummariesByMediaId,
 } from './media-community.server.ts'
 
 test('score distribution rounds decimal ratings into bounded ten-point buckets', () => {
@@ -53,26 +54,33 @@ test('status breakdown stays data-driven and ranks the largest groups first', ()
 
 test('community and following statistics exclude private-list tracking', async () => {
 	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
-	const [viewer, publicMember, privateMember] = await Promise.all([
-		prisma.user.create({
-			data: {
-				email: `viewer_${suffix}@example.com`,
-				username: `viewer_${suffix}`,
-			},
-		}),
-		prisma.user.create({
-			data: {
-				email: `public_${suffix}@example.com`,
-				username: `public_${suffix}`,
-			},
-		}),
-		prisma.user.create({
-			data: {
-				email: `private_${suffix}@example.com`,
-				username: `private_${suffix}`,
-			},
-		}),
-	])
+	const [viewer, publicMember, privateMember, listlessMember] =
+		await Promise.all([
+			prisma.user.create({
+				data: {
+					email: `viewer_${suffix}@example.com`,
+					username: `viewer_${suffix}`,
+				},
+			}),
+			prisma.user.create({
+				data: {
+					email: `public_${suffix}@example.com`,
+					username: `public_${suffix}`,
+				},
+			}),
+			prisma.user.create({
+				data: {
+					email: `private_${suffix}@example.com`,
+					username: `private_${suffix}`,
+				},
+			}),
+			prisma.user.create({
+				data: {
+					email: `listless_${suffix}@example.com`,
+					username: `listless_${suffix}`,
+				},
+			}),
+		])
 	const listType = await prisma.listType.create({
 		data: {
 			name: `community-${suffix}`,
@@ -124,6 +132,14 @@ test('community and following statistics exclude private-list tracking', async (
 				score: 10,
 			},
 		}),
+		prisma.trackingState.create({
+			data: {
+				ownerId: listlessMember.id,
+				mediaId: media.id,
+				status: 'watching',
+				score: 6,
+			},
+		}),
 		prisma.follow.create({
 			data: { followerId: viewer.id, followingId: publicMember.id },
 		}),
@@ -133,13 +149,77 @@ test('community and following statistics exclude private-list tracking', async (
 	])
 
 	const community = await getMediaCommunityStatistics(media.id)
-	expect(community.trackers).toBe(1)
-	expect(community.ratings).toBe(1)
-	expect(community.meanScore).toBe(8)
-	expect(community.statusBreakdown).toEqual([
-		expect.objectContaining({ status: 'completed', count: 1 }),
-	])
+	expect(community.trackers).toBe(2)
+	expect(community.ratings).toBe(2)
+	expect(community.meanScore).toBe(7)
+	expect(community.statusBreakdown).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({ status: 'completed', count: 1 }),
+			expect.objectContaining({ status: 'watching', count: 1 }),
+		]),
+	)
 	const followed = await getFollowedMediaTracking(media.id, viewer.id)
 	expect(followed.total).toBe(1)
 	expect(followed.items.map(item => item.member.id)).toEqual([publicMember.id])
+})
+
+test('public tracking summaries deduplicate and merge bounded chunks', async () => {
+	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
+	const owner = await prisma.user.create({
+		data: {
+			email: `summary_${suffix}@example.com`,
+			username: `summary_${suffix}`,
+		},
+	})
+	const mediaIds = Array.from(
+		{ length: 401 },
+		(_, index) => `summary_${suffix}_${index}`,
+	)
+	await prisma.media.createMany({
+		data: mediaIds.map((id, index) => ({
+			id,
+			kind: 'movie',
+			title: `Summary chunk ${index}`,
+		})),
+	})
+	await prisma.trackingState.createMany({
+		data: [
+			{
+				ownerId: owner.id,
+				mediaId: mediaIds[0]!,
+				status: 'completed',
+				score: 7.5,
+			},
+			{
+				ownerId: owner.id,
+				mediaId: mediaIds[400]!,
+				status: 'watching',
+			},
+		],
+	})
+
+	await expect(getPublicTrackingSummariesByMediaId([])).resolves.toEqual(
+		new Map(),
+	)
+	const summaries = await getPublicTrackingSummariesByMediaId([
+		...mediaIds,
+		mediaIds[0]!,
+	])
+
+	expect(summaries.size).toBe(401)
+	expect(summaries.get(mediaIds[0]!)).toEqual({
+		trackerCount: 1,
+		ratingCount: 1,
+		communityScore: 7.5,
+	})
+	expect(summaries.get(mediaIds[1]!)).toEqual({
+		trackerCount: 0,
+		ratingCount: 0,
+		communityScore: null,
+	})
+	expect(summaries.get(mediaIds[400]!)).toEqual({
+		trackerCount: 1,
+		ratingCount: 0,
+		communityScore: null,
+	})
 })

--- a/app/utils/media-community.server.ts
+++ b/app/utils/media-community.server.ts
@@ -12,6 +12,65 @@ type StatusGroup = {
 	_count: { _all: number }
 }
 
+export type PublicTrackingSummary = {
+	trackerCount: number
+	ratingCount: number
+	communityScore: number | null
+}
+
+const PUBLIC_TRACKING_SUMMARY_CHUNK_SIZE = 400
+
+const emptyPublicTrackingSummary = (): PublicTrackingSummary => ({
+	trackerCount: 0,
+	ratingCount: 0,
+	communityScore: null,
+})
+
+function finiteScore(value: unknown) {
+	if (value === null || value === undefined) return null
+	const score = Number(value)
+	return Number.isFinite(score) ? score : null
+}
+
+export async function getPublicTrackingSummariesByMediaId(
+	mediaIds: readonly string[],
+) {
+	const uniqueMediaIds = [...new Set(mediaIds)]
+	const summaries = new Map<string, PublicTrackingSummary>(
+		uniqueMediaIds.map(mediaId => [mediaId, emptyPublicTrackingSummary()]),
+	)
+
+	for (
+		let offset = 0;
+		offset < uniqueMediaIds.length;
+		offset += PUBLIC_TRACKING_SUMMARY_CHUNK_SIZE
+	) {
+		const chunk = uniqueMediaIds.slice(
+			offset,
+			offset + PUBLIC_TRACKING_SUMMARY_CHUNK_SIZE,
+		)
+		const groups = await prisma.trackingState.groupBy({
+			by: ['mediaId'],
+			where: {
+				mediaId: { in: chunk },
+				AND: [publicTrackingStateWhere],
+			},
+			_count: { _all: true, score: true },
+			_avg: { score: true },
+		})
+
+		for (const group of groups) {
+			summaries.set(group.mediaId, {
+				trackerCount: group._count._all,
+				ratingCount: group._count.score,
+				communityScore: finiteScore(group._avg.score),
+			})
+		}
+	}
+
+	return summaries
+}
+
 function titleCase(value: string) {
 	return value
 		.replace(/([a-z])([A-Z])/g, '$1 $2')
@@ -59,12 +118,8 @@ export function buildStatusBreakdown(groups: StatusGroup[]) {
 }
 
 export async function getMediaCommunityStatistics(mediaId: string) {
-	const [summary, scoreGroups, statusGroups] = await Promise.all([
-		prisma.trackingState.aggregate({
-			where: { mediaId, AND: [publicTrackingStateWhere] },
-			_count: { id: true, score: true },
-			_avg: { score: true },
-		}),
+	const [summaries, scoreGroups, statusGroups] = await Promise.all([
+		getPublicTrackingSummariesByMediaId([mediaId]),
 		prisma.trackingState.groupBy({
 			by: ['score'],
 			where: {
@@ -80,11 +135,12 @@ export async function getMediaCommunityStatistics(mediaId: string) {
 			_count: { _all: true },
 		}),
 	])
+	const summary = summaries.get(mediaId) ?? emptyPublicTrackingSummary()
 
 	return {
-		trackers: summary._count.id,
-		ratings: summary._count.score,
-		meanScore: summary._avg.score === null ? null : Number(summary._avg.score),
+		trackers: summary.trackerCount,
+		ratings: summary.ratingCount,
+		meanScore: summary.communityScore,
 		scoreDistribution: buildScoreDistribution(scoreGroups),
 		statusBreakdown: buildStatusBreakdown(statusGroups),
 	}

--- a/app/utils/media-recommendations.server.test.ts
+++ b/app/utils/media-recommendations.server.test.ts
@@ -179,8 +179,9 @@ test('titles without genres fall back to same-kind community popularity', async 
 })
 
 test('private-list tracking does not affect recommendation rank or statistics', async () => {
-	const [publicMember, privateMember] = await Promise.all([
+	const [publicMember, listlessMember, privateMember] = await Promise.all([
 		createUser('public_recommendation_member'),
+		createUser('listless_recommendation_member'),
 		createUser('private_recommendation_member'),
 	])
 	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
@@ -247,6 +248,14 @@ test('private-list tracking does not affect recommendation rank or statistics', 
 		}),
 		prisma.trackingState.create({
 			data: {
+				ownerId: listlessMember.id,
+				mediaId: publicCandidate.id,
+				status: 'watching',
+				score: 6.5,
+			},
+		}),
+		prisma.trackingState.create({
+			data: {
 				ownerId: privateMember.id,
 				mediaId: privateCandidate.id,
 				status: 'completed',
@@ -263,9 +272,9 @@ test('private-list tracking does not affect recommendation rank or statistics', 
 	])
 	expect(result.items.find(item => item.id === publicCandidate.id)).toEqual(
 		expect.objectContaining({
-			communityScore: 8,
-			ratingCount: 1,
-			trackerCount: 1,
+			communityScore: 7.25,
+			ratingCount: 2,
+			trackerCount: 2,
 		}),
 	)
 	expect(result.items.find(item => item.id === privateCandidate.id)).toEqual(

--- a/app/utils/media-recommendations.server.ts
+++ b/app/utils/media-recommendations.server.ts
@@ -1,6 +1,10 @@
 import { type Prisma } from '@prisma/client'
 import { prisma } from './db.server.ts'
 import { catalogPopularityScore, splitGenres } from './discovery.server.ts'
+import {
+	getPublicTrackingSummariesByMediaId,
+	type PublicTrackingSummary,
+} from './media-community.server.ts'
 import { prismaSearchFilter } from './prisma-search.server.ts'
 
 export const MEDIA_RECOMMENDATION_LIMIT = 6
@@ -16,16 +20,8 @@ const recommendationMediaSelect = {
 	startYear: true,
 	airYear: true,
 	genres: true,
-	trackingStates: {
-		select: {
-			score: true,
-			statusWatchlistId: true,
-			statusWatchlist: { select: { isPublic: true } },
-		},
-	},
 	_count: {
 		select: {
-			trackingStates: true,
 			reviews: true,
 			diaryEntries: true,
 		},
@@ -64,26 +60,10 @@ function yearFor(media: RecommendationMedia) {
 	return media.startYear || media.airYear || null
 }
 
-function scoreFor(media: RecommendationMedia) {
-	const scores = publicTrackingStates(media)
-		.map(state => (state.score === null ? null : Number(state.score)))
-		.filter(
-			(score): score is number => score !== null && Number.isFinite(score),
-		)
-	if (!scores.length) return null
-	return scores.reduce((total, score) => total + score, 0) / scores.length
-}
-
-function publicTrackingStates(media: RecommendationMedia) {
-	return media.trackingStates.filter(
-		state =>
-			state.statusWatchlistId === null || state.statusWatchlist?.isPublic,
-	)
-}
-
 function rankCandidate(
 	media: RecommendationMedia,
 	sourceGenres: string[],
+	trackingSummary: PublicTrackingSummary,
 ): RankedRecommendation {
 	const candidateGenreKeys = new Set(
 		splitGenres(media.genres).map(genre => genre.toLocaleLowerCase()),
@@ -95,8 +75,6 @@ function rankCandidate(
 		...sourceGenres.map(genre => genre.toLocaleLowerCase()),
 		...candidateGenreKeys,
 	]).size
-	const publicStates = publicTrackingStates(media)
-	const scores = publicStates.filter(state => state.score !== null)
 
 	return {
 		media,
@@ -104,11 +82,11 @@ function rankCandidate(
 		similarity: unionSize ? matchedGenres.length / unionSize : 0,
 		popularity: catalogPopularityScore({
 			...media._count,
-			trackingStates: publicStates.length,
+			trackingStates: trackingSummary.trackerCount,
 		}),
-		communityScore: scoreFor(media),
-		ratingCount: scores.length,
-		trackerCount: publicStates.length,
+		communityScore: trackingSummary.communityScore,
+		ratingCount: trackingSummary.ratingCount,
+		trackerCount: trackingSummary.trackerCount,
 	}
 }
 
@@ -162,8 +140,21 @@ export async function getSimilarMediaRecommendations(
 		orderBy: [{ reviews: { _count: 'desc' } }, { title: 'asc' }],
 		take: MEDIA_RECOMMENDATION_CANDIDATE_LIMIT,
 	})
+	const trackingSummaries = await getPublicTrackingSummariesByMediaId(
+		candidates.map(media => media.id),
+	)
 	const ranked = candidates
-		.map(media => rankCandidate(media, sourceGenres))
+		.map(media =>
+			rankCandidate(
+				media,
+				sourceGenres,
+				trackingSummaries.get(media.id) ?? {
+					trackerCount: 0,
+					ratingCount: 0,
+					communityScore: null,
+				},
+			),
+		)
 		.filter(item => !sourceGenres.length || item.matchedGenres.length)
 		.sort(compareRecommendations)
 		.slice(0, boundedLimit)

--- a/app/utils/media-relations.server.test.ts
+++ b/app/utils/media-relations.server.test.ts
@@ -72,10 +72,36 @@ test('syncs provider identities and returns inverse relation groups', async () =
 })
 
 test('orders relation groups chronologically and returns tracking context', async () => {
-	const viewer = await prisma.user.create({
+	const [viewer, publicMember] = await Promise.all([
+		prisma.user.create({
+			data: {
+				email: 'relation-viewer@example.com',
+				username: 'relation_viewer',
+			},
+		}),
+		prisma.user.create({
+			data: {
+				email: 'relation-community@example.com',
+				username: 'relation_community',
+			},
+		}),
+	])
+	const listType = await prisma.listType.create({
 		data: {
-			email: 'relation-viewer@example.com',
-			username: 'relation_viewer',
+			name: 'relation-private-status',
+			header: 'Relation status',
+			columns: '{}',
+			mediaType: '[]',
+			completionType: '{}',
+		},
+	})
+	const privateList = await prisma.watchlist.create({
+		data: {
+			ownerId: viewer.id,
+			typeId: listType.id,
+			name: 'private',
+			header: 'Private relation status',
+			isPublic: false,
 		},
 	})
 	const [source, later, earlier, undated] = await Promise.all([
@@ -100,14 +126,25 @@ test('orders relation groups chronologically and returns tracking context', asyn
 			provider: 'tmdb',
 		})),
 	})
-	await prisma.trackingState.create({
-		data: {
-			ownerId: viewer.id,
-			mediaId: earlier.id,
-			status: 'plan-to-watch',
-			score: 8.5,
-		},
-	})
+	await Promise.all([
+		prisma.trackingState.create({
+			data: {
+				ownerId: viewer.id,
+				mediaId: earlier.id,
+				status: 'plan-to-watch',
+				statusWatchlistId: privateList.id,
+				score: 8.5,
+			},
+		}),
+		prisma.trackingState.create({
+			data: {
+				ownerId: publicMember.id,
+				mediaId: earlier.id,
+				status: 'completed',
+				score: 7,
+			},
+		}),
+	])
 
 	const [group] = await getMediaRelations(source.id, viewer.id)
 	expect(group?.items.map(item => item.title)).toEqual([
@@ -119,7 +156,7 @@ test('orders relation groups chronologically and returns tracking context', asyn
 		trackerCount: 1,
 		viewerTracking: {
 			status: 'plan-to-watch',
-			statusLabel: 'Plan To Watch',
+			statusLabel: 'Private relation status',
 			score: 8.5,
 		},
 	})

--- a/app/utils/media-relations.server.ts
+++ b/app/utils/media-relations.server.ts
@@ -1,5 +1,6 @@
 import { type Prisma } from '@prisma/client'
 import { prisma } from './db.server.ts'
+import { getPublicTrackingSummariesByMediaId } from './media-community.server.ts'
 import { splitLegacyThumbnail } from './media-detail.ts'
 import { type MediaIdentity } from './media-identity.ts'
 import {
@@ -20,12 +21,6 @@ const relatedMediaSelect = {
 	startSeason: true,
 	startYear: true,
 	airYear: true,
-	trackingStates: {
-		select: {
-			statusWatchlistId: true,
-			statusWatchlist: { select: { isPublic: true } },
-		},
-	},
 } satisfies Prisma.MediaSelect
 
 type RelatedMedia = Prisma.MediaGetPayload<{
@@ -96,9 +91,10 @@ export async function getMediaRelations(
 			),
 		),
 	]
-	const viewerRows =
+	const [trackingSummaries, viewerRows] = await Promise.all([
+		getPublicTrackingSummariesByMediaId(relatedMediaIds),
 		viewerId && relatedMediaIds.length
-			? await prisma.trackingState.findMany({
+			? prisma.trackingState.findMany({
 					where: { ownerId: viewerId, mediaId: { in: relatedMediaIds } },
 					select: {
 						mediaId: true,
@@ -107,7 +103,8 @@ export async function getMediaRelations(
 						statusWatchlist: { select: { header: true } },
 					},
 				})
-			: []
+			: Promise.resolve([]),
+	])
 	const viewerTrackingByMedia = new Map(
 		viewerRows.map(row => [
 			row.mediaId,
@@ -162,11 +159,7 @@ export async function getMediaRelations(
 				imageUrl: splitLegacyThumbnail(media.thumbnail).imageUrl,
 				type: media.type,
 				year: yearFor(media),
-				trackerCount: media.trackingStates.filter(
-					state =>
-						state.statusWatchlistId === null ||
-						state.statusWatchlist?.isPublic,
-				).length,
+				trackerCount: trackingSummaries.get(media.id)?.trackerCount ?? 0,
 				viewerTracking: viewerTrackingByMedia.get(media.id) ?? null,
 				chronology: chronologyFor(media),
 			},

--- a/app/utils/recommendation-graph.server.test.ts
+++ b/app/utils/recommendation-graph.server.test.ts
@@ -230,3 +230,88 @@ test('show-less feedback subtracts genre affinity without affecting public data'
 		await prisma.trackingState.count({ where: { mediaId: seed.id } }),
 	).toBe(1)
 })
+
+test('graph popularity uses public tracking counts and ignores private lists', async () => {
+	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
+	const [viewer, publicMember, privateMember] = await Promise.all([
+		createUser('Graph privacy viewer'),
+		createUser('Graph public member'),
+		createUser('Graph private member'),
+	])
+	const listType = await prisma.listType.create({
+		data: {
+			name: `graph-privacy-${suffix}`,
+			header: 'Graph privacy',
+			columns: '{}',
+			mediaType: '["movie"]',
+			completionType: '{}',
+		},
+	})
+	const privateList = await prisma.watchlist.create({
+		data: {
+			ownerId: privateMember.id,
+			typeId: listType.id,
+			name: 'private',
+			header: 'Private',
+			isPublic: false,
+		},
+	})
+	const [seed, publicCandidate, privateCandidate] = await Promise.all([
+		prisma.media.create({
+			data: { kind: 'movie', title: `Graph ranking seed ${suffix}` },
+		}),
+		prisma.media.create({
+			data: { kind: 'movie', title: `Graph Z public ${suffix}` },
+		}),
+		prisma.media.create({
+			data: { kind: 'movie', title: `Graph A private ${suffix}` },
+		}),
+	])
+	await Promise.all([
+		prisma.trackingState.create({
+			data: {
+				ownerId: viewer.id,
+				mediaId: seed.id,
+				status: 'completed',
+				score: 9,
+			},
+		}),
+		prisma.trackingState.create({
+			data: {
+				ownerId: publicMember.id,
+				mediaId: publicCandidate.id,
+				status: 'completed',
+			},
+		}),
+		prisma.trackingState.create({
+			data: {
+				ownerId: privateMember.id,
+				mediaId: privateCandidate.id,
+				status: 'completed',
+				statusWatchlistId: privateList.id,
+			},
+		}),
+		prisma.mediaRelation.create({
+			data: {
+				sourceMediaId: seed.id,
+				targetMediaId: publicCandidate.id,
+				relationType: 'sequel',
+			},
+		}),
+		prisma.mediaRelation.create({
+			data: {
+				sourceMediaId: seed.id,
+				targetMediaId: privateCandidate.id,
+				relationType: 'sequel',
+			},
+		}),
+	])
+
+	const graph = await getRecommendationGraph(viewer.id)
+	const connected = graph.lanes.find(lane => lane.key === 'connected')
+
+	expect(connected?.items.map(item => item.id)).toEqual([
+		publicCandidate.id,
+		privateCandidate.id,
+	])
+})

--- a/app/utils/recommendation-graph.server.ts
+++ b/app/utils/recommendation-graph.server.ts
@@ -1,6 +1,7 @@
 import { type Prisma } from '@prisma/client'
 import { prisma } from './db.server.ts'
 import { catalogPopularityScore, splitGenres } from './discovery.server.ts'
+import { publicTrackingStateWhere } from './lists/visibility.ts'
 import { prismaSearchFilter } from './prisma-search.server.ts'
 import {
 	type RecommendationGraph,
@@ -30,12 +31,7 @@ const recommendationMediaSelect = {
 	_count: {
 		select: {
 			trackingStates: {
-				where: {
-					OR: [
-						{ statusWatchlistId: null },
-						{ statusWatchlist: { isPublic: true } },
-					],
-				},
+				where: publicTrackingStateWhere,
 			},
 			reviews: true,
 			diaryEntries: true,
@@ -412,11 +408,8 @@ export async function getRecommendationGraph(
 				? prisma.trackingState.findMany({
 						where: {
 							ownerId: { in: followedIds },
-							OR: [
-								{ statusWatchlistId: null },
-								{ statusWatchlist: { isPublic: true } },
-							],
 							AND: [
+								publicTrackingStateWhere,
 								{
 									OR: [{ score: { gte: 8 } }, { repeatCount: { gt: 0 } }],
 								},

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "validate:release:browser": "cross-env CI=true PORT=4122 playwright test --project=chromium",
     "validate:release:browser:portable": "cross-env CI=true PORT=4122 playwright test --project=chromium --ignore-snapshots",
     "validate:release:postgres": "npm run prisma:generate:postgres && npm run db:migrate:postgres && npm run db:verify:postgres && npm run db:smoke:postgres && npm run db:loadtest:postgres -- --commit --count 2000 --cleanup-after",
-    "validate:scale:postgres": "npm run prisma:generate:postgres && npm run db:migrate:postgres && npm run db:verify:postgres && npm run db:smoke:postgres && npm run db:loadtest:postgres -- --commit --count 100000 --member-count 1000 --tracking-per-member 100 --activity-per-member 20 --require-trigram-indexes --require-calendar-indexes --cleanup-after"
+    "validate:scale:postgres": "npm run prisma:generate:postgres && npm run db:migrate:postgres && npm run db:verify:postgres && npm run db:smoke:postgres && npm run db:loadtest:postgres -- --commit --count 100000 --member-count 1000 --tracking-per-member 100 --activity-per-member 20 --require-trigram-indexes --require-calendar-indexes --require-community-indexes --cleanup-after"
   },
   "eslintIgnore": [
     "/node_modules",

--- a/scripts/load-test-postgres-catalog.mjs
+++ b/scripts/load-test-postgres-catalog.mjs
@@ -31,6 +31,36 @@ const requiredCalendarIndexesByQuery = {
 	'calendar-occurrence-range': 'ReleaseOccurrence_releaseAt_status_idx',
 	'calendar-public-tracker-counts': 'TrackingState_mediaId_idx',
 }
+const communityCandidateLimit = 1_000
+const communityCandidateChunkSize = 400
+const requiredCommunityIndex = 'TrackingState_mediaId_idx'
+const communityAggregateGroupsSql = `SELECT
+	tracking."mediaId",
+	COUNT(*)::int AS "trackerCount",
+	COUNT(tracking.score)::int AS "ratingCount",
+	AVG(tracking.score)::double precision AS "communityScore"
+ FROM "TrackingState" AS tracking
+ LEFT JOIN "Watchlist" AS watchlist
+   ON watchlist.id = tracking."statusWatchlistId"
+ WHERE tracking."mediaId" = ANY($1::text[])
+   AND (
+     tracking."statusWatchlistId" IS NULL
+     OR watchlist."isPublic" = true
+   )
+ GROUP BY tracking."mediaId"`
+const communityAggregateReferenceSql = `SELECT
+	COUNT(DISTINCT tracking."mediaId")::int AS "groupCount",
+	COUNT(*)::int AS "trackerCount",
+	COUNT(tracking.score)::int AS "ratingCount",
+	AVG(tracking.score)::double precision AS "communityScore"
+ FROM "TrackingState" AS tracking
+ LEFT JOIN "Watchlist" AS watchlist
+   ON watchlist.id = tracking."statusWatchlistId"
+ WHERE tracking."mediaId" = ANY($1::text[])
+   AND (
+     tracking."statusWatchlistId" IS NULL
+     OR watchlist."isPublic" = true
+   )`
 const usage = `Usage: npm run db:loadtest:postgres -- [options]
 
 Options:
@@ -51,6 +81,7 @@ Options:
   --cleanup-after           Delete only load-catalog-* records after reporting
   --require-trigram-indexes Fail if measured text searches avoid trigram indexes
   --require-calendar-indexes Fail if bounded calendar queries avoid their indexes
+  --require-community-indexes Fail if chunked community aggregates avoid their index
   --help                    Show this help
 
 DATABASE_URL must use PostgreSQL and its database name must contain a clearly
@@ -99,6 +130,7 @@ function assertKnownArguments() {
 		'--cleanup-after',
 		'--require-trigram-indexes',
 		'--require-calendar-indexes',
+		'--require-community-indexes',
 		'--help',
 	])
 	for (let index = 0; index < args.length; index++) {
@@ -608,6 +640,130 @@ async function explain(prisma, name, sql, values = []) {
 	}
 }
 
+function communityAggregateChunks(count) {
+	const candidateIds = Array.from(
+		{ length: Math.min(communityCandidateLimit, count) },
+		(_, index) => `${prefix}media-${index + 1}`,
+	)
+	const chunks = []
+	for (
+		let offset = 0;
+		offset < candidateIds.length;
+		offset += communityCandidateChunkSize
+	) {
+		chunks.push({
+			name: `community-aggregate-chunk-${offset / communityCandidateChunkSize + 1}`,
+			candidateIds: candidateIds.slice(
+				offset,
+				offset + communityCandidateChunkSize,
+			),
+		})
+	}
+	return { candidateIds, chunks }
+}
+
+function summarizeCommunityAggregateRows(rows) {
+	let trackerCount = 0
+	let ratingCount = 0
+	let scoreTotal = 0
+	for (const row of rows) {
+		const rowTrackerCount = Number(row.trackerCount)
+		const rowRatingCount = Number(row.ratingCount)
+		const rowCommunityScore =
+			row.communityScore === null ? null : Number(row.communityScore)
+		if (
+			!Number.isSafeInteger(rowTrackerCount) ||
+			rowTrackerCount < 1 ||
+			!Number.isSafeInteger(rowRatingCount) ||
+			rowRatingCount < 0 ||
+			rowRatingCount > rowTrackerCount ||
+			(rowRatingCount === 0
+				? rowCommunityScore !== null
+				: !Number.isFinite(rowCommunityScore))
+		) {
+			throw new Error('Community aggregate query returned invalid values')
+		}
+		trackerCount += rowTrackerCount
+		ratingCount += rowRatingCount
+		scoreTotal += (rowCommunityScore ?? 0) * rowRatingCount
+	}
+	return {
+		groups: rows.length,
+		trackers: trackerCount,
+		ratings: ratingCount,
+		weightedMean: ratingCount ? scoreTotal / ratingCount : null,
+	}
+}
+
+function matchingCommunitySummaries(left, right) {
+	const scoresMatch =
+		left.weightedMean === null || right.weightedMean === null
+			? left.weightedMean === right.weightedMean
+			: Math.abs(left.weightedMean - right.weightedMean) <=
+				1e-10 *
+					Math.max(1, Math.abs(left.weightedMean), Math.abs(right.weightedMean))
+	return (
+		left.groups === right.groups &&
+		left.trackers === right.trackers &&
+		left.ratings === right.ratings &&
+		scoresMatch
+	)
+}
+
+async function communityAggregateMetrics(prisma, count) {
+	const { candidateIds, chunks } = communityAggregateChunks(count)
+	const chunkMetrics = []
+	for (const chunk of chunks) {
+		const rows = await prisma.$queryRawUnsafe(
+			communityAggregateGroupsSql,
+			chunk.candidateIds,
+		)
+		chunkMetrics.push({
+			name: chunk.name,
+			candidateCount: chunk.candidateIds.length,
+			...summarizeCommunityAggregateRows(rows),
+		})
+	}
+	const totalRatingCount = chunkMetrics.reduce(
+		(total, chunk) => total + chunk.ratings,
+		0,
+	)
+	const total = {
+		groups: chunkMetrics.reduce((total, chunk) => total + chunk.groups, 0),
+		trackers: chunkMetrics.reduce((total, chunk) => total + chunk.trackers, 0),
+		ratings: totalRatingCount,
+		weightedMean: totalRatingCount
+			? chunkMetrics.reduce(
+					(total, chunk) => total + (chunk.weightedMean ?? 0) * chunk.ratings,
+					0,
+				) / totalRatingCount
+			: null,
+	}
+	const referenceRows = await prisma.$queryRawUnsafe(
+		communityAggregateReferenceSql,
+		candidateIds,
+	)
+	if (referenceRows.length !== 1) {
+		throw new Error('Community aggregate reference query returned no result')
+	}
+	const reference = {
+		groups: Number(referenceRows[0].groupCount),
+		trackers: Number(referenceRows[0].trackerCount),
+		ratings: Number(referenceRows[0].ratingCount),
+		weightedMean:
+			referenceRows[0].communityScore === null
+				? null
+				: Number(referenceRows[0].communityScore),
+	}
+	return {
+		candidateCount: candidateIds.length,
+		chunks: chunkMetrics,
+		total,
+		reference,
+		matchesReference: matchingCommunitySummaries(total, reference),
+	}
+}
+
 async function queryMetrics(prisma, count, shape, scheduleAnchor) {
 	const needle = Math.max(4, Math.floor(count * 0.73))
 	const alternate = Math.max(4, Math.floor((count * 0.44) / 4) * 4)
@@ -733,7 +889,24 @@ async function queryMetrics(prisma, count, shape, scheduleAnchor) {
 			[publicTrackerCandidateIds],
 		),
 	)
+	const { chunks: communityChunks } = communityAggregateChunks(count)
+	for (const chunk of communityChunks) {
+		queries.push(
+			await explain(prisma, chunk.name, communityAggregateGroupsSql, [
+				chunk.candidateIds,
+			]),
+		)
+	}
 	return queries
+}
+
+function requiredCommunityIndexesByQuery(count) {
+	return Object.fromEntries(
+		communityAggregateChunks(count).chunks.map(chunk => [
+			chunk.name,
+			requiredCommunityIndex,
+		]),
+	)
 }
 
 async function databasePressureSnapshot(prisma) {
@@ -930,9 +1103,15 @@ async function main() {
 	const cleanupAfter = args.includes('--cleanup-after')
 	const requireTrigramIndexes = args.includes('--require-trigram-indexes')
 	const requireCalendarIndexes = args.includes('--require-calendar-indexes')
+	const requireCommunityIndexes = args.includes('--require-community-indexes')
 	if (requireCalendarIndexes && !shape.memberCount) {
 		throw new Error(
 			'--require-calendar-indexes requires --member-count so the bounded tracker aggregation is measured',
+		)
+	}
+	if (requireCommunityIndexes && !shape.memberCount) {
+		throw new Error(
+			'--require-community-indexes requires --member-count so community aggregates are measured',
 		)
 	}
 	const target = assertSafeLoadDatabaseUrl(process.env.DATABASE_URL)
@@ -1094,10 +1273,20 @@ async function main() {
 		await prisma.$executeRawUnsafe('ANALYZE "CatalogFeedItem"')
 		await prisma.$executeRawUnsafe('ANALYZE "ReleaseOccurrence"')
 		if (shape.memberCount) {
+			await prisma.$executeRawUnsafe('ANALYZE "Watchlist"')
 			await prisma.$executeRawUnsafe('ANALYZE "TrackingState"')
 			await prisma.$executeRawUnsafe('ANALYZE "Entry"')
 			await prisma.$executeRawUnsafe('ANALYZE "ActivityEvent"')
 		}
+		const communityAggregates = shape.memberCount
+			? await communityAggregateMetrics(prisma, count)
+			: null
+		const communityAggregateAssertionError =
+			communityAggregates && !communityAggregates.matchesReference
+				? new Error(
+						`Chunked community aggregates differ from the scalar reference: chunks=${JSON.stringify(communityAggregates.total)} reference=${JSON.stringify(communityAggregates.reference)}`,
+					)
+				: undefined
 		const queries = await queryMetrics(
 			prisma,
 			count,
@@ -1126,6 +1315,17 @@ async function main() {
 		} catch (error) {
 			calendarQueryIndexAssertionError = error
 		}
+		let communityQueryIndexAssertionError
+		if (shape.memberCount) {
+			try {
+				assertRequiredQueryIndexes(
+					queries,
+					requiredCommunityIndexesByQuery(count),
+				)
+			} catch (error) {
+				communityQueryIndexAssertionError = error
+			}
+		}
 		const missingQueryIndexes =
 			queryIndexAssertionError?.missingRequirements ?? []
 		const missingIndexes = [
@@ -1136,6 +1336,13 @@ async function main() {
 		const missingCalendarIndexes = [
 			...new Set(
 				missingCalendarQueryIndexes.map(({ requiredIndex }) => requiredIndex),
+			),
+		]
+		const missingCommunityQueryIndexes =
+			communityQueryIndexAssertionError?.missingRequirements ?? []
+		const missingCommunityIndexes = [
+			...new Set(
+				missingCommunityQueryIndexes.map(({ requiredIndex }) => requiredIndex),
 			),
 		]
 		const insertedRows = loaded - checkpoint.initialRows
@@ -1159,6 +1366,7 @@ async function main() {
 				trackingPerMember: shape.trackingPerMember,
 				activityPerMember: shape.activityPerMember,
 			},
+			communityAggregates,
 			recovery: {
 				checkpointSha256,
 				interruptedAt: checkpoint.interruptedAt ?? null,
@@ -1176,6 +1384,8 @@ async function main() {
 			missingQueryIndexes,
 			missingCalendarIndexes,
 			missingCalendarQueryIndexes,
+			missingCommunityIndexes,
+			missingCommunityQueryIndexes,
 		}
 		writePrivateJson(reportPath, report)
 		console.log(
@@ -1189,6 +1399,11 @@ async function main() {
 		console.log(
 			`Concurrent work: ${searches} searches + ${updateBatches} hydration updates + ${concurrency.memberReads} member reads + ${concurrency.trackingWriteBatches} tracking writes in ${concurrency.wallMs}ms.`,
 		)
+		if (communityAggregates) {
+			console.log(
+				`Community aggregates: ${communityAggregates.candidateCount} candidates in ${communityAggregates.chunks.length} chunks; groups=${communityAggregates.total.groups}; trackers=${communityAggregates.total.trackers}; ratings=${communityAggregates.total.ratings}; weighted mean=${communityAggregates.total.weightedMean ?? 'none'}.`,
+			)
+		}
 		console.log(`Report written: ${reportPath}`)
 		if (cleanupAfter) {
 			const cleaned = await cleanup(prisma)
@@ -1196,21 +1411,27 @@ async function main() {
 				`Cleanup removed ${cleaned.deletedMedia} media and ${cleaned.deletedMembers} member rows in ${cleaned.wallMs}ms.`,
 			)
 		}
-		const requiredIndexErrors = [
+		const validationErrors = [
+			...(communityAggregateAssertionError
+				? [communityAggregateAssertionError]
+				: []),
 			...(requireTrigramIndexes && queryIndexAssertionError
 				? [queryIndexAssertionError]
 				: []),
 			...(requireCalendarIndexes && calendarQueryIndexAssertionError
 				? [calendarQueryIndexAssertionError]
 				: []),
+			...(requireCommunityIndexes && communityQueryIndexAssertionError
+				? [communityQueryIndexAssertionError]
+				: []),
 		]
-		if (requiredIndexErrors.length === 1) {
-			throw requiredIndexErrors[0]
+		if (validationErrors.length === 1) {
+			throw validationErrors[0]
 		}
-		if (requiredIndexErrors.length > 1) {
+		if (validationErrors.length > 1) {
 			throw new AggregateError(
-				requiredIndexErrors,
-				'Required PostgreSQL query indexes were not used',
+				validationErrors,
+				'PostgreSQL aggregate and query-index validations failed',
 			)
 		}
 	} finally {

--- a/scripts/smoke-postgres.ts
+++ b/scripts/smoke-postgres.ts
@@ -477,60 +477,111 @@ async function main() {
 		if (!liveActionType) {
 			throw new Error('Live-action list type is unavailable')
 		}
-		const privateTracker = await prisma.user.create({
-			data: {
-				email: `postgres-smoke-private-${suffix}@example.com`,
-				username: `PostgresSmokePrivate${suffix}`,
-				name: `PostgreSQL private tracker ${suffix}`,
-			},
-		})
-		userIds.push(privateTracker.id)
-		const nullListTracker = await prisma.user.create({
-			data: {
-				email: `postgres-smoke-null-${suffix}@example.com`,
-				username: `PostgresSmokeNull${suffix}`,
-				name: `PostgreSQL null-list tracker ${suffix}`,
-			},
-		})
-		userIds.push(nullListTracker.id)
-		const [publicWatchlist, privateWatchlist] = await Promise.all([
+		const createTracker = async (
+			key: string,
+			usernameLabel: string,
+			nameLabel: string,
+		) => {
+			const tracker = await prisma.user.create({
+				data: {
+					email: `postgres-smoke-${key}-${suffix}@example.com`,
+					username: `PostgresSmoke${usernameLabel}${suffix}`,
+					name: `PostgreSQL ${nameLabel} tracker ${suffix}`,
+				},
+			})
+			userIds.push(tracker.id)
+			return tracker
+		}
+		const publicUnscoredTracker = await createTracker(
+			'public-unscored',
+			'PublicUnscored',
+			'public unscored',
+		)
+		const privateScoredTracker = await createTracker(
+			'private-scored',
+			'PrivateScored',
+			'private scored',
+		)
+		const privateUnscoredTracker = await createTracker(
+			'private-unscored',
+			'PrivateUnscored',
+			'private unscored',
+		)
+		const listlessScoredTracker = await createTracker(
+			'listless-scored',
+			'ListlessScored',
+			'listless scored',
+		)
+		const listlessUnscoredTracker = await createTracker(
+			'listless-unscored',
+			'ListlessUnscored',
+			'listless unscored',
+		)
+		const createTrackerWatchlist = (ownerId: string, isPublic: boolean) =>
 			prisma.watchlist.create({
 				data: {
-					ownerId: user.id,
+					ownerId,
 					typeId: liveActionType.id,
 					name: 'watching',
 					header: 'Watching',
-					isPublic: true,
+					isPublic,
 				},
-			}),
-			prisma.watchlist.create({
-				data: {
-					ownerId: privateTracker.id,
-					typeId: liveActionType.id,
-					name: 'watching',
-					header: 'Watching',
-					isPublic: false,
-				},
-			}),
-		])
+			})
+		const publicScoredWatchlist = await createTrackerWatchlist(user.id, true)
+		const publicUnscoredWatchlist = await createTrackerWatchlist(
+			publicUnscoredTracker.id,
+			true,
+		)
+		const privateScoredWatchlist = await createTrackerWatchlist(
+			privateScoredTracker.id,
+			false,
+		)
+		const privateUnscoredWatchlist = await createTrackerWatchlist(
+			privateUnscoredTracker.id,
+			false,
+		)
 		await prisma.trackingState.createMany({
 			data: [
 				{
 					ownerId: user.id,
 					mediaId: media.id,
 					status: 'watching',
-					statusWatchlistId: publicWatchlist.id,
+					score: 8,
+					statusWatchlistId: publicScoredWatchlist.id,
 				},
 				{
-					ownerId: privateTracker.id,
+					ownerId: publicUnscoredTracker.id,
 					mediaId: media.id,
 					status: 'watching',
-					statusWatchlistId: privateWatchlist.id,
+					score: null,
+					statusWatchlistId: publicUnscoredWatchlist.id,
 				},
 				{
-					ownerId: nullListTracker.id,
+					ownerId: privateScoredTracker.id,
 					mediaId: media.id,
 					status: 'watching',
+					score: 10,
+					statusWatchlistId: privateScoredWatchlist.id,
+				},
+				{
+					ownerId: privateUnscoredTracker.id,
+					mediaId: media.id,
+					status: 'watching',
+					score: null,
+					statusWatchlistId: privateUnscoredWatchlist.id,
+				},
+				{
+					ownerId: listlessScoredTracker.id,
+					mediaId: media.id,
+					status: 'watching',
+					score: 7,
+					statusWatchlistId: null,
+				},
+				{
+					ownerId: listlessUnscoredTracker.id,
+					mediaId: media.id,
+					status: 'watching',
+					score: null,
 					statusWatchlistId: null,
 				},
 			],
@@ -538,23 +589,28 @@ async function main() {
 		const publicTrackerCounts = await prisma.trackingState.groupBy({
 			by: ['mediaId'],
 			where: {
-				mediaId: media.id,
+				mediaId: {
+					in: [media.id, `postgres-smoke-untracked-${suffix}`],
+				},
 				AND: [publicTrackingStateWhere],
 			},
-			_count: { _all: true },
+			_count: { _all: true, score: true },
+			_avg: { score: true },
 		})
 		if (
 			publicTrackerCounts.length !== 1 ||
 			publicTrackerCounts[0]?.mediaId !== media.id ||
-			publicTrackerCounts[0]._count._all !== 2
+			publicTrackerCounts[0]._count._all !== 4 ||
+			publicTrackerCounts[0]._count.score !== 2 ||
+			Number(publicTrackerCounts[0]._avg.score) !== 7.5
 		) {
 			throw new Error(
-				'Candidate-bounded tracker count did not include public/null-list tracking while excluding private-list tracking',
+				'Candidate-bounded community aggregates did not preserve public/listless visibility and scored/unscored semantics',
 			)
 		}
 
 		console.log(
-			'PostgreSQL smoke test passed: schema, required indexes, model writes, provider-aware searches, release ranges, tracker privacy, visibility boundaries, and atomic import rollback are healthy.',
+			'PostgreSQL smoke test passed: schema, required indexes, model writes, provider-aware searches, release ranges, community aggregates, visibility boundaries, and atomic import rollback are healthy.',
 		)
 	} finally {
 		if (mediaId) await prisma.media.deleteMany({ where: { id: mediaId } })


### PR DESCRIPTION
## Promotion

Promote the exact protected `develop` tree from `c67fd0279546899ef366dcd01b3b71fb6022a3b3` to production.

Includes:

- candidate-bounded SQL aggregation for community tracker/rating/mean metrics
- removal of count-only tracking-state payloads from discovery and recommendations
- separate result-bounded viewer-private tracking lookups
- preserved TMDB/MAL, top-rated, for-you, pagination, and TOMT ordering
- exact PostgreSQL aggregate correctness and index-plan gates

Source PR: #112

## Verified on develop

- CI Core, Browser, PostgreSQL, and Branch policy
- CodeQL
- Dependency review
- local 716-test coverage gate, production static/build/bundle gates, 97 Chromium tests, PostgreSQL release gate, and representative 100k exact-index/correctness gate

This PR must be merged with the **merge commit** method so `main` retains `develop` as a direct parent and the exact release tree can be verified.