### PR TITLE
Harden ranked cache foundation

### DIFF
--- a/app/utils/cache-key.server.test.ts
+++ b/app/utils/cache-key.server.test.ts
@@ -1,0 +1,432 @@
+import { describe, expect, test } from 'vitest'
+import {
+	cacheDatasourceIdentity,
+	canonicalCachePayload,
+	createOpaqueCacheKey,
+	isOpaqueCacheKey,
+	type OpaqueCacheKey,
+} from './cache-key.server.ts'
+
+const sqliteUrl = 'file:./tests/prisma/cache-key.db?connection_limit=1'
+
+describe('canonical cache payloads', () => {
+	test('sorts object keys recursively while preserving array order', () => {
+		expect(
+			canonicalCachePayload({
+				z: [{ second: 2, first: 1 }],
+				a: { truthy: true, empty: null },
+			}),
+		).toBe('{"a":{"empty":null,"truthy":true},"z":[{"first":1,"second":2}]}')
+		expect(canonicalCachePayload({ values: ['a', 'b'] })).not.toBe(
+			canonicalCachePayload({ values: ['b', 'a'] }),
+		)
+		expect(canonicalCachePayload({ value: -0 })).toBe('{"value":0}')
+	})
+
+	test.each([
+		['undefined', { value: undefined }],
+		['NaN', { value: Number.NaN }],
+		['infinity', { value: Number.POSITIVE_INFINITY }],
+		['bigint', { value: 1n }],
+		['date', { value: new Date('2026-07-28T00:00:00.000Z') }],
+		['function', { value: () => undefined }],
+	])('rejects %s instead of silently coercing it', (_label, value) => {
+		expect(() => canonicalCachePayload(value)).toThrow(TypeError)
+	})
+
+	test('rejects cycles, sparse arrays, accessors, and oversized payloads', () => {
+		const cycle: Record<string, unknown> = {}
+		cycle.self = cycle
+		expect(() => canonicalCachePayload(cycle)).toThrow('cycles')
+
+		const sparse = Array.from({ length: 2 }) as unknown[]
+		delete sparse[0]
+		expect(() => canonicalCachePayload(sparse)).toThrow('empty slots')
+
+		const accessor = Object.defineProperty({}, 'secret', {
+			enumerable: true,
+			get: () => 'not-evaluated',
+		})
+		expect(() => canonicalCachePayload(accessor)).toThrow('accessors')
+
+		expect(() => canonicalCachePayload('x'.repeat(65 * 1024))).toThrow(
+			'canonical JSON limits',
+		)
+	})
+
+	test('rejects array accessors without executing them', () => {
+		let accesses = 0
+		const accessor = Object.defineProperty([], '0', {
+			enumerable: true,
+			get: () => {
+				accesses += 1
+				return 'not-evaluated'
+			},
+		})
+
+		expect(() => canonicalCachePayload(accessor)).toThrow('accessors')
+		expect(accesses).toBe(0)
+	})
+
+	test('rejects hidden object properties instead of colliding with an empty object', () => {
+		const hidden = Object.defineProperty({}, 'private', {
+			enumerable: false,
+			value: 'must-not-be-omitted',
+		})
+
+		expect(canonicalCachePayload({})).toBe('{}')
+		expect(() => canonicalCachePayload(hidden)).toThrow('non-enumerable values')
+	})
+
+	test('rejects hidden object accessors without executing them', () => {
+		let accesses = 0
+		const hiddenAccessor = Object.defineProperty({}, 'private', {
+			enumerable: false,
+			get: () => {
+				accesses += 1
+				return 'must-not-be-evaluated'
+			},
+		})
+
+		expect(() => canonicalCachePayload(hiddenAccessor)).toThrow('accessors')
+		expect(accesses).toBe(0)
+	})
+
+	test('rejects enumerable numeric-looking array properties instead of omitting them', () => {
+		const ordinary = ['value']
+		const disguised = Object.defineProperty(['value'], '4294967295', {
+			enumerable: true,
+			value: 'must-not-be-omitted',
+		})
+
+		expect(() => canonicalCachePayload(disguised)).toThrow('indexed values')
+		expect(() => canonicalCachePayload(disguised)).toThrow(TypeError)
+		expect(canonicalCachePayload(ordinary)).toBe('["value"]')
+	})
+
+	test('rejects hidden array values while allowing the built-in length property', () => {
+		const ordinary = ['value']
+		const hiddenIndex = Object.defineProperty([], '0', {
+			enumerable: false,
+			value: 'must-not-be-omitted',
+		})
+		const hiddenExtra = Object.defineProperty(['value'], 'private', {
+			enumerable: false,
+			value: 'must-not-be-omitted',
+		})
+
+		expect(canonicalCachePayload(ordinary)).toBe('["value"]')
+		expect(() => canonicalCachePayload(hiddenIndex)).toThrow(
+			'non-enumerable values',
+		)
+		expect(() => canonicalCachePayload(hiddenExtra)).toThrow(
+			'non-enumerable values',
+		)
+	})
+
+	test('rejects hidden array accessors without executing them', () => {
+		let accesses = 0
+		const hiddenAccessor = Object.defineProperty(['value'], 'private', {
+			enumerable: false,
+			get: () => {
+				accesses += 1
+				return 'must-not-be-evaluated'
+			},
+		})
+
+		expect(() => canonicalCachePayload(hiddenAccessor)).toThrow('accessors')
+		expect(accesses).toBe(0)
+	})
+})
+
+describe('cache datasource identity', () => {
+	test('normalizes SQLite paths and ignores connection tuning', () => {
+		expect(
+			cacheDatasourceIdentity(
+				'file:./tests/prisma/../prisma/cache-key.db?connection_limit=1',
+			),
+		).toBe(
+			cacheDatasourceIdentity(
+				'file:./tests/prisma/cache-key.db?connection_limit=20',
+			),
+		)
+		expect(cacheDatasourceIdentity('file::memory:')).toContain(':memory:')
+		expect(
+			cacheDatasourceIdentity('file:./tests/prisma/other-cache-key.db'),
+		).not.toBe(cacheDatasourceIdentity(sqliteUrl))
+	})
+
+	test('resolves relative SQLite URLs from the Prisma schema directory', () => {
+		const sqliteBasePath = '/repo/prisma'
+		const relative = cacheDatasourceIdentity('file:./data.db', {
+			sqliteBasePath,
+		})
+		const schemaAbsolute = cacheDatasourceIdentity(
+			'file:/repo/prisma/data.db',
+			{ sqliteBasePath },
+		)
+		const repositoryAbsolute = cacheDatasourceIdentity('file:/repo/data.db', {
+			sqliteBasePath,
+		})
+
+		expect(JSON.parse(relative)).toMatchObject({
+			provider: 'sqlite',
+			database: '/repo/prisma/data.db',
+		})
+		expect(relative).toBe(schemaAbsolute)
+		expect(relative).not.toBe(repositoryAbsolute)
+	})
+
+	test('normalizes PostgreSQL aliases, credentials, host case, and default port', () => {
+		const first = cacheDatasourceIdentity(
+			'postgresql://alice:first-secret@DB.EXAMPLE.invalid/veud?schema=public&sslmode=require',
+		)
+		const rotated = cacheDatasourceIdentity(
+			'postgres://bob:second-secret@db.example.invalid:5432/veud?schema=public&sslmode=disable',
+		)
+		expect(rotated).toBe(first)
+		expect(first).not.toContain('alice')
+		expect(first).not.toContain('first-secret')
+		expect(first).not.toContain('sslmode')
+	})
+
+	test('distinguishes database, schema, host, port, and SQLite memory modes', () => {
+		const base = cacheDatasourceIdentity(
+			'postgresql://user:secret@db.example.invalid/veud?schema=public',
+		)
+		for (const candidate of [
+			'postgresql://user:secret@other.example.invalid/veud?schema=public',
+			'postgresql://user:secret@db.example.invalid:5433/veud?schema=public',
+			'postgresql://user:secret@db.example.invalid/other?schema=public',
+			'postgresql://user:secret@db.example.invalid/veud?schema=tenant',
+		]) {
+			expect(cacheDatasourceIdentity(candidate)).not.toBe(base)
+		}
+		expect(
+			cacheDatasourceIdentity('file:memory?mode=memory&cache=shared'),
+		).not.toBe(cacheDatasourceIdentity('file:memory?mode=memory&cache=private'))
+	})
+
+	test.each([
+		'file:memory?mode=memory&mode=ro',
+		'file:memory?cache=shared&cache=private',
+		'postgresql://user:secret@db.example.invalid/veud?schema=public&schema=private',
+		'postgresql://user:secret@db.example.invalid/veud?host=%2Ffirst&host=%2Fsecond',
+	])('rejects duplicate identity parameters: %s', databaseUrl => {
+		expect(() => cacheDatasourceIdentity(databaseUrl)).toThrow(
+			'DATABASE_URL is not a supported datasource URL',
+		)
+	})
+
+	test.each([
+		undefined,
+		'',
+		' postgres://user:secret@example.invalid/veud',
+		'https://user:secret@example.invalid/veud',
+		'postgresql://user:secret@example.invalid/',
+		'file:',
+		'file://server/share/cache.db',
+	])('rejects unsupported datasources without reflecting input: %s', value => {
+		let error: unknown
+		try {
+			cacheDatasourceIdentity(value)
+		} catch (caught) {
+			error = caught
+		}
+		expect(error).toBeInstanceOf(TypeError)
+		expect(String(error)).not.toContain('secret')
+		expect(String(error)).not.toContain('example.invalid')
+	})
+})
+
+describe('opaque cache keys', () => {
+	function key(
+		overrides: Partial<Parameters<typeof createOpaqueCacheKey>[0]> = {},
+	) {
+		return createOpaqueCacheKey({
+			namespace: 'discovery',
+			version: 1,
+			scope: { kind: 'public' },
+			payload: {
+				query: 'a private search phrase',
+				filters: { kind: 'movie', page: 1 },
+			},
+			datasourceUrl:
+				'postgresql://cache-user:database-secret@db.example.invalid/veud',
+			...overrides,
+		})
+	}
+
+	test('is branded, fixed-format, deterministic, and canonical', () => {
+		const first = key()
+		const branded: OpaqueCacheKey = first
+		const reordered = key({
+			payload: {
+				filters: { page: 1, kind: 'movie' },
+				query: 'a private search phrase',
+			},
+		})
+		expect(first).toBe(reordered)
+		expect(branded).toMatch(/^ck1_discovery_v1_[A-Za-z0-9_-]{43}$/)
+		expect(isOpaqueCacheKey(first)).toBe(true)
+		expect(isOpaqueCacheKey(first, 'discovery')).toBe(true)
+	})
+
+	test('exposes only namespace and version while hashing private material', () => {
+		const first = key({
+			scope: { kind: 'viewer', viewerId: 'viewer-private-id' },
+		})
+		for (const secret of [
+			'viewer',
+			'viewer-private-id',
+			'a private search phrase',
+			'cache-user',
+			'database-secret',
+			'db.example.invalid',
+			'veud',
+		]) {
+			expect(first).not.toContain(secret)
+		}
+		expect(first).toMatch(/^ck1_discovery_v1_/)
+	})
+
+	test('separates public, viewer, and distinct viewer scopes automatically', () => {
+		const publicKey = key({ scope: { kind: 'public' } })
+		const viewerA = key({
+			scope: { kind: 'viewer', viewerId: 'viewer-a' },
+		})
+		const viewerB = key({
+			scope: { kind: 'viewer', viewerId: 'viewer-b' },
+		})
+
+		expect(viewerA).not.toBe(publicKey)
+		expect(viewerB).not.toBe(publicKey)
+		expect(viewerA).not.toBe(viewerB)
+		expect(key({ scope: { kind: 'viewer', viewerId: 'viewer-a' } })).toBe(
+			viewerA,
+		)
+	})
+
+	test('changes for every semantic key dimension but not credential rotation', () => {
+		const base = key()
+		for (const candidate of [
+			key({ namespace: 'recommendations' }),
+			key({ version: 2 }),
+			key({ scope: { kind: 'viewer', viewerId: 'viewer-a' } }),
+			key({ payload: { filters: { kind: 'tv', page: 1 } } }),
+			key({
+				datasourceUrl:
+					'postgresql://cache-user:database-secret@db.example.invalid/other',
+			}),
+		]) {
+			expect(candidate).not.toBe(base)
+		}
+		expect(
+			key({
+				datasourceUrl:
+					'postgres://rotated-user:new-secret@DB.EXAMPLE.invalid:5432/veud?sslmode=require',
+			}),
+		).toBe(base)
+	})
+
+	test('keeps namespace and version inside the digest as well as the prefix', () => {
+		const digest = (value: OpaqueCacheKey) => value.split('_').at(-1)
+
+		expect(digest(key({ namespace: 'recommendations' }))).not.toBe(
+			digest(key()),
+		)
+		expect(digest(key({ version: 2 }))).not.toBe(digest(key()))
+	})
+
+	test('threads the SQLite schema base through opaque key construction', () => {
+		const input = {
+			namespace: 'discovery',
+			version: 1,
+			scope: { kind: 'public' },
+			payload: { kind: 'movie' },
+			sqliteBasePath: '/repo/prisma',
+		} as const
+		const relative = createOpaqueCacheKey({
+			...input,
+			datasourceUrl: 'file:./data.db',
+		})
+		const schemaAbsolute = createOpaqueCacheKey({
+			...input,
+			datasourceUrl: 'file:/repo/prisma/data.db',
+		})
+		const repositoryAbsolute = createOpaqueCacheKey({
+			...input,
+			datasourceUrl: 'file:/repo/data.db',
+		})
+
+		expect(relative).toBe(schemaAbsolute)
+		expect(relative).not.toBe(repositoryAbsolute)
+	})
+
+	test.each([
+		{ namespace: '', version: 1 },
+		{ namespace: 'Contains-private-text', version: 1 },
+		{ namespace: 'private_text', version: 1 },
+		{ namespace: 'valid', version: 0 },
+		{ namespace: 'valid', version: Number.NaN },
+	])('rejects invalid labels and versions', invalid => {
+		expect(() =>
+			key({
+				namespace: invalid.namespace,
+				version: invalid.version,
+			}),
+		).toThrow(TypeError)
+	})
+
+	test.each([
+		{ kind: 'viewer' },
+		{ kind: 'viewer', viewerId: '' },
+		{ kind: 'viewer', viewerId: ' padded' },
+		{ kind: 'viewer', viewerId: 'x'.repeat(513) },
+		{ kind: 'public', viewerId: 'must-not-be-ignored' },
+		{ kind: 'other' },
+	])('rejects an invalid or ambiguous scope: %o', scope => {
+		expect(() => key({ scope: scope as never })).toThrow(
+			'Cache key scope is invalid',
+		)
+	})
+
+	test('rejects scope accessors without executing them', () => {
+		let accesses = 0
+		const scope = Object.defineProperty({}, 'kind', {
+			enumerable: true,
+			get: () => {
+				accesses += 1
+				return 'public'
+			},
+		})
+
+		expect(() => key({ scope: scope as never })).toThrow(
+			'Cache key scope is invalid',
+		)
+		expect(accesses).toBe(0)
+	})
+
+	test.each([
+		undefined,
+		null,
+		'',
+		'ck1_discovery_v1_short',
+		`ck2_discovery_v1_${'a'.repeat(43)}`,
+		`ck1_Discovery_v1_${'a'.repeat(43)}`,
+		`ck1_discovery_v0_${'a'.repeat(43)}`,
+		`ck1_discovery_v1000000001_${'a'.repeat(43)}`,
+		`ck1_discovery_v1_${'a'.repeat(44)}`,
+		`ck1_discovery_v1_${'a'.repeat(43)}_extra`,
+	])('runtime matcher rejects malformed keys: %s', value => {
+		expect(isOpaqueCacheKey(value)).toBe(false)
+	})
+
+	test('runtime matcher enforces an expected safe namespace', () => {
+		const value = key()
+
+		expect(isOpaqueCacheKey(value, 'discovery')).toBe(true)
+		expect(isOpaqueCacheKey(value, 'recommendations')).toBe(false)
+		expect(isOpaqueCacheKey(value, 'invalid_namespace')).toBe(false)
+	})
+})

--- a/app/utils/cache-key.server.ts
+++ b/app/utils/cache-key.server.ts
@@ -1,0 +1,396 @@
+import { createHash } from 'node:crypto'
+import path from 'node:path'
+
+const CACHE_KEY_FORMAT_VERSION = 1
+const MAX_CANONICAL_BYTES = 64 * 1024
+const MAX_CANONICAL_DEPTH = 32
+const MAX_CANONICAL_NODES = 10_000
+const MAX_VIEWER_ID_BYTES = 512
+const CACHE_NAMESPACE_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/
+const OPAQUE_CACHE_KEY_PATTERN =
+	/^ck1_([a-z0-9][a-z0-9-]{0,63})_v([1-9]\d{0,9})_([A-Za-z0-9_-]{43})$/
+
+declare const opaqueCacheKeyBrand: unique symbol
+export type OpaqueCacheKey = string & {
+	readonly [opaqueCacheKeyBrand]: true
+}
+
+export type CacheKeyScope =
+	| { readonly kind: 'public' }
+	| { readonly kind: 'viewer'; readonly viewerId: string }
+
+export type CanonicalCacheValue =
+	| null
+	| boolean
+	| number
+	| string
+	| readonly CanonicalCacheValue[]
+	| { readonly [key: string]: CanonicalCacheValue }
+
+function canonicalValue(value: unknown) {
+	const activeObjects = new WeakSet<object>()
+	let nodes = 0
+
+	function serialize(current: unknown, depth: number): string {
+		nodes += 1
+		if (nodes > MAX_CANONICAL_NODES || depth > MAX_CANONICAL_DEPTH) {
+			throw new TypeError('Cache key payload exceeds canonical JSON limits')
+		}
+
+		if (current === null) return 'null'
+		if (typeof current === 'string' || typeof current === 'boolean') {
+			return JSON.stringify(current)
+		}
+		if (typeof current === 'number') {
+			if (!Number.isFinite(current)) {
+				throw new TypeError('Cache key payload contains a non-finite number')
+			}
+			return JSON.stringify(Object.is(current, -0) ? 0 : current)
+		}
+		if (typeof current !== 'object') {
+			throw new TypeError('Cache key payload is not canonical JSON')
+		}
+
+		if (activeObjects.has(current)) {
+			throw new TypeError('Cache key payload must not contain cycles')
+		}
+		activeObjects.add(current)
+		try {
+			if (Array.isArray(current)) {
+				if (Object.getOwnPropertySymbols(current).length) {
+					throw new TypeError(
+						'Cache key payload arrays must contain only indexed values',
+					)
+				}
+				const descriptors = Object.getOwnPropertyDescriptors(current)
+				for (const key of Object.getOwnPropertyNames(current)) {
+					if (key === 'length') continue
+					const descriptor = descriptors[key]
+					if (!descriptor || !('value' in descriptor)) {
+						throw new TypeError(
+							'Cache key payload arrays must not contain accessors',
+						)
+					}
+					if (!descriptor.enumerable) {
+						throw new TypeError(
+							'Cache key payload arrays must not contain non-enumerable values',
+						)
+					}
+					if (!/^(?:0|[1-9]\d*)$/.test(key)) {
+						throw new TypeError(
+							'Cache key payload arrays must contain only indexed values',
+						)
+					}
+					const index = Number(key)
+					if (
+						!Number.isSafeInteger(index) ||
+						index >= 0xffff_ffff ||
+						index >= current.length
+					) {
+						throw new TypeError(
+							'Cache key payload arrays must contain only indexed values',
+						)
+					}
+				}
+				const values: string[] = []
+				for (let index = 0; index < current.length; index += 1) {
+					const descriptor = descriptors[String(index)]
+					if (!descriptor) {
+						throw new TypeError(
+							'Cache key payload arrays must not contain empty slots',
+						)
+					}
+					if (!('value' in descriptor)) {
+						throw new TypeError(
+							'Cache key payload arrays must not contain accessors',
+						)
+					}
+					values.push(serialize(descriptor.value, depth + 1))
+				}
+				return `[${values.join(',')}]`
+			}
+
+			const prototype = Object.getPrototypeOf(current)
+			if (prototype !== Object.prototype && prototype !== null) {
+				throw new TypeError('Cache key payload must contain only plain objects')
+			}
+			if (Object.getOwnPropertySymbols(current).length) {
+				throw new TypeError(
+					'Cache key payload objects must not contain symbol keys',
+				)
+			}
+			const descriptors = Object.getOwnPropertyDescriptors(current)
+			const entries = Object.getOwnPropertyNames(current)
+				.sort()
+				.map(key => {
+					const descriptor = descriptors[key]
+					if (!descriptor || !('value' in descriptor)) {
+						throw new TypeError(
+							'Cache key payload objects must not contain accessors',
+						)
+					}
+					if (!descriptor.enumerable) {
+						throw new TypeError(
+							'Cache key payload objects must not contain non-enumerable values',
+						)
+					}
+					return `${JSON.stringify(key)}:${serialize(
+						descriptor.value,
+						depth + 1,
+					)}`
+				})
+			return `{${entries.join(',')}}`
+		} finally {
+			activeObjects.delete(current)
+		}
+	}
+
+	return serialize(value, 0)
+}
+
+/**
+ * Produces deterministic JSON for cache-key material. Objects are key-sorted;
+ * arrays retain their order. Values outside JSON's lossless scalar/object
+ * model are rejected instead of being silently omitted or coerced.
+ */
+export function canonicalCachePayload(value: unknown) {
+	const canonical = canonicalValue(value)
+	if (Buffer.byteLength(canonical, 'utf8') > MAX_CANONICAL_BYTES) {
+		throw new TypeError('Cache key payload exceeds canonical JSON limits')
+	}
+	return canonical
+}
+
+function requiredCacheNamespace(value: unknown) {
+	if (typeof value !== 'string' || !CACHE_NAMESPACE_PATTERN.test(value)) {
+		throw new TypeError('Cache key namespace is invalid')
+	}
+	return value
+}
+
+function validCacheKeyVersion(value: unknown): value is number {
+	return (
+		Number.isSafeInteger(value) &&
+		(value as number) >= 1 &&
+		(value as number) <= 1_000_000_000
+	)
+}
+
+function invalidCacheScope(): never {
+	throw new TypeError('Cache key scope is invalid')
+}
+
+function cacheScopeMaterial(scope: CacheKeyScope): CanonicalCacheValue {
+	if (typeof scope !== 'object' || scope === null || Array.isArray(scope)) {
+		return invalidCacheScope()
+	}
+	const prototype = Object.getPrototypeOf(scope)
+	if (prototype !== Object.prototype && prototype !== null) {
+		return invalidCacheScope()
+	}
+	if (Object.getOwnPropertySymbols(scope).length) {
+		return invalidCacheScope()
+	}
+	const descriptors = Object.getOwnPropertyDescriptors(scope)
+	const propertyNames = Object.getOwnPropertyNames(scope).sort()
+	const kindDescriptor = descriptors.kind
+	if (!kindDescriptor || !('value' in kindDescriptor)) {
+		return invalidCacheScope()
+	}
+
+	if (
+		kindDescriptor.value === 'public' &&
+		propertyNames.length === 1 &&
+		propertyNames[0] === 'kind'
+	) {
+		return { kind: 'public' }
+	}
+	const viewerIdDescriptor = descriptors.viewerId
+	if (
+		kindDescriptor.value !== 'viewer' ||
+		propertyNames.length !== 2 ||
+		propertyNames[0] !== 'kind' ||
+		propertyNames[1] !== 'viewerId' ||
+		!viewerIdDescriptor ||
+		!('value' in viewerIdDescriptor)
+	) {
+		return invalidCacheScope()
+	}
+	const viewerId = viewerIdDescriptor.value
+	if (
+		typeof viewerId !== 'string' ||
+		!viewerId.trim() ||
+		viewerId !== viewerId.trim() ||
+		Buffer.byteLength(viewerId, 'utf8') > MAX_VIEWER_ID_BYTES
+	) {
+		return invalidCacheScope()
+	}
+	return { kind: 'viewer', viewerId }
+}
+
+function decodeDatasourceComponent(value: string) {
+	try {
+		return decodeURIComponent(value)
+	} catch {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+}
+
+function uniqueDatasourceParameter(parameters: URLSearchParams, name: string) {
+	const values = parameters.getAll(name)
+	if (values.length > 1) {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+	return values[0] ?? null
+}
+
+function sqliteDatasourceIdentity(databaseUrl: string, sqliteBasePath: string) {
+	const raw = databaseUrl.slice('file:'.length)
+	const fragmentIndex = raw.indexOf('#')
+	if (fragmentIndex !== -1) {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+	const queryIndex = raw.indexOf('?')
+	const encodedPath = queryIndex === -1 ? raw : raw.slice(0, queryIndex)
+	const query = queryIndex === -1 ? '' : raw.slice(queryIndex + 1)
+	if (!encodedPath || encodedPath.startsWith('//')) {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+	const decodedPath = decodeDatasourceComponent(encodedPath)
+	if (!decodedPath.trim() || decodedPath !== decodedPath.trim()) {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+
+	const parameters = new URLSearchParams(query)
+	const mode = uniqueDatasourceParameter(parameters, 'mode')
+	const sharedCache = uniqueDatasourceParameter(parameters, 'cache')
+	return {
+		provider: 'sqlite',
+		database:
+			decodedPath === ':memory:'
+				? decodedPath
+				: path.resolve(sqliteBasePath, decodedPath),
+		...(mode ? { mode } : {}),
+		...(sharedCache ? { cache: sharedCache } : {}),
+	}
+}
+
+function postgresDatasourceIdentity(databaseUrl: string) {
+	let parsed: URL
+	try {
+		parsed = new URL(databaseUrl)
+	} catch {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+	if (
+		(parsed.protocol !== 'postgres:' && parsed.protocol !== 'postgresql:') ||
+		!parsed.hostname ||
+		parsed.hash
+	) {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+	const database = decodeDatasourceComponent(parsed.pathname.slice(1))
+	if (
+		!database.trim() ||
+		database !== database.trim() ||
+		database.includes('/')
+	) {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+	const schema =
+		uniqueDatasourceParameter(parsed.searchParams, 'schema') ?? 'public'
+	if (!schema.trim() || schema !== schema.trim()) {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+	const socketHost = uniqueDatasourceParameter(parsed.searchParams, 'host')
+	if (
+		socketHost !== null &&
+		(!socketHost.trim() || socketHost !== socketHost.trim())
+	) {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+	return {
+		provider: 'postgresql',
+		host: parsed.hostname.toLocaleLowerCase('en-US'),
+		port: parsed.port ? Number(parsed.port) : 5432,
+		database,
+		schema,
+		...(socketHost ? { socketHost } : {}),
+	}
+}
+
+/**
+ * Returns a stable, credential-free identity for the database addressed by a
+ * Prisma SQLite or PostgreSQL datasource URL. Connection tuning, usernames,
+ * passwords, and TLS parameters deliberately do not affect the identity.
+ */
+export function cacheDatasourceIdentity(
+	databaseUrl: string | undefined,
+	{
+		sqliteBasePath = path.resolve(process.cwd(), 'prisma'),
+	}: { sqliteBasePath?: string } = {},
+) {
+	if (
+		typeof databaseUrl !== 'string' ||
+		!databaseUrl.trim() ||
+		databaseUrl !== databaseUrl.trim()
+	) {
+		throw new TypeError('DATABASE_URL is not a supported datasource URL')
+	}
+	const identity = databaseUrl.startsWith('file:')
+		? sqliteDatasourceIdentity(databaseUrl, path.resolve(sqliteBasePath))
+		: postgresDatasourceIdentity(databaseUrl)
+	return canonicalCachePayload(identity)
+}
+
+export function createOpaqueCacheKey({
+	namespace,
+	version,
+	scope,
+	payload,
+	datasourceUrl = process.env.DATABASE_URL,
+	sqliteBasePath,
+}: {
+	namespace: string
+	version: number
+	scope: CacheKeyScope
+	payload: CanonicalCacheValue
+	datasourceUrl?: string
+	sqliteBasePath?: string
+}): OpaqueCacheKey {
+	const safeNamespace = requiredCacheNamespace(namespace)
+	const safeScope = cacheScopeMaterial(scope)
+	if (!validCacheKeyVersion(version)) {
+		throw new TypeError('Cache key version is invalid')
+	}
+	const material = canonicalCachePayload({
+		namespace: safeNamespace,
+		version,
+		datasource: cacheDatasourceIdentity(datasourceUrl, { sqliteBasePath }),
+		scope: safeScope,
+		payload,
+	})
+	const digest = createHash('sha256')
+		.update(material, 'utf8')
+		.digest('base64url')
+	return `ck${CACHE_KEY_FORMAT_VERSION}_${safeNamespace}_v${version}_${digest}` as OpaqueCacheKey
+}
+
+export function isOpaqueCacheKey(
+	value: unknown,
+	expectedNamespace?: string,
+): value is OpaqueCacheKey {
+	if (typeof value !== 'string') return false
+	const match = OPAQUE_CACHE_KEY_PATTERN.exec(value)
+	if (!match) return false
+	const [, namespace, version] = match
+	if (!validCacheKeyVersion(Number(version))) return false
+	if (
+		expectedNamespace !== undefined &&
+		(!CACHE_NAMESPACE_PATTERN.test(expectedNamespace) ||
+			namespace !== expectedNamespace)
+	) {
+		return false
+	}
+	return true
+}

--- a/app/utils/cache.server.test.ts
+++ b/app/utils/cache.server.test.ts
@@ -1,8 +1,145 @@
-import { describe, expect, test, vi } from 'vitest'
-import { createCacheResourceCloser } from './cache.server.ts'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { createBatch } from '@epic-web/cachified'
+import Database from 'better-sqlite3'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+	createOpaqueCacheKey,
+	type OpaqueCacheKey,
+} from './cache-key.server.ts'
+import {
+	cache,
+	cachifiedSafely,
+	createCacheResourceCloser,
+	createMemoryCache,
+	createSafeCacheReporter,
+	createSqliteCacheAdapter,
+	createSqliteCacheResource,
+	getCacheOperationsSnapshot,
+	initializeCacheDatabase,
+	pruneCacheDatabase,
+	resetCacheResourcesForTest,
+	SAFE_CACHE_MAX_TTL_MS,
+	type CacheMetricEvent,
+	type CacheMetricNamespace,
+	type InspectableMemoryCache,
+} from './cache.server.ts'
+
+const temporaryDirectories = new Set<string>()
+
+function createTemporaryDirectory() {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'veud-cache-test-'))
+	temporaryDirectories.add(directory)
+	return directory
+}
+
+function cacheEntry<Value>(
+	value: Value,
+	{
+		createdTime = Date.now(),
+		ttl = 1_000,
+		swr = 0,
+	}: {
+		createdTime?: number
+		ttl?: number | null
+		swr?: number | null
+	} = {},
+) {
+	return {
+		metadata: { createdTime, ttl, swr },
+		value,
+	}
+}
+
+function opaqueCacheKey({
+	namespace = 'ranked-discovery',
+	viewerId = 'viewer-a',
+	query = 'private search terms',
+}: {
+	namespace?: 'ranked-discovery' | 'recommendation-graph'
+	viewerId?: string
+	query?: string
+} = {}) {
+	return createOpaqueCacheKey({
+		namespace,
+		version: 1,
+		scope: { kind: 'viewer', viewerId },
+		payload: { query },
+		datasourceUrl: 'postgresql://cache-user:secret@db.example.invalid/veud',
+	})
+}
+
+afterEach(() => {
+	vi.useRealTimers()
+	resetCacheResourcesForTest()
+	for (const directory of temporaryDirectories) {
+		fs.rmSync(directory, { recursive: true, force: true })
+	}
+	temporaryDirectories.clear()
+})
 
 describe('cache resource lifecycle', () => {
-	test('closes the database exactly once', async () => {
+	test('does not open its configured database merely by being imported or reset', () => {
+		const directory = createTemporaryDirectory()
+		const databasePath = path.join(directory, 'lazy-cache.db')
+		const moduleUrl = pathToFileURL(
+			path.join(process.cwd(), 'app/utils/cache.server.ts'),
+		).href
+
+		const result = spawnSync(
+			process.execPath,
+			[
+				'--experimental-strip-types',
+				'--input-type=module',
+				'--eval',
+				`const cacheModule = await import(${JSON.stringify(moduleUrl)}); cacheModule.resetCacheResourcesForTest()`,
+			],
+			{
+				cwd: process.cwd(),
+				encoding: 'utf8',
+				env: {
+					...process.env,
+					CACHE_DATABASE_PATH: databasePath,
+					NODE_ENV: 'test',
+				},
+			},
+		)
+
+		expect(result.status, result.stderr).toBe(0)
+		expect(fs.existsSync(databasePath)).toBe(false)
+	})
+
+	test('unified test reset empties an already-opened SQLite singleton', async () => {
+		const safeKey = opaqueCacheKey()
+		await cache.set('present', cacheEntry('value'))
+		await cachifiedSafely('ranked-discovery', {
+			key: safeKey,
+			ttl: 1_000,
+			getFreshValue: () => 'memory value',
+		})
+		expect(await cache.get('present')).toMatchObject({ value: 'value' })
+		expect(getCacheOperationsSnapshot()['ranked-discovery']).toBeDefined()
+
+		resetCacheResourcesForTest()
+
+		expect(await cache.get('present')).toBeNull()
+		expect(getCacheOperationsSnapshot()).toEqual({})
+
+		const refresh = vi.fn(() => 'refreshed')
+		await expect(
+			cachifiedSafely('ranked-discovery', {
+				key: safeKey,
+				ttl: 1_000,
+				getFreshValue: refresh,
+			}),
+		).resolves.toBe('refreshed')
+		expect(refresh).toHaveBeenCalledOnce()
+	})
+
+	test('closes the database exactly once', () => {
 		let databaseOpen = true
 		const clearTimer = vi.fn()
 		const closeDatabase = vi.fn(() => {
@@ -20,5 +157,957 @@ describe('cache resource lifecycle', () => {
 		expect(clearTimer).toHaveBeenCalledOnce()
 		expect(closeDatabase).toHaveBeenCalledOnce()
 		expect(databaseOpen).toBe(false)
+	})
+
+	test('owns and idempotently closes its SQLite resource', async () => {
+		const resource = createSqliteCacheResource({
+			databasePath: ':memory:',
+			pruneIntervalMs: null,
+		})
+		await resource.cache.set('present', cacheEntry('value'))
+
+		expect(resource.open).toBe(true)
+		expect(resource.keys(10)).toEqual(['present'])
+		expect(resource.clear()).toBe(1)
+		expect(resource.keys(10)).toEqual([])
+
+		resource.close()
+		resource.close()
+
+		expect(resource.open).toBe(false)
+		expect(resource.prune()).toBe(0)
+		expect(resource.keys(10)).toEqual([])
+	})
+})
+
+describe('SQLite cache adapter', () => {
+	test.each([
+		['false', false],
+		['zero', 0],
+		['empty string', ''],
+		['null', null],
+	])('round-trips the falsey value %s', async (_label, value) => {
+		const db = new Database(':memory:')
+		initializeCacheDatabase(db)
+		const sqliteCache = createSqliteCacheAdapter(db, {
+			now: () => 1_000,
+		})
+
+		await sqliteCache.set(
+			'falsey',
+			cacheEntry(value, { createdTime: 1_000, ttl: 1_000 }),
+		)
+
+		expect(await sqliteCache.get('falsey')).toEqual(
+			cacheEntry(value, { createdTime: 1_000, ttl: 1_000 }),
+		)
+		db.close()
+	})
+
+	test('serves stale values only inside their SWR window', async () => {
+		const db = new Database(':memory:')
+		initializeCacheDatabase(db)
+		let now = 1_000
+		const sqliteCache = createSqliteCacheAdapter(db, { now: () => now })
+		await sqliteCache.set(
+			'stale',
+			cacheEntry('value', { createdTime: 800, ttl: 100, swr: 100 }),
+		)
+
+		// Cachified treats the exact expiration endpoint as readable.
+		expect(await sqliteCache.get('stale')).toMatchObject({ value: 'value' })
+		now = 1_001
+		expect(await sqliteCache.get('stale')).toBeNull()
+		expect(
+			db.prepare('SELECT key FROM cache WHERE key = ?').get('stale'),
+		).toBeUndefined()
+		db.close()
+	})
+
+	test('preserves missing TTL and explicit infinite current or legacy SWR', async () => {
+		const db = new Database(':memory:')
+		initializeCacheDatabase(db)
+		const sqliteCache = createSqliteCacheAdapter(db, {
+			now: () => 10_000_000,
+		})
+		const entries = [
+			{
+				key: 'missing-ttl',
+				entry: { metadata: { createdTime: 1 }, value: 'missing' },
+			},
+			{
+				key: 'infinite-swr',
+				entry: {
+					metadata: { createdTime: 1, ttl: 10, swr: null },
+					value: 'current',
+				},
+			},
+			{
+				key: 'infinite-swv',
+				entry: {
+					metadata: { createdTime: 1, ttl: 10, swv: null },
+					value: 'legacy',
+				},
+			},
+		]
+
+		for (const { key, entry } of entries) {
+			await sqliteCache.set(key, entry)
+			expect(await sqliteCache.get(key)).toMatchObject({ value: entry.value })
+		}
+		db.close()
+	})
+
+	test('deletes malformed serialized rows instead of throwing', async () => {
+		const db = new Database(':memory:')
+		initializeCacheDatabase(db)
+		const sqliteCache = createSqliteCacheAdapter(db)
+		const insert = db.prepare(
+			'INSERT INTO cache (key, metadata, value) VALUES (?, ?, ?)',
+		)
+		insert.run('bad-metadata-json', '{', JSON.stringify({ still: 'valid' }))
+		insert.run(
+			'bad-value-json',
+			JSON.stringify({ createdTime: Date.now(), ttl: null }),
+			'{',
+		)
+		insert.run(
+			'bad-metadata-shape',
+			JSON.stringify({ createdTime: 'yesterday', ttl: null }),
+			JSON.stringify('value'),
+		)
+
+		expect(await sqliteCache.get('bad-metadata-json')).toBeNull()
+		expect(await sqliteCache.get('bad-value-json')).toBeNull()
+		expect(await sqliteCache.get('bad-metadata-shape')).toBeNull()
+		expect(db.prepare('SELECT COUNT(*) AS count FROM cache').get()).toEqual({
+			count: 0,
+		})
+		db.close()
+	})
+
+	test('prunes malformed and fully expired rows in bounded SQL batches', () => {
+		const db = new Database(':memory:')
+		initializeCacheDatabase(db)
+		const insert = db.prepare(
+			'INSERT INTO cache (key, metadata, value) VALUES (?, ?, ?)',
+		)
+		const insertEntry = (
+			key: string,
+			metadata: Record<string, unknown>,
+			value = 'value',
+		) => insert.run(key, JSON.stringify(metadata), JSON.stringify(value))
+
+		insertEntry('fresh', { createdTime: 900, ttl: 200, swr: 0 })
+		insertEntry('inside-swr', { createdTime: 850, ttl: 100, swr: 100 })
+		insertEntry('unbounded-legacy', { createdTime: 0 })
+		insertEntry('expired', { createdTime: 700, ttl: 100, swr: 100 })
+		insert.run('bad-metadata', '{', JSON.stringify('value'))
+		insert.run('bad-value', JSON.stringify({ createdTime: 900, ttl: 200 }), '{')
+
+		expect(pruneCacheDatabase(db, { now: 1_000, limit: 2 })).toBe(2)
+		expect(
+			(
+				db.prepare('SELECT COUNT(*) AS count FROM cache').get() as {
+					count: number
+				}
+			).count,
+		).toBe(4)
+		expect(pruneCacheDatabase(db, { now: 1_000, limit: 2 })).toBe(1)
+		expect(
+			db
+				.prepare('SELECT key FROM cache ORDER BY key')
+				.all()
+				.map(row => (row as { key: string }).key),
+		).toEqual(['fresh', 'inside-swr', 'unbounded-legacy'])
+		db.close()
+	})
+
+	test('pruning keeps exact endpoints and infinite stale windows', () => {
+		const db = new Database(':memory:')
+		initializeCacheDatabase(db)
+		const insert = db.prepare(
+			'INSERT INTO cache (key, metadata, value) VALUES (?, ?, ?)',
+		)
+		const insertEntry = (key: string, metadata: Record<string, unknown>) =>
+			insert.run(key, JSON.stringify(metadata), JSON.stringify('value'))
+
+		insertEntry('endpoint', { createdTime: 800, ttl: 100, swr: 100 })
+		insertEntry('missing-ttl', { createdTime: 1 })
+		insertEntry('infinite-swr', { createdTime: 1, ttl: 10, swr: null })
+		insertEntry('infinite-swv', { createdTime: 1, ttl: 10, swv: null })
+
+		expect(pruneCacheDatabase(db, { now: 1_000 })).toBe(0)
+		expect(pruneCacheDatabase(db, { now: 1_001 })).toBe(1)
+		expect(
+			db
+				.prepare('SELECT key FROM cache ORDER BY key')
+				.all()
+				.map(row => (row as { key: string }).key),
+		).toEqual(['infinite-swr', 'infinite-swv', 'missing-ttl'])
+		db.close()
+	})
+
+	test('recovers a corrupt regular cache file and restricts its mode', async () => {
+		const directory = createTemporaryDirectory()
+		const databasePath = path.join(directory, 'cache.db')
+		fs.writeFileSync(databasePath, 'not a sqlite database', { mode: 0o644 })
+
+		const resource = createSqliteCacheResource({
+			databasePath,
+			pruneIntervalMs: null,
+		})
+		await resource.cache.set('recovered', cacheEntry('yes', { ttl: null }))
+
+		expect(await resource.cache.get('recovered')).toMatchObject({
+			value: 'yes',
+		})
+		expect(fs.statSync(databasePath).mode & 0o777).toBe(0o600)
+		resource.close()
+	})
+
+	test('recovers corruption first reached by initial pruning and removes regular sidecars', async () => {
+		const directory = createTemporaryDirectory()
+		const databasePath = path.join(directory, 'partial-cache.db')
+		const original = new Database(databasePath)
+		initializeCacheDatabase(original)
+		original
+			.prepare('INSERT INTO cache (key, metadata, value) VALUES (?, ?, ?)')
+			.run(
+				'old',
+				JSON.stringify({ createdTime: 1, ttl: 1, swr: 0 }),
+				JSON.stringify('old'),
+			)
+		const rootPage = original
+			.prepare(
+				"SELECT rootpage FROM sqlite_master WHERE type = 'table' AND name = 'cache'",
+			)
+			.pluck()
+			.get() as number
+		const pageSize = original.pragma('page_size', { simple: true }) as number
+		original.close()
+
+		const descriptor = fs.openSync(databasePath, 'r+')
+		try {
+			// A table b-tree page must begin with a recognized page type. Keep
+			// sqlite_master intact so open/schema/adapter preparation still work.
+			fs.writeSync(
+				descriptor,
+				Buffer.from([0]),
+				0,
+				1,
+				(rootPage - 1) * pageSize,
+			)
+		} finally {
+			fs.closeSync(descriptor)
+		}
+
+		const probe = new Database(databasePath)
+		expect(() => initializeCacheDatabase(probe)).not.toThrow()
+		expect(() => createSqliteCacheAdapter(probe)).not.toThrow()
+		expect(() => pruneCacheDatabase(probe)).toThrow()
+		probe.close()
+
+		for (const suffix of ['-journal', '-wal', '-shm']) {
+			fs.writeFileSync(`${databasePath}${suffix}`, 'stale sidecar')
+		}
+		const resource = createSqliteCacheResource({
+			databasePath,
+			pruneIntervalMs: null,
+		})
+		await resource.cache.set('new', cacheEntry('recovered', { ttl: null }))
+
+		expect(await resource.cache.get('new')).toMatchObject({
+			value: 'recovered',
+		})
+		expect(resource.keys(10)).toEqual(['new'])
+		for (const suffix of ['-journal', '-wal', '-shm']) {
+			expect(fs.existsSync(`${databasePath}${suffix}`)).toBe(false)
+		}
+		resource.close()
+	})
+
+	test('creates missing private parent directories', () => {
+		const directory = createTemporaryDirectory()
+		const parent = path.join(directory, 'private-cache')
+		const resource = createSqliteCacheResource({
+			databasePath: path.join(parent, 'cache.db'),
+			pruneIntervalMs: null,
+		})
+
+		expect(fs.statSync(parent).mode & 0o077).toBe(0)
+		expect(fs.statSync(path.join(parent, 'cache.db')).mode & 0o077).toBe(0)
+		resource.close()
+	})
+
+	test('does not delete a non-corrupt path when opening fails', () => {
+		const directory = createTemporaryDirectory()
+		const databasePath = path.join(directory, 'cache.db')
+		fs.mkdirSync(databasePath)
+
+		expect(() =>
+			createSqliteCacheResource({
+				databasePath,
+				pruneIntervalMs: null,
+			}),
+		).toThrow()
+		expect(fs.statSync(databasePath).isDirectory()).toBe(true)
+	})
+})
+
+describe('bounded in-memory cache', () => {
+	test('restores only the remaining wall-clock TTL', () => {
+		const wallClock = new Date('2026-07-28T12:00:00.000Z').getTime()
+		let monotonicClock = 500
+		const memoryCache = createMemoryCache({
+			maxEntries: 10,
+			maxSizeBytes: 10_000,
+			maxEntrySizeBytes: 5_000,
+			now: () => wallClock,
+			monotonicNow: () => monotonicClock,
+		})
+
+		memoryCache.set(
+			'expired',
+			cacheEntry('expired', {
+				createdTime: wallClock - 2_000,
+				ttl: 1_000,
+			}),
+		)
+		expect(memoryCache.get('expired')).toBeUndefined()
+
+		memoryCache.set(
+			'fresh',
+			cacheEntry('fresh', { createdTime: wallClock - 250, ttl: 1_000 }),
+		)
+		expect(memoryCache.get('fresh')).toMatchObject({ value: 'fresh' })
+		monotonicClock += 749
+		expect(memoryCache.get('fresh')).toMatchObject({ value: 'fresh' })
+		monotonicClock += 2
+		expect(memoryCache.get('fresh')).toBeUndefined()
+
+		memoryCache.set(
+			'unbounded',
+			cacheEntry('unbounded', { createdTime: wallClock, ttl: null }),
+		)
+		monotonicClock += 365 * 24 * 60 * 60 * 1_000
+		expect(memoryCache.get('unbounded')).toMatchObject({
+			value: 'unbounded',
+		})
+	})
+
+	test('keeps exact endpoints and explicit infinite stale windows', () => {
+		let wallClock = 1_000
+		let monotonicClock = 500
+		const memoryCache = createMemoryCache({
+			maxEntries: 10,
+			maxSizeBytes: 10_000,
+			maxEntrySizeBytes: 5_000,
+			now: () => wallClock,
+			monotonicNow: () => monotonicClock,
+		})
+
+		memoryCache.set(
+			'endpoint',
+			cacheEntry('endpoint', { createdTime: 900, ttl: 100, swr: 0 }),
+		)
+		expect(memoryCache.get('endpoint')).toMatchObject({ value: 'endpoint' })
+		wallClock += 1
+		monotonicClock += 1
+		expect(memoryCache.get('endpoint')).toBeUndefined()
+
+		for (const [key, entry] of [
+			['missing-ttl', { metadata: { createdTime: 1 }, value: 'missing' }],
+			[
+				'infinite-swr',
+				{
+					metadata: { createdTime: 1, ttl: 10, swr: null },
+					value: 'current',
+				},
+			],
+			[
+				'infinite-swv',
+				{
+					metadata: { createdTime: 1, ttl: 10, swv: null },
+					value: 'legacy',
+				},
+			],
+		] as const) {
+			memoryCache.set(key, entry)
+			expect(memoryCache.get(key)).toMatchObject({ value: entry.value })
+		}
+	})
+
+	test('enforces entry-count, total-byte, and per-entry byte bounds', () => {
+		const countBounded = createMemoryCache({
+			maxEntries: 2,
+			maxSizeBytes: 10_000,
+			maxEntrySizeBytes: 5_000,
+		})
+		countBounded.set('one', cacheEntry('one'))
+		countBounded.set('two', cacheEntry('two'))
+		countBounded.set('three', cacheEntry('three'))
+		expect(countBounded.snapshot().entries).toBe(2)
+		expect(countBounded.get('one')).toBeUndefined()
+
+		const byteBounded = createMemoryCache({
+			maxEntries: 10,
+			maxSizeBytes: 300,
+			maxEntrySizeBytes: 250,
+		})
+		byteBounded.set('first', cacheEntry('x'.repeat(100)))
+		byteBounded.set('second', cacheEntry('y'.repeat(100)))
+		expect(byteBounded.snapshot().entries).toBe(1)
+		expect(byteBounded.snapshot().calculatedSizeBytes).toBeLessThanOrEqual(300)
+		expect(byteBounded.get('first')).toBeUndefined()
+		expect(byteBounded.get('second')).toBeDefined()
+
+		byteBounded.set('oversized', cacheEntry('z'.repeat(500)))
+		expect(byteBounded.get('oversized')).toBeUndefined()
+	})
+
+	test('rejects unserializable entries and invalid capacities', () => {
+		const memoryCache = createMemoryCache({
+			maxEntries: 10,
+			maxSizeBytes: 1_000,
+			maxEntrySizeBytes: 500,
+		})
+		const circular: { self?: unknown } = {}
+		circular.self = circular
+
+		expect(() =>
+			memoryCache.set('circular', cacheEntry(circular)),
+		).not.toThrow()
+		expect(memoryCache.get('circular')).toBeUndefined()
+		expect(() =>
+			createMemoryCache({
+				maxSizeBytes: 100,
+				maxEntrySizeBytes: 101,
+			}),
+		).toThrow(/must not exceed/)
+	})
+
+	test('supports bounded inspection and prefix invalidation', () => {
+		const memoryCache = createMemoryCache()
+		memoryCache.set('rank:movie:one', cacheEntry(1))
+		memoryCache.set('rank:movie:two', cacheEntry(2))
+		memoryCache.set('rank:anime:one', cacheEntry(3))
+
+		expect(memoryCache.keys(2)).toHaveLength(2)
+		expect(memoryCache.deleteByPrefix('rank:movie:')).toBe(2)
+		expect(memoryCache.keys().sort()).toEqual(['rank:anime:one'])
+	})
+})
+
+describe('privacy-safe cache reporting', () => {
+	test('records aggregate event classes without retaining event payloads', () => {
+		const privateText = 'viewer-123 secret query'
+		const report = createSafeCacheReporter('ranked-discovery')({} as never)
+		const events: Array<{
+			name: string
+			event: Record<string, unknown>
+			metric: CacheMetricEvent
+		}> = [
+			{
+				name: 'getCachedValueSuccess',
+				event: { value: privateText, migrated: false },
+				metric: 'hit',
+			},
+			{ name: 'getCachedValueEmpty', event: {}, metric: 'miss' },
+			{ name: 'getFreshValueStart', event: {}, metric: 'refresh' },
+			{
+				name: 'getFreshValueError',
+				event: { error: new Error(privateText) },
+				metric: 'refresh-error',
+			},
+			{
+				name: 'writeFreshValueError',
+				event: { error: new Error(privateText) },
+				metric: 'write-error',
+			},
+			{
+				name: 'checkCachedValueErrorObj',
+				event: { reason: privateText },
+				metric: 'invalid',
+			},
+		]
+		for (const { name, event } of events) {
+			report({ name, ...event } as never)
+		}
+
+		const snapshot = getCacheOperationsSnapshot()
+		for (const { metric } of events) {
+			expect(snapshot['ranked-discovery'][metric]).toBe(1)
+		}
+		expect(JSON.stringify(snapshot)).not.toContain(privateText)
+		expect(() =>
+			createSafeCacheReporter(
+				'cmz8q7z5w0001viewerprivate' as CacheMetricNamespace,
+			),
+		).toThrow(/registered static cache family/)
+	})
+
+	test('stores only opaque keys, uses namespace-only timings, and coalesces refreshes', async () => {
+		const privateViewer = 'viewer-private-id'
+		const privateQuery = 'secret query'
+		const key = opaqueCacheKey({
+			viewerId: privateViewer,
+			query: privateQuery,
+		})
+		const timings = {}
+		const memoryCache = createMemoryCache()
+		const getFreshValue = vi.fn(async () => {
+			await new Promise(resolve => setTimeout(resolve, 10))
+			return { result: 'grounded' }
+		})
+
+		const values = await Promise.all(
+			Array.from({ length: 20 }, () =>
+				cachifiedSafely(
+					'ranked-discovery',
+					{
+						key,
+						ttl: 1_000,
+						timings,
+						getFreshValue,
+					},
+					memoryCache,
+				),
+			),
+		)
+
+		expect(getFreshValue).toHaveBeenCalledOnce()
+		expect(values).toHaveLength(20)
+		expect(memoryCache.keys()).toEqual([key])
+		const storedEntry = await memoryCache.get(key)
+		expect(storedEntry?.metadata.swr).toBe(0)
+		const observableState = JSON.stringify({
+			keys: memoryCache.keys(),
+			timings,
+			metrics: getCacheOperationsSnapshot(),
+		})
+		expect(observableState).not.toContain(privateViewer)
+		expect(observableState).not.toContain(privateQuery)
+		expect(Object.keys(timings).sort()).toEqual([
+			'cache:ranked-discovery',
+			'getFreshValue:ranked-discovery',
+		])
+	})
+
+	test('detaches and deeply freezes canonical ranking plans', async () => {
+		const memoryCache = createMemoryCache()
+		const key = opaqueCacheKey()
+		const originalPlan = {
+			pages: [
+				{
+					ids: ['media-a', 'media-b'],
+					scores: [0.9, 0.8],
+				},
+			],
+		}
+
+		const first = await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key,
+				ttl: 1_000,
+				getFreshValue: () => originalPlan,
+			},
+			memoryCache,
+		)
+
+		expect(Object.isFrozen(first)).toBe(true)
+		expect(Object.isFrozen(first.pages)).toBe(true)
+		expect(Object.isFrozen(first.pages[0])).toBe(true)
+		expect(Object.isFrozen(first.pages[0]?.ids)).toBe(true)
+		expect(Reflect.set(first.pages[0]!.ids, '0', 'consumer-poison')).toBe(false)
+
+		originalPlan.pages[0]!.ids[0] = 'producer-poison'
+		originalPlan.pages.push({ ids: ['media-c'], scores: [0.7] })
+
+		const unexpectedRefresh = vi.fn(() => originalPlan)
+		const second = await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key,
+				ttl: 1_000,
+				getFreshValue: unexpectedRefresh,
+			},
+			memoryCache,
+		)
+		const storedEntry = await memoryCache.get(key)
+
+		expect(unexpectedRefresh).not.toHaveBeenCalled()
+		expect(second).toEqual({
+			pages: [
+				{
+					ids: ['media-a', 'media-b'],
+					scores: [0.9, 0.8],
+				},
+			],
+		})
+		expect(second).not.toBe(first)
+		expect(storedEntry?.value).toEqual(second)
+		expect(storedEntry?.value).not.toBe(first)
+		expect(storedEntry?.value).not.toBe(originalPlan)
+	})
+
+	test('rejects noncanonical fresh values without storing them', async () => {
+		const memoryCache = createMemoryCache()
+		const cyclic: Record<string, unknown> = {}
+		cyclic.self = cyclic
+		const invalidValues = [
+			['undefined', undefined],
+			['nested undefined', { ids: [undefined] }],
+			['date', new Date()],
+			['NaN', Number.NaN],
+			['infinity', Infinity],
+			['cycle', cyclic],
+		] as const
+
+		for (const [label, value] of invalidValues) {
+			const key = opaqueCacheKey({ query: `invalid ${label}` })
+			await expect(
+				cachifiedSafely(
+					'ranked-discovery',
+					{
+						key,
+						ttl: 1_000,
+						getFreshValue: () => value,
+					} as never,
+					memoryCache,
+				),
+			).rejects.toBeInstanceOf(TypeError)
+			expect(memoryCache.keys()).not.toContain(key)
+		}
+	})
+
+	test('sanitizes cached migrations before they can be stored or returned', async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(1_000)
+		const memoryCache = createMemoryCache()
+		const key = opaqueCacheKey()
+		await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key,
+				ttl: 1_000,
+				getFreshValue: () => ({ ids: ['old-id'] }),
+			},
+			memoryCache,
+		)
+
+		const migratedPlan = {
+			ids: ['new-id'],
+			evidence: { source: 'migration' },
+		}
+		const migrated = await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key,
+				ttl: 1_000,
+				getFreshValue: () => ({ ids: ['unexpected'] }),
+				checkValue(_value, migrate) {
+					return migrate(migratedPlan)
+				},
+			},
+			memoryCache,
+		)
+		expect(Object.isFrozen(migrated)).toBe(true)
+		expect(Object.isFrozen(migrated.ids)).toBe(true)
+		migratedPlan.ids[0] = 'migration-poison'
+
+		await vi.runAllTimersAsync()
+		expect((await memoryCache.get(key))?.value).toEqual({
+			ids: ['new-id'],
+			evidence: { source: 'migration' },
+		})
+
+		const nextHit = await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key,
+				ttl: 1_000,
+				getFreshValue: () => ({ ids: ['unexpected'] }),
+			},
+			memoryCache,
+		)
+		expect(nextHit).toEqual({
+			ids: ['new-id'],
+			evidence: { source: 'migration' },
+		})
+	})
+
+	test('does not store an invalid cached migration', async () => {
+		const memoryCache = createMemoryCache()
+		const key = opaqueCacheKey()
+		await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key,
+				ttl: 1_000,
+				getFreshValue: () => ({ ids: ['stable-id'] }),
+			},
+			memoryCache,
+		)
+		const cyclic: Record<string, unknown> = {}
+		cyclic.self = cyclic
+
+		await expect(
+			cachifiedSafely(
+				'ranked-discovery',
+				{
+					key,
+					ttl: 1_000,
+					getFreshValue() {
+						throw new Error('refresh after invalid migration')
+					},
+					checkValue(_value, migrate) {
+						return migrate(cyclic as never)
+					},
+				},
+				memoryCache,
+			),
+		).rejects.toThrow('refresh after invalid migration')
+		expect(memoryCache.keys()).not.toContain(key)
+	})
+
+	test('separates otherwise-identical viewer scopes', async () => {
+		const memoryCache = createMemoryCache()
+		const viewerAKey = opaqueCacheKey({ viewerId: 'viewer-a' })
+		const viewerBKey = opaqueCacheKey({ viewerId: 'viewer-b' })
+		expect(viewerAKey).not.toBe(viewerBKey)
+
+		await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key: viewerAKey,
+				ttl: 1_000,
+				getFreshValue: () => 'viewer-a-result',
+			},
+			memoryCache,
+		)
+		await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key: viewerBKey,
+				ttl: 1_000,
+				getFreshValue: () => 'viewer-b-result',
+			},
+			memoryCache,
+		)
+		const unexpectedRefresh = vi.fn(() => 'wrong')
+		const viewerAResult = await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key: viewerAKey,
+				ttl: 1_000,
+				getFreshValue: unexpectedRefresh,
+			},
+			memoryCache,
+		)
+
+		expect(viewerAResult).toBe('viewer-a-result')
+		expect(unexpectedRefresh).not.toHaveBeenCalled()
+		expect(memoryCache.keys().sort()).toEqual([viewerAKey, viewerBKey].sort())
+	})
+
+	test('rejects raw or mismatched keys and unsafe cache options', async () => {
+		const memoryCache = createMemoryCache()
+		const rankedKey = opaqueCacheKey()
+		const graphKey = opaqueCacheKey({
+			namespace: 'recommendation-graph',
+		})
+		const baseOptions = {
+			key: rankedKey,
+			ttl: 1_000,
+			getFreshValue: () => 'value',
+		}
+
+		await expect(
+			cachifiedSafely(
+				'ranked-discovery',
+				{
+					...baseOptions,
+					key: 'viewer-123:secret query' as OpaqueCacheKey,
+				},
+				memoryCache,
+			),
+		).rejects.toThrow(/does not match/)
+		await expect(
+			cachifiedSafely(
+				'ranked-discovery',
+				{ ...baseOptions, key: graphKey },
+				memoryCache,
+			),
+		).rejects.toThrow(/does not match/)
+
+		for (const [option, value] of [
+			['cache', memoryCache],
+			['fallbackToCache', true],
+			['staleRefreshTimeout', 1],
+			['staleWhileRevalidate', 1],
+			['swr', 1],
+			['traceId', 'viewer-private-id'],
+		] as const) {
+			await expect(
+				cachifiedSafely(
+					'ranked-discovery',
+					{ ...baseOptions, [option]: value } as never,
+					memoryCache,
+				),
+			).rejects.toThrow(option)
+		}
+		await expect(
+			cachifiedSafely(
+				'ranked-discovery',
+				baseOptions,
+				{} as InspectableMemoryCache,
+			),
+		).rejects.toThrow(/inspectable memory caches/)
+	})
+
+	test('requires a finite positive ttl no greater than five minutes', async () => {
+		const memoryCache = createMemoryCache()
+		const baseOptions = {
+			key: opaqueCacheKey(),
+			getFreshValue: () => 'value',
+		}
+
+		for (const ttl of [
+			undefined,
+			Infinity,
+			Number.NaN,
+			0,
+			-1,
+			SAFE_CACHE_MAX_TTL_MS + 1,
+		]) {
+			await expect(
+				cachifiedSafely(
+					'ranked-discovery',
+					{ ...baseOptions, ttl } as never,
+					memoryCache,
+				),
+			).rejects.toThrow(/ttl must be finite, positive/)
+		}
+
+		await expect(
+			cachifiedSafely(
+				'ranked-discovery',
+				{
+					...baseOptions,
+					ttl: SAFE_CACHE_MAX_TTL_MS,
+				},
+				memoryCache,
+			),
+		).resolves.toBe('value')
+	})
+
+	test('gives refresh callbacks frozen detached safe metadata', async () => {
+		const memoryCache = createMemoryCache()
+		const key = opaqueCacheKey()
+		let callbackCreatedTime: number | undefined
+
+		await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key,
+				ttl: 1_000,
+				getFreshValue({ metadata }) {
+					callbackCreatedTime = metadata.createdTime
+					expect(Object.isFrozen(metadata)).toBe(true)
+					expect(metadata).toEqual({
+						createdTime: expect.any(Number),
+						ttl: 1_000,
+						swr: 0,
+					})
+					expect(Reflect.set(metadata, 'ttl', Infinity)).toBe(false)
+					expect(Reflect.set(metadata, 'swr', Infinity)).toBe(false)
+					expect(Reflect.set(metadata, 'traceId', 'viewer-private-id')).toBe(
+						false,
+					)
+					return 'safe'
+				},
+			},
+			memoryCache,
+		)
+
+		const storedEntry = await memoryCache.get(key)
+		expect(storedEntry).toEqual({
+			metadata: {
+				createdTime: callbackCreatedTime,
+				ttl: 1_000,
+				swr: 0,
+			},
+			value: 'safe',
+		})
+	})
+
+	test('preserves Cachified callback symbol handlers', async () => {
+		const memoryCache = createMemoryCache()
+		const key = opaqueCacheKey()
+		await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key,
+				ttl: 1_000,
+				getFreshValue: () => 'cached',
+			},
+			memoryCache,
+		)
+
+		const batchLoader = vi.fn(async (parameters: string[]) =>
+			parameters.map(() => 'unexpected'),
+		)
+		const batch = createBatch(batchLoader, false)
+		const batchedFreshValue = batch.add('unused')
+		await expect(
+			cachifiedSafely(
+				'ranked-discovery',
+				{
+					key,
+					ttl: 1_000,
+					getFreshValue: batchedFreshValue,
+				},
+				memoryCache,
+			),
+		).resolves.toBe('cached')
+
+		const submitted = vi.fn()
+		void batch.submit().then(submitted)
+		await Promise.resolve()
+		await Promise.resolve()
+
+		expect(submitted).toHaveBeenCalledOnce()
+		expect(batchLoader).not.toHaveBeenCalled()
+	})
+
+	test('never falls back to a cached value after a forced refresh fails', async () => {
+		const memoryCache = createMemoryCache()
+		const key = opaqueCacheKey()
+		await cachifiedSafely(
+			'ranked-discovery',
+			{
+				key,
+				ttl: 1_000,
+				getFreshValue: () => 'cached',
+			},
+			memoryCache,
+		)
+
+		await expect(
+			cachifiedSafely(
+				'ranked-discovery',
+				{
+					key,
+					ttl: 1_000,
+					forceFresh: true,
+					getFreshValue() {
+						throw new Error('refresh failed')
+					},
+				},
+				memoryCache,
+			),
+		).rejects.toThrow('refresh failed')
 	})
 })

--- a/app/utils/cache.server.ts
+++ b/app/utils/cache.server.ts
@@ -1,4 +1,5 @@
-import fs from 'fs'
+import fs from 'node:fs'
+import path from 'node:path'
 import {
 	cachified as baseCachified,
 	verboseReporter,
@@ -7,87 +8,426 @@ import {
 	type Cache as CachifiedCache,
 	type CachifiedOptions,
 	type Cache,
-	totalTtl,
 	type CreateReporter,
+	type GetFreshValue,
 } from '@epic-web/cachified'
 import { remember } from '@epic-web/remember'
 import Database from 'better-sqlite3'
 import { LRUCache } from 'lru-cache'
 import { z } from 'zod'
+import {
+	canonicalCachePayload,
+	isOpaqueCacheKey,
+	type CanonicalCacheValue,
+	type OpaqueCacheKey,
+} from './cache-key.server.ts'
 import { cachifiedTimingReporter, type Timings } from './timing.server.ts'
 
-const CACHE_DATABASE_PATH = process.env.CACHE_DATABASE_PATH
+const DEFAULT_PRUNE_INTERVAL_MS = 60 * 60 * 1_000
+const DEFAULT_MAX_PRUNE_ROWS = 5_000
+const DEFAULT_MEMORY_MAX_ENTRIES = 5_000
+const DEFAULT_MEMORY_MAX_SIZE_BYTES = 32 * 1024 * 1024
+const DEFAULT_MEMORY_MAX_ENTRY_SIZE_BYTES = 512 * 1024
+const MAX_SQL_LIMIT = 100_000
+const SQLITE_MAX_FINITE_NUMBER = 1.7976931348623157e308
+export const SAFE_CACHE_MAX_TTL_MS = 5 * 60 * 1_000
 
-const cacheDb = remember('cacheDb', createDatabase)
-
-function createDatabase(tryAgain = true): Database.Database {
-	const db = new Database(CACHE_DATABASE_PATH)
-
-	try {
-		// create cache table with metadata JSON column and value JSON column if it does not exist already
-		db.exec(`
-			CREATE TABLE IF NOT EXISTS cache (
-				key TEXT PRIMARY KEY,
-				metadata TEXT,
-				value TEXT
-			)
-		`)
-		pruneDatabase(db)
-	} catch (error: unknown) {
-		fs.unlinkSync(CACHE_DATABASE_PATH)
-		if (tryAgain) {
-			console.error(
-				`Error creating cache database, deleting the file at "${CACHE_DATABASE_PATH}" and trying again...`,
-			)
-			return createDatabase(false)
-		}
-		throw error
-	}
-	return db
-}
-
-function pruneDatabase(db: Database.Database, now = Date.now()) {
-	const rows = db.prepare('SELECT key, metadata FROM cache').all() as Array<{
-		key: string
-		metadata: string
-	}>
-	const expiredKeys: string[] = []
-	for (const row of rows) {
-		try {
-			const metadata = JSON.parse(row.metadata) as {
-				createdTime?: unknown
-				ttl?: unknown
-				swr?: unknown
-			}
-			const createdTime = Number(metadata.createdTime)
-			const ttl = metadata.ttl == null ? Infinity : Number(metadata.ttl)
-			const swr = metadata.swr == null ? 0 : Number(metadata.swr)
-			if (
-				Number.isFinite(createdTime) &&
-				Number.isFinite(ttl) &&
-				Number.isFinite(swr) &&
-				createdTime + ttl + swr <= now
-			) {
-				expiredKeys.push(row.key)
-			}
-		} catch {
-			expiredKeys.push(row.key)
-		}
-	}
-	if (!expiredKeys.length) return 0
-	const remove = db.prepare('DELETE FROM cache WHERE key = ?')
-	db.transaction((keys: string[]) => {
-		for (const key of keys) remove.run(key)
-	})(expiredKeys)
-	return expiredKeys.length
-}
-
-const cacheCleanupTimer = remember('cache-cleanup-timer', () => {
-	const timer = setInterval(() => pruneDatabase(cacheDb), 60 * 60 * 1_000)
-	timer.unref()
-	return timer
+const cacheMetadataSchema = z
+	.object({
+		createdTime: z.number().finite(),
+		ttl: z.number().finite().nullable().optional(),
+		swr: z.number().finite().nullable().optional(),
+		swv: z.number().finite().nullable().optional(),
+		traceId: z.unknown().optional(),
+	})
+	.passthrough()
+const cacheEntrySchema = z.object({
+	metadata: cacheMetadataSchema,
+	value: z.unknown(),
 })
-void cacheCleanupTimer
+const cacheQueryResultSchema = z.object({
+	metadata: z.string(),
+	value: z.string(),
+})
+
+function normalizeSqlLimit(limit: number) {
+	if (!Number.isFinite(limit) || limit <= 0) return 0
+	return Math.min(Math.floor(limit), MAX_SQL_LIMIT)
+}
+
+function getCacheMetadataLifetime(metadata: {
+	ttl?: number | null
+	swr?: number | null
+	swv?: number | null
+}) {
+	// Old cache rows can predate the explicit `ttl: null` representation.
+	// Missing/null TTLs and explicit null stale windows are unbounded.
+	if (metadata.ttl == null) return Infinity
+	const staleWhileRevalidate =
+		metadata.swr === undefined ? metadata.swv : metadata.swr
+	if (staleWhileRevalidate === null) return Infinity
+	return metadata.ttl + (staleWhileRevalidate ?? 0)
+}
+
+function isCacheMetadataExpired(
+	metadata: {
+		createdTime: number
+		ttl?: number | null
+		swr?: number | null
+		swv?: number | null
+	},
+	now: number,
+) {
+	const lifetime = getCacheMetadataLifetime(metadata)
+	return Number.isFinite(lifetime) && metadata.createdTime + lifetime < now
+}
+
+export function initializeCacheDatabase(db: Database.Database) {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS cache (
+			key TEXT PRIMARY KEY,
+			metadata TEXT,
+			value TEXT
+		)
+	`)
+}
+
+export function pruneCacheDatabase(
+	db: Database.Database,
+	{
+		now = Date.now(),
+		limit = DEFAULT_MAX_PRUNE_ROWS,
+	}: {
+		now?: number
+		limit?: number
+	} = {},
+) {
+	const normalizedLimit = normalizeSqlLimit(limit)
+	if (!normalizedLimit) return 0
+	if (!Number.isFinite(now)) {
+		throw new RangeError('Cache prune time must be a finite number.')
+	}
+
+	// CASE expressions are evaluated lazily by SQLite. Keeping JSON validity
+	// checks first prevents malformed rows from reaching json_type/extract.
+	const result = db
+		.prepare(
+			`
+				DELETE FROM cache
+				WHERE key IN (
+					SELECT key
+					FROM cache
+					WHERE
+						CASE
+							WHEN json_valid(metadata) <> 1 THEN 1
+							WHEN json_valid(value) <> 1 THEN 1
+							WHEN json_type(metadata) <> 'object' THEN 1
+							WHEN COALESCE(
+								json_type(metadata, '$.createdTime') NOT IN ('integer', 'real'),
+								1
+							) THEN 1
+							WHEN abs(json_extract(metadata, '$.createdTime')) > @maxFinite THEN 1
+							WHEN json_type(metadata, '$.ttl') IS NOT NULL
+								AND json_type(metadata, '$.ttl') NOT IN ('null', 'integer', 'real')
+								THEN 1
+							WHEN json_type(metadata, '$.ttl') IN ('integer', 'real')
+								AND abs(json_extract(metadata, '$.ttl')) > @maxFinite
+								THEN 1
+							WHEN json_type(metadata, '$.swr') IS NOT NULL
+								AND json_type(metadata, '$.swr') NOT IN ('null', 'integer', 'real')
+								THEN 1
+							WHEN json_type(metadata, '$.swr') IN ('integer', 'real')
+								AND abs(json_extract(metadata, '$.swr')) > @maxFinite
+								THEN 1
+							WHEN json_type(metadata, '$.swv') IS NOT NULL
+								AND json_type(metadata, '$.swv') NOT IN ('null', 'integer', 'real')
+								THEN 1
+							WHEN json_type(metadata, '$.swv') IN ('integer', 'real')
+								AND abs(json_extract(metadata, '$.swv')) > @maxFinite
+								THEN 1
+							WHEN json_type(metadata, '$.ttl') IN ('integer', 'real')
+								AND json_type(metadata, '$.swr') IS NOT 'null'
+								AND NOT (
+									json_type(metadata, '$.swr') IS NULL
+									AND json_type(metadata, '$.swv') IS 'null'
+								)
+								AND (
+									json_extract(metadata, '$.createdTime')
+									+ json_extract(metadata, '$.ttl')
+									+ CASE
+										WHEN json_type(metadata, '$.swr') IN ('integer', 'real')
+											THEN json_extract(metadata, '$.swr')
+										WHEN json_type(metadata, '$.swr') IS NULL
+											AND json_type(metadata, '$.swv') IN ('integer', 'real')
+											THEN json_extract(metadata, '$.swv')
+										ELSE 0
+									END
+								) < @now
+								THEN 1
+							ELSE 0
+						END = 1
+					LIMIT @limit
+				)
+			`,
+		)
+		.run({
+			limit: normalizedLimit,
+			maxFinite: SQLITE_MAX_FINITE_NUMBER,
+			now,
+		})
+	return result.changes
+}
+
+export function createSqliteCacheAdapter(
+	db: Database.Database,
+	{ now = Date.now }: { now?: () => number } = {},
+): CachifiedCache {
+	const selectEntry = db.prepare(
+		'SELECT value, metadata FROM cache WHERE key = ?',
+	)
+	const deleteEntry = db.prepare('DELETE FROM cache WHERE key = ?')
+	const writeEntry = db.prepare(
+		'INSERT OR REPLACE INTO cache (key, value, metadata) VALUES (@key, @value, @metadata)',
+	)
+
+	return {
+		name: 'SQLite cache',
+		get(key) {
+			const result = selectEntry.get(key)
+			if (result == null) return null
+
+			const parseResult = cacheQueryResultSchema.safeParse(result)
+			if (!parseResult.success) {
+				deleteEntry.run(key)
+				return null
+			}
+
+			try {
+				const parsedEntry = cacheEntrySchema.safeParse({
+					metadata: JSON.parse(parseResult.data.metadata),
+					value: JSON.parse(parseResult.data.value),
+				})
+				if (!parsedEntry.success) {
+					deleteEntry.run(key)
+					return null
+				}
+
+				const entry = parsedEntry.data
+				if (isCacheMetadataExpired(entry.metadata, now())) {
+					deleteEntry.run(key)
+					return null
+				}
+				return {
+					metadata: entry.metadata,
+					value: entry.value,
+				}
+			} catch {
+				deleteEntry.run(key)
+				return null
+			}
+		},
+		async set(key, entry) {
+			writeEntry.run({
+				key,
+				value: JSON.stringify(entry.value),
+				metadata: JSON.stringify(entry.metadata),
+			})
+		},
+		async delete(key) {
+			deleteEntry.run(key)
+		},
+	}
+}
+
+function isSqliteCorruption(error: unknown) {
+	const code =
+		typeof error === 'object' && error !== null && 'code' in error
+			? (error as { code?: unknown }).code
+			: undefined
+	return (
+		typeof code === 'string' &&
+		(code === 'SQLITE_NOTADB' || code.startsWith('SQLITE_CORRUPT'))
+	)
+}
+
+function normalizeCacheDatabasePath(databasePath: string) {
+	if (!databasePath || databasePath.trim() !== databasePath) {
+		throw new Error(
+			'CACHE_DATABASE_PATH must be a non-empty path without surrounding whitespace.',
+		)
+	}
+	if (databasePath === ':memory:') return databasePath
+
+	const resolvedPath = path.resolve(databasePath)
+	if (
+		fs.existsSync(resolvedPath) &&
+		fs.lstatSync(resolvedPath).isSymbolicLink()
+	) {
+		throw new Error('CACHE_DATABASE_PATH must not point to a symbolic link.')
+	}
+	fs.mkdirSync(path.dirname(resolvedPath), { recursive: true, mode: 0o700 })
+	return resolvedPath
+}
+
+function closeDatabaseAfterFailure(db: Database.Database | undefined) {
+	if (!db?.open) return
+	try {
+		db.close()
+	} catch {
+		// Preserve the operation error which caused recovery.
+	}
+}
+
+function removeCorruptDatabaseFiles(databasePath: string) {
+	const mainStat = fs.lstatSync(databasePath)
+	if (!mainStat.isFile()) return false
+
+	for (const suffix of ['-journal', '-wal', '-shm', '']) {
+		const candidate = `${databasePath}${suffix}`
+		if (!fs.existsSync(candidate)) continue
+		const stat = fs.lstatSync(candidate)
+		if (stat.isFile()) fs.unlinkSync(candidate)
+	}
+	return true
+}
+
+function openPreparedCacheDatabase({
+	databasePath,
+	now,
+	maxPruneRows,
+	canRecover = true,
+}: {
+	databasePath: string
+	now: () => number
+	maxPruneRows: number
+	canRecover?: boolean
+}) {
+	const normalizedPath = normalizeCacheDatabasePath(databasePath)
+	let db: Database.Database | undefined
+	try {
+		db = new Database(normalizedPath)
+		initializeCacheDatabase(db)
+		if (normalizedPath !== ':memory:') fs.chmodSync(normalizedPath, 0o600)
+		const sqliteCache = createSqliteCacheAdapter(db, { now })
+		pruneCacheDatabase(db, {
+			now: now(),
+			limit: maxPruneRows,
+		})
+		return { db, sqliteCache }
+	} catch (error) {
+		closeDatabaseAfterFailure(db)
+
+		if (
+			!canRecover ||
+			normalizedPath === ':memory:' ||
+			!isSqliteCorruption(error)
+		) {
+			throw error
+		}
+
+		if (!removeCorruptDatabaseFiles(normalizedPath)) throw error
+		return openPreparedCacheDatabase({
+			databasePath: normalizedPath,
+			now,
+			maxPruneRows,
+			canRecover: false,
+		})
+	}
+}
+
+export type SqliteCacheResource = {
+	cache: CachifiedCache
+	prune: (now?: number, limit?: number) => number
+	clear: () => number
+	keys: (limit: number) => string[]
+	searchKeys: (search: string, limit: number) => string[]
+	close: () => void
+	readonly open: boolean
+}
+
+export function createSqliteCacheResource({
+	databasePath,
+	now = Date.now,
+	pruneIntervalMs = DEFAULT_PRUNE_INTERVAL_MS,
+	maxPruneRows = DEFAULT_MAX_PRUNE_ROWS,
+}: {
+	databasePath: string
+	now?: () => number
+	pruneIntervalMs?: number | null
+	maxPruneRows?: number
+}): SqliteCacheResource {
+	const normalizedMaxPruneRows = normalizeSqlLimit(maxPruneRows)
+	if (!normalizedMaxPruneRows) {
+		throw new RangeError('maxPruneRows must be a positive finite number.')
+	}
+	if (
+		pruneIntervalMs !== null &&
+		(!Number.isFinite(pruneIntervalMs) || pruneIntervalMs <= 0)
+	) {
+		throw new RangeError(
+			'pruneIntervalMs must be null or a positive finite number.',
+		)
+	}
+
+	const { db, sqliteCache } = openPreparedCacheDatabase({
+		databasePath,
+		now,
+		maxPruneRows: normalizedMaxPruneRows,
+	})
+	let closed = false
+	const prune = (pruneNow = now(), limit: number = normalizedMaxPruneRows) => {
+		if (closed || !db.open) return 0
+		return pruneCacheDatabase(db, { now: pruneNow, limit })
+	}
+
+	const cleanupTimer =
+		pruneIntervalMs === null
+			? null
+			: setInterval(() => {
+					try {
+						prune()
+					} catch (error) {
+						console.error('SQLite cache pruning failed.', error)
+					}
+				}, pruneIntervalMs)
+	cleanupTimer?.unref()
+
+	const close = () => {
+		if (closed) return
+		closed = true
+		if (cleanupTimer) clearInterval(cleanupTimer)
+		if (db.open) db.close()
+	}
+
+	return {
+		cache: sqliteCache,
+		prune,
+		clear() {
+			if (closed || !db.open) return 0
+			return db.prepare('DELETE FROM cache').run().changes
+		},
+		keys(limit) {
+			const normalizedLimit = normalizeSqlLimit(limit)
+			if (!normalizedLimit || closed) return []
+			return db
+				.prepare('SELECT key FROM cache LIMIT ?')
+				.all(normalizedLimit)
+				.map(row => (row as { key: string }).key)
+		},
+		searchKeys(search, limit) {
+			const normalizedLimit = normalizeSqlLimit(limit)
+			if (!normalizedLimit || closed) return []
+			return db
+				.prepare('SELECT key FROM cache WHERE key LIKE ? LIMIT ?')
+				.all(`%${search}%`, normalizedLimit)
+				.map(row => (row as { key: string }).key)
+		},
+		close,
+		get open() {
+			return !closed && db.open
+		},
+	}
+}
 
 export function createCacheResourceCloser({
 	clearTimer,
@@ -101,117 +441,605 @@ export function createCacheResourceCloser({
 	let closed = false
 	return () => {
 		if (closed) return
+		closed = true
 		clearTimer()
 		if (isDatabaseOpen()) closeDatabase()
-		closed = true
 	}
 }
 
-const closeCacheResourcesOnce = remember('cache-resource-closer', () =>
-	createCacheResourceCloser({
-		clearTimer: () => clearInterval(cacheCleanupTimer),
-		isDatabaseOpen: () => cacheDb.open,
-		closeDatabase: () => cacheDb.close(),
-	}),
+type CacheResourceState = {
+	resource: SqliteCacheResource | null
+	closed: boolean
+}
+
+const cacheResourceState = remember<CacheResourceState>(
+	'cache-resource-state-v2',
+	() => ({ resource: null, closed: false }),
 )
+
+function getSqliteCacheResource() {
+	if (cacheResourceState.closed) {
+		throw new Error('The SQLite cache resource has already been closed.')
+	}
+	if (!cacheResourceState.resource) {
+		cacheResourceState.resource = createSqliteCacheResource({
+			databasePath: process.env.CACHE_DATABASE_PATH ?? '',
+		})
+	}
+	return cacheResourceState.resource
+}
 
 export function closeCacheResources() {
-	closeCacheResourcesOnce()
+	if (cacheResourceState.closed) return
+	cacheResourceState.closed = true
+	cacheResourceState.resource?.close()
 }
 
-export function pruneExpiredCacheEntries(now = Date.now()) {
-	return pruneDatabase(cacheDb, now)
+export function pruneExpiredCacheEntries(
+	now = Date.now(),
+	limit = DEFAULT_MAX_PRUNE_ROWS,
+) {
+	return getSqliteCacheResource().prune(now, limit)
 }
 
-const lru = remember(
-	'lru-cache',
-	() => new LRUCache<string, CacheEntry<unknown>>({ max: 5000 }),
+export type MemoryCacheSnapshot = {
+	entries: number
+	calculatedSizeBytes: number
+	maxSizeBytes: number
+}
+
+export type InspectableMemoryCache = Cache & {
+	keys: (limit?: number) => string[]
+	deleteByPrefix: (prefix: string) => number
+	clear: () => void
+	snapshot: () => MemoryCacheSnapshot
+}
+
+function requirePositiveInteger(value: number, name: string) {
+	if (!Number.isSafeInteger(value) || value <= 0) {
+		throw new RangeError(`${name} must be a positive safe integer.`)
+	}
+	return value
+}
+
+export function createMemoryCache({
+	name = 'app-memory-cache',
+	maxEntries = DEFAULT_MEMORY_MAX_ENTRIES,
+	maxSizeBytes = DEFAULT_MEMORY_MAX_SIZE_BYTES,
+	maxEntrySizeBytes = DEFAULT_MEMORY_MAX_ENTRY_SIZE_BYTES,
+	now = Date.now,
+	monotonicNow,
+}: {
+	name?: string
+	maxEntries?: number
+	maxSizeBytes?: number
+	maxEntrySizeBytes?: number
+	now?: () => number
+	monotonicNow?: () => number
+} = {}): InspectableMemoryCache {
+	requirePositiveInteger(maxEntries, 'maxEntries')
+	requirePositiveInteger(maxSizeBytes, 'maxSizeBytes')
+	requirePositiveInteger(maxEntrySizeBytes, 'maxEntrySizeBytes')
+	if (maxEntrySizeBytes > maxSizeBytes) {
+		throw new RangeError('maxEntrySizeBytes must not exceed maxSizeBytes.')
+	}
+
+	const lru = new LRUCache<string, CacheEntry<unknown>>({
+		max: maxEntries,
+		maxSize: maxSizeBytes,
+		maxEntrySize: maxEntrySizeBytes,
+		perf: monotonicNow ? { now: monotonicNow } : undefined,
+		ttlResolution: monotonicNow ? 0 : 1,
+		sizeCalculation: (entry, key) => {
+			try {
+				const serialized = JSON.stringify(entry)
+				if (serialized === undefined) return maxEntrySizeBytes + 1
+				return Math.max(
+					1,
+					Buffer.byteLength(key, 'utf8') +
+						Buffer.byteLength(serialized, 'utf8'),
+				)
+			} catch {
+				return maxEntrySizeBytes + 1
+			}
+		},
+	})
+
+	return {
+		name,
+		set(key, entry) {
+			const createdTime = entry?.metadata?.createdTime
+			const lifetime = getCacheMetadataLifetime(entry?.metadata ?? {})
+			if (
+				!Number.isFinite(createdTime) ||
+				(lifetime !== Infinity && !Number.isFinite(lifetime))
+			) {
+				lru.delete(key)
+				return entry
+			}
+
+			const currentTime = now()
+			if (!Number.isFinite(currentTime)) {
+				lru.delete(key)
+				return entry
+			}
+			const remainingTtl =
+				lifetime === Infinity ? Infinity : createdTime + lifetime - currentTime
+			if (remainingTtl !== Infinity && remainingTtl < 0) {
+				lru.delete(key)
+				return entry
+			}
+
+			lru.set(key, entry, {
+				ttl: remainingTtl === Infinity ? undefined : Math.max(1, remainingTtl),
+			})
+			return entry
+		},
+		get(key) {
+			const entry = lru.get(key)
+			if (!entry) return
+			const currentTime = now()
+			if (
+				!Number.isFinite(currentTime) ||
+				isCacheMetadataExpired(entry.metadata, currentTime)
+			) {
+				lru.delete(key)
+				return
+			}
+			return entry
+		},
+		delete: key => lru.delete(key),
+		keys(limit = maxEntries) {
+			const normalizedLimit = normalizeSqlLimit(limit)
+			if (!normalizedLimit) return []
+			const keys: string[] = []
+			for (const key of lru.keys()) {
+				keys.push(key)
+				if (keys.length >= normalizedLimit) break
+			}
+			return keys
+		},
+		deleteByPrefix(prefix) {
+			let deleted = 0
+			for (const key of [...lru.keys()]) {
+				if (key.startsWith(prefix) && lru.delete(key)) deleted++
+			}
+			return deleted
+		},
+		clear: () => lru.clear(),
+		snapshot: () => ({
+			entries: lru.size,
+			calculatedSizeBytes: lru.calculatedSize,
+			maxSizeBytes,
+		}),
+	}
+}
+
+export const lruCache = remember<InspectableMemoryCache>(
+	'lru-cache-v2',
+	createMemoryCache,
 )
 
-export const lruCache = {
-	name: 'app-memory-cache',
-	set: (key, value) => {
-		const ttl = totalTtl(value?.metadata)
-		lru.set(key, value, {
-			ttl: ttl === Infinity ? undefined : ttl,
-			start: value?.metadata?.createdTime,
-		})
-		return value
-	},
-	get: key => lru.get(key),
-	delete: key => lru.delete(key),
-} satisfies Cache
-
-const cacheEntrySchema = z.object({
-	metadata: z.object({
-		createdTime: z.number(),
-		ttl: z.number().nullable().optional(),
-		swr: z.number().nullable().optional(),
-	}),
-	value: z.unknown(),
-})
-const cacheQueryResultSchema = z.object({
-	metadata: z.string(),
-	value: z.string(),
-})
+export function resetMemoryCacheForTest() {
+	if (process.env.NODE_ENV !== 'test') {
+		throw new Error('The memory cache can only be reset by the test runtime.')
+	}
+	lruCache.clear()
+}
 
 export const cache: CachifiedCache = {
 	name: 'SQLite cache',
 	get(key) {
-		const result = cacheDb
-			.prepare('SELECT value, metadata FROM cache WHERE key = ?')
-			.get(key)
-		const parseResult = cacheQueryResultSchema.safeParse(result)
-		if (!parseResult.success) return null
-
-		const parsedEntry = cacheEntrySchema.safeParse({
-			metadata: JSON.parse(parseResult.data.metadata),
-			value: JSON.parse(parseResult.data.value),
-		})
-		if (!parsedEntry.success) return null
-		const { metadata, value } = parsedEntry.data
-		if (!value) return null
-		const ttl = totalTtl(metadata)
-		if (Number.isFinite(ttl) && metadata.createdTime + ttl <= Date.now()) {
-			cacheDb.prepare('DELETE FROM cache WHERE key = ?').run(key)
-			return null
-		}
-		return { metadata, value }
+		return getSqliteCacheResource().cache.get(key)
 	},
-	async set(key, entry) {
-		cacheDb
-			.prepare(
-				'INSERT OR REPLACE INTO cache (key, value, metadata) VALUES (@key, @value, @metadata)',
-			)
-			.run({
-				key,
-				value: JSON.stringify(entry.value),
-				metadata: JSON.stringify(entry.metadata),
-			})
+	set(key, entry) {
+		return getSqliteCacheResource().cache.set(key, entry)
 	},
-	async delete(key) {
-		cacheDb.prepare('DELETE FROM cache WHERE key = ?').run(key)
+	delete(key) {
+		return getSqliteCacheResource().cache.delete(key)
 	},
 }
 
 export async function getAllCacheKeys(limit: number) {
 	return {
-		sqlite: cacheDb
-			.prepare('SELECT key FROM cache LIMIT ?')
-			.all(limit)
-			.map(row => (row as { key: string }).key),
-		lru: [...lru.keys()],
+		sqlite: getSqliteCacheResource().keys(limit),
+		lru: lruCache.keys(limit),
 	}
 }
 
 export async function searchCacheKeys(search: string, limit: number) {
 	return {
-		sqlite: cacheDb
-			.prepare('SELECT key FROM cache WHERE key LIKE ? LIMIT ?')
-			.all(`%${search}%`, limit)
-			.map(row => (row as { key: string }).key),
-		lru: [...lru.keys()].filter(key => key.includes(search)),
+		sqlite: getSqliteCacheResource().searchKeys(search, limit),
+		lru: lruCache
+			.keys()
+			.filter(key => key.includes(search))
+			.slice(0, normalizeSqlLimit(limit)),
 	}
+}
+
+export type CacheMetricEvent =
+	'hit' | 'miss' | 'refresh' | 'refresh-error' | 'write-error' | 'invalid'
+
+export type CacheMetricCounts = Record<CacheMetricEvent, number>
+export type CacheOperationsSnapshot = Readonly<
+	Record<string, Readonly<CacheMetricCounts>>
+>
+
+export const cacheMetricNamespaces = [
+	'ranked-discovery',
+	'recommendation-graph',
+] as const
+export type CacheMetricNamespace = (typeof cacheMetricNamespaces)[number]
+
+const cacheMetricNamespaceSet = new Set<string>(cacheMetricNamespaces)
+const cacheMetricEvents = [
+	'hit',
+	'miss',
+	'refresh',
+	'refresh-error',
+	'write-error',
+	'invalid',
+] as const satisfies readonly CacheMetricEvent[]
+
+const cacheOperations = remember<Map<string, CacheMetricCounts>>(
+	'cache-operations-v1',
+	() => new Map(),
+)
+
+function validateCacheMetricNamespace(
+	namespace: CacheMetricNamespace,
+): CacheMetricNamespace {
+	if (!cacheMetricNamespaceSet.has(namespace)) {
+		throw new Error(
+			'Cache metric namespace must be a registered static cache family.',
+		)
+	}
+	return namespace
+}
+
+function getCacheMetricCounts(namespace: CacheMetricNamespace) {
+	const existing = cacheOperations.get(namespace)
+	if (existing) return existing
+	const counts = Object.fromEntries(
+		cacheMetricEvents.map(event => [event, 0]),
+	) as CacheMetricCounts
+	cacheOperations.set(namespace, counts)
+	return counts
+}
+
+function incrementCacheMetric(
+	counts: CacheMetricCounts,
+	event: CacheMetricEvent,
+) {
+	counts[event] = Math.min(Number.MAX_SAFE_INTEGER, counts[event] + 1)
+}
+
+export function createSafeCacheReporter<Value = unknown>(
+	namespace: CacheMetricNamespace,
+): CreateReporter<Value> {
+	const safeNamespace = validateCacheMetricNamespace(namespace)
+	return () => event => {
+		const counts = getCacheMetricCounts(safeNamespace)
+		switch (event.name) {
+			case 'getCachedValueSuccess':
+				incrementCacheMetric(counts, 'hit')
+				break
+			case 'getCachedValueEmpty':
+				incrementCacheMetric(counts, 'miss')
+				break
+			case 'getFreshValueStart':
+			case 'refreshValueStart':
+				incrementCacheMetric(counts, 'refresh')
+				break
+			case 'getFreshValueError':
+			case 'refreshValueError':
+				incrementCacheMetric(counts, 'refresh-error')
+				break
+			case 'writeFreshValueError':
+				incrementCacheMetric(counts, 'write-error')
+				break
+			case 'checkFreshValueErrorObj':
+			case 'checkCachedValueErrorObj':
+			case 'getCachedValueError':
+				incrementCacheMetric(counts, 'invalid')
+				break
+		}
+	}
+}
+
+export function getCacheOperationsSnapshot(): CacheOperationsSnapshot {
+	return Object.fromEntries(
+		[...cacheOperations.entries()]
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([namespace, counts]) => [namespace, { ...counts }]),
+	)
+}
+
+export function resetCacheOperationsForTest() {
+	cacheOperations.clear()
+}
+
+export function resetCacheResourcesForTest() {
+	if (process.env.NODE_ENV !== 'test') {
+		throw new Error('Cache resources can only be reset by the test runtime.')
+	}
+	lruCache.clear()
+	cacheOperations.clear()
+	cacheResourceState.resource?.clear()
+}
+
+function addSafeTiming(timings: Timings, type: string, start: number) {
+	const timing = timings[type] ?? (timings[type] = [])
+	timing.push({ time: performance.now() - start })
+}
+
+function createSafeTimingReporter<Value>(
+	namespace: CacheMetricNamespace,
+	timings?: Timings,
+): CreateReporter<Value> | undefined {
+	if (!timings) return
+	const safeNamespace = validateCacheMetricNamespace(namespace)
+	return () => {
+		const retrievalStart = performance.now()
+		let freshValueStart: number | undefined
+		return event => {
+			switch (event.name) {
+				case 'getFreshValueStart':
+					freshValueStart = performance.now()
+					break
+				case 'getFreshValueSuccess':
+				case 'getFreshValueError':
+					if (freshValueStart !== undefined) {
+						addSafeTiming(
+							timings,
+							`getFreshValue:${safeNamespace}`,
+							freshValueStart,
+						)
+						freshValueStart = undefined
+					}
+					break
+				case 'done':
+					addSafeTiming(timings, `cache:${safeNamespace}`, retrievalStart)
+					break
+			}
+		}
+	}
+}
+
+type UnsafePrivateCacheOption =
+	| 'cache'
+	| 'fallbackToCache'
+	| 'staleRefreshTimeout'
+	| 'staleWhileRevalidate'
+	| 'swr'
+	| 'traceId'
+
+export type SafeCachifiedOptions<Value extends CanonicalCacheValue> = Omit<
+	CachifiedOptions<Value>,
+	UnsafePrivateCacheOption | 'key' | 'ttl'
+> & {
+	key: OpaqueCacheKey
+	ttl: number
+	timings?: Timings
+}
+
+const forbiddenSafeCacheOptions = [
+	'cache',
+	'fallbackToCache',
+	'staleRefreshTimeout',
+	'staleWhileRevalidate',
+	'swr',
+	'traceId',
+] as const satisfies readonly UnsafePrivateCacheOption[]
+
+function assertInspectableMemoryCache(
+	value: unknown,
+): asserts value is InspectableMemoryCache {
+	if (
+		typeof value !== 'object' ||
+		value === null ||
+		!('get' in value) ||
+		typeof value.get !== 'function' ||
+		!('set' in value) ||
+		typeof value.set !== 'function' ||
+		!('delete' in value) ||
+		typeof value.delete !== 'function' ||
+		!('keys' in value) ||
+		typeof value.keys !== 'function' ||
+		!('deleteByPrefix' in value) ||
+		typeof value.deleteByPrefix !== 'function' ||
+		!('clear' in value) ||
+		typeof value.clear !== 'function' ||
+		!('snapshot' in value) ||
+		typeof value.snapshot !== 'function'
+	) {
+		throw new TypeError(
+			'Safe cache test overrides must be inspectable memory caches.',
+		)
+	}
+}
+
+function validateSafeCacheTtl(ttl: unknown) {
+	if (
+		typeof ttl !== 'number' ||
+		!Number.isFinite(ttl) ||
+		ttl <= 0 ||
+		ttl > SAFE_CACHE_MAX_TTL_MS
+	) {
+		throw new RangeError(
+			`Safe cache ttl must be finite, positive, and no greater than ${SAFE_CACHE_MAX_TTL_MS} milliseconds.`,
+		)
+	}
+	return ttl
+}
+
+function deepFreezeCanonicalCacheValue(
+	value: CanonicalCacheValue,
+): CanonicalCacheValue {
+	if (value === null || typeof value !== 'object') return value
+	if (Array.isArray(value)) {
+		for (const child of value as readonly CanonicalCacheValue[]) {
+			deepFreezeCanonicalCacheValue(child)
+		}
+	} else {
+		for (const child of Object.values(
+			value as Readonly<Record<string, CanonicalCacheValue>>,
+		)) {
+			deepFreezeCanonicalCacheValue(child)
+		}
+	}
+	return Object.freeze(value)
+}
+
+function cloneAndFreezeCanonicalCacheValue<Value extends CanonicalCacheValue>(
+	value: Value,
+): Value {
+	const canonical = canonicalCachePayload(value)
+	if (value === null || typeof value !== 'object') return value
+	return deepFreezeCanonicalCacheValue(
+		JSON.parse(canonical) as CanonicalCacheValue,
+	) as Value
+}
+
+function cloneSafeCacheMetadata(metadata: CacheEntry['metadata']) {
+	if (!Number.isFinite(metadata.createdTime)) {
+		throw new TypeError('Safe cache metadata must have a finite creation time.')
+	}
+	const ttl = validateSafeCacheTtl(metadata.ttl)
+	if (metadata.swr !== 0) {
+		throw new TypeError('Safe cache metadata must not use stale revalidation.')
+	}
+	return Object.freeze({
+		createdTime: metadata.createdTime,
+		ttl,
+		swr: 0,
+	})
+}
+
+function cloneSafeCacheEntry<Value extends CanonicalCacheValue>(
+	entry: CacheEntry<Value>,
+): CacheEntry<Value> {
+	return Object.freeze({
+		metadata: cloneSafeCacheMetadata(entry.metadata),
+		value: cloneAndFreezeCanonicalCacheValue(entry.value),
+	})
+}
+
+const safeMemoryCacheFacades = remember<
+	WeakMap<InspectableMemoryCache, Cache<CanonicalCacheValue>>
+>('safe-memory-cache-facades-v1', () => new WeakMap())
+
+function getSafeMemoryCacheFacade(
+	memoryCache: InspectableMemoryCache,
+): Cache<CanonicalCacheValue> {
+	const existing = safeMemoryCacheFacades.get(memoryCache)
+	if (existing) return existing
+
+	const safeCache: Cache<CanonicalCacheValue> = {
+		name: memoryCache.name,
+		async get(key) {
+			const entry = await memoryCache.get(key)
+			if (entry == null) return entry
+			return cloneSafeCacheEntry(entry as CacheEntry<CanonicalCacheValue>)
+		},
+		set(key, entry) {
+			return memoryCache.set(key, cloneSafeCacheEntry(entry))
+		},
+		delete(key) {
+			return memoryCache.delete(key)
+		},
+	}
+	safeMemoryCacheFacades.set(memoryCache, safeCache)
+	return safeCache
+}
+
+function createSafeCheckValue<Value extends CanonicalCacheValue>(
+	checkValue: CachifiedOptions<Value>['checkValue'],
+): CachifiedOptions<Value>['checkValue'] {
+	if (typeof checkValue !== 'function') return checkValue
+	return (value, migrate) =>
+		checkValue(value, (migratedValue, updateCache) =>
+			migrate(cloneAndFreezeCanonicalCacheValue(migratedValue), updateCache),
+		)
+}
+
+function createSafeGetFreshValue<Value extends CanonicalCacheValue>(
+	getFreshValue: GetFreshValue<Value>,
+	ttl: number,
+): GetFreshValue<Value> {
+	const wrappedGetFreshValue: GetFreshValue<Value> = async context => {
+		const metadata = Object.freeze({
+			createdTime: context.metadata.createdTime,
+			ttl,
+			swr: 0,
+		})
+		return cloneAndFreezeCanonicalCacheValue(
+			await getFreshValue({
+				background: context.background,
+				metadata,
+			}),
+		)
+	}
+
+	for (const symbol of Object.getOwnPropertySymbols(getFreshValue)) {
+		const descriptor = Object.getOwnPropertyDescriptor(getFreshValue, symbol)
+		if (descriptor) {
+			Object.defineProperty(wrappedGetFreshValue, symbol, descriptor)
+		}
+	}
+
+	return wrappedGetFreshValue
+}
+
+export async function cachifiedSafely<Value extends CanonicalCacheValue>(
+	namespace: CacheMetricNamespace,
+	safeOptions: SafeCachifiedOptions<Value>,
+	memoryCache: InspectableMemoryCache = lruCache,
+): Promise<Value> {
+	const safeNamespace = validateCacheMetricNamespace(namespace)
+	const rawOptions = safeOptions as unknown as Record<string, unknown>
+	for (const option of forbiddenSafeCacheOptions) {
+		if (Object.hasOwn(rawOptions, option)) {
+			throw new TypeError(`Safe cache options must not include "${option}".`)
+		}
+	}
+	assertInspectableMemoryCache(memoryCache)
+	if (memoryCache !== lruCache && process.env.NODE_ENV !== 'test') {
+		throw new TypeError(
+			'Safe cache overrides are available only in the test runtime.',
+		)
+	}
+
+	const { timings, key, ttl, getFreshValue, checkValue, ...options } =
+		safeOptions
+	if (!isOpaqueCacheKey(key, safeNamespace)) {
+		throw new TypeError(
+			'Opaque cache key does not match the registered cache namespace.',
+		)
+	}
+	const validatedTtl = validateSafeCacheTtl(ttl)
+	const safeGetFreshValue = createSafeGetFreshValue(getFreshValue, validatedTtl)
+	const safeCheckValue = createSafeCheckValue(checkValue)
+	const safeCache = getSafeMemoryCacheFacade(memoryCache)
+
+	const value = await baseCachified(
+		{
+			...options,
+			key,
+			getFreshValue: safeGetFreshValue,
+			checkValue: safeCheckValue,
+			cache: safeCache,
+			fallbackToCache: false,
+			staleWhileRevalidate: 0,
+			swr: 0,
+			ttl: validatedTtl,
+		},
+		mergeReporters(
+			createSafeTimingReporter<Value>(safeNamespace, timings),
+			createSafeCacheReporter<Value>(safeNamespace),
+		),
+	)
+	return cloneAndFreezeCanonicalCacheValue(value)
 }
 
 export async function cachified<Value>(

--- a/app/utils/env.server.test.ts
+++ b/app/utils/env.server.test.ts
@@ -172,3 +172,28 @@ describe('environment cryptographic secrets', () => {
 		).toBe(true)
 	})
 })
+
+describe('cache database path', () => {
+	test.each([
+		['empty', ''],
+		['whitespace-only', '   '],
+		['leading whitespace', ' other/cache.db'],
+		['trailing whitespace', 'other/cache.db '],
+		['leading newline', '\nother/cache.db'],
+	])('rejects an %s path', (_label, CACHE_DATABASE_PATH) => {
+		expect(
+			fieldErrors(productionEnvironment({ CACHE_DATABASE_PATH }))
+				.CACHE_DATABASE_PATH,
+		).toBeDefined()
+	})
+
+	test.each(['other/cache.db', '/var/lib/veud/cache.db', ':memory:'])(
+		'accepts the nonblank path %s',
+		CACHE_DATABASE_PATH => {
+			expect(
+				parseEnvironment(productionEnvironment({ CACHE_DATABASE_PATH }))
+					.success,
+			).toBe(true)
+		},
+	)
+})

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -12,7 +12,13 @@ const schema = z
 		VERIFICATION_SECRET_KEYS: z.string().optional(),
 		INTERNAL_COMMAND_TOKEN: z.string(),
 		HONEYPOT_SECRET: z.string(),
-		CACHE_DATABASE_PATH: z.string(),
+		CACHE_DATABASE_PATH: z
+			.string()
+			.min(1)
+			.refine(
+				value => value.trim().length > 0 && value === value.trim(),
+				'CACHE_DATABASE_PATH must be non-empty and have no surrounding whitespace.',
+			),
 		// If you plan on using Sentry, uncomment this line
 		// SENTRY_DSN: z.string(),
 		// If you plan to use Resend, uncomment this line

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,7 @@ process.env.SESSION_SECRET = E2E_SESSION_SECRET
 process.env.VERIFICATION_SECRET_KEYS = ''
 process.env.INTERNAL_COMMAND_TOKEN = ''
 process.env.HONEYPOT_SECRET = E2E_HONEYPOT_SECRET
+process.env.CACHE_DATABASE_PATH = ':memory:'
 
 export default defineConfig({
 	testDir: './tests/e2e',
@@ -58,6 +59,7 @@ export default defineConfig({
 			VERIFICATION_SECRET_KEYS: '',
 			INTERNAL_COMMAND_TOKEN: '',
 			HONEYPOT_SECRET: E2E_HONEYPOT_SECRET,
+			CACHE_DATABASE_PATH: ':memory:',
 			VEUD_E2E: '1',
 			// The server runs in production mode, so this marker is what relaxes
 			// rate limits enough for a full browser suite from one address.

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -12,6 +12,7 @@ const databasePath = path.join(process.cwd(), databaseFile)
 // DATABASE_URL). Without it the test DB uses a multi-connection pool and a read can
 // miss a write just committed on another pooled connection.
 process.env.DATABASE_URL = `file:${databasePath}?connection_limit=1`
+process.env.CACHE_DATABASE_PATH = ':memory:'
 
 beforeAll(async () => {
 	await fsExtra.copyFile(BASE_DATABASE_PATH, databasePath)
@@ -22,7 +23,10 @@ beforeAll(async () => {
 afterEach(async () => {
 	const { prisma } = await import('#app/utils/db.server.ts')
 	const { cleanupDb } = await import('#tests/db-utils.ts')
+	const { resetCacheResourcesForTest } =
+		await import('#app/utils/cache.server.ts')
 	await cleanupDb(prisma)
+	resetCacheResourcesForTest()
 })
 
 afterAll(async () => {

--- a/tests/setup/playwright-server.ts
+++ b/tests/setup/playwright-server.ts
@@ -5,6 +5,8 @@ import {
 	removePlaywrightDatabase,
 } from './playwright-database.ts'
 
+process.env.CACHE_DATABASE_PATH = ':memory:'
+
 // Playwright starts the production server, so always build the current source.
 // Without this, direct `playwright test` runs can silently exercise an old build.
 await execa('npm', ['run', 'build'], {
@@ -19,6 +21,7 @@ const server = execa('npm', ['run', 'start:mocks'], {
 	env: {
 		...process.env,
 		DATABASE_URL: PLAYWRIGHT_DATABASE_URL,
+		CACHE_DATABASE_PATH: ':memory:',
 		VEUD_E2E: '1',
 	},
 })


### PR DESCRIPTION
## Summary
- fix wall-clock TTL/SWR restoration and bound the in-memory cache by entries and bytes
- make the SQLite cache lazy, securely permissioned, corruption-aware, falsey-safe, and SQL-pruned in bounded batches
- add opaque canonical public/viewer cache keys and a memory-only ranked-cache API with immutable bounded payloads and aggregate-only metrics
- isolate Vitest and Playwright cache storage and validate cache configuration

This intentionally establishes the safe foundation for PERF-003 without activating ranked discovery or personalized recommendation-graph caching yet.

## Validation
- 161 Vitest files / 815 tests with coverage
- icons, ESLint, React Router type generation, and TypeScript
- production client/SSR/server builds and all bundle budgets
- production-mode SQLite lazy-import, permission, reopen, falsey-value, and close smoke
- 97 Chromium scenarios
- three independent publication-clear reviews
