### PR TITLE
Cache bounded ranked discovery plans

### DIFF
--- a/app/routes/discover.route.test.ts
+++ b/app/routes/discover.route.test.ts
@@ -2,11 +2,30 @@ import { faker } from '@faker-js/faker'
 import { afterEach, expect, test, vi } from 'vitest'
 import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import * as discoveryServer from '#app/utils/discovery.server.ts'
 import { type NaturalLanguageDiscoveryPlan } from '#app/utils/natural-language-discovery.ts'
+import * as recommendationGraphServer from '#app/utils/recommendation-graph.server.ts'
 import { BASE_URL, getSessionCookieHeader } from '#tests/utils.ts'
 import { action, loader } from './discover.tsx'
 
+vi.mock('#app/utils/discovery.server.ts', async importOriginal => {
+	const actual = (await importOriginal()) as typeof discoveryServer
+	return {
+		...actual,
+		getDiscoveryResults: vi.fn(actual.getDiscoveryResults),
+	}
+})
+
+vi.mock('#app/utils/recommendation-graph.server.ts', async importOriginal => {
+	const actual = (await importOriginal()) as typeof recommendationGraphServer
+	return {
+		...actual,
+		getRecommendationGraph: vi.fn(actual.getRecommendationGraph),
+	}
+})
+
 afterEach(() => {
+	vi.clearAllMocks()
 	vi.unstubAllEnvs()
 	vi.unstubAllGlobals()
 })
@@ -58,7 +77,7 @@ test('anonymous discovery loads filters and falls back from personalized ranking
 	expect(result.data.genres).toEqual(['Drama'])
 })
 
-test('signed-in discovery returns unseen personalized results', async () => {
+test('signed-in discovery returns unseen recommendation graph results', async () => {
 	const viewer = await createUser('discover_viewer')
 	const listType = await prisma.listType.upsert({
 		where: { name: 'anime' },
@@ -116,8 +135,12 @@ test('signed-in discovery returns unseen personalized results', async () => {
 	} as any)
 
 	expect(result.data.isSignedIn).toBe(true)
-	expect(result.data.preferredGenres).toEqual(['Fantasy'])
-	expect(result.data.items.map(item => item.id)).toEqual([unseen.id])
+	expect(result.data.items).toEqual([])
+	expect(
+		result.data.recommendationGraph?.lanes
+			.flatMap(lane => lane.items)
+			.map(item => item.id),
+	).toContain(unseen.id)
 
 	await prisma.recommendationFeedback.create({
 		data: {
@@ -137,6 +160,87 @@ test('signed-in discovery returns unseen personalized results', async () => {
 	expect(afterFeedback.data.recommendationGraph?.hiddenItems).toEqual([
 		expect.objectContaining({ id: unseen.id }),
 	])
+})
+
+test('recommendation graph-only state skips discovery while variants retain it', async () => {
+	const viewer = await createUser('discover_graph_only')
+	const cookie = await cookieFor(viewer.id)
+	const getDiscoveryResults = vi.mocked(discoveryServer.getDiscoveryResults)
+	const getRecommendationGraph = vi.mocked(
+		recommendationGraphServer.getRecommendationGraph,
+	)
+
+	const graphOnly = await loader({
+		request: new Request(`${BASE_URL}/discover?sort=for-you`, {
+			headers: { cookie },
+		}),
+		params: {},
+	} as any)
+
+	expect(getDiscoveryResults).not.toHaveBeenCalled()
+	expect(getRecommendationGraph).toHaveBeenCalledOnce()
+	expect(getRecommendationGraph).toHaveBeenCalledWith(viewer.id)
+	expect(graphOnly.data.recommendationGraph).not.toBeNull()
+	expect(graphOnly.data).toEqual(
+		expect.objectContaining({
+			items: [],
+			total: 0,
+			pageCount: 1,
+			preferredGenres: [],
+			filters: expect.objectContaining({
+				mode: 'standard',
+				kind: 'all',
+				sort: 'for-you',
+				page: 1,
+			}),
+		}),
+	)
+
+	const variants = [
+		['query', 'sort=for-you&q=clue', true],
+		['mode', 'sort=for-you&mode=memory', false],
+		['kind', 'sort=for-you&kind=movie', true],
+		['genre', 'sort=for-you&genre=Drama', true],
+		['year', 'sort=for-you&year=2026', true],
+		['status', 'sort=for-you&status=Released', true],
+		['provider', 'sort=for-you&provider=tmdb', true],
+		['sort', 'sort=popular', true],
+		['page', 'sort=for-you&page=2', true],
+	] as const
+	for (const [label, search, callsDiscovery] of variants) {
+		const discoveryCalls = getDiscoveryResults.mock.calls.length
+		const graphCalls = getRecommendationGraph.mock.calls.length
+		const result = await loader({
+			request: new Request(`${BASE_URL}/discover?${search}`, {
+				headers: { cookie },
+			}),
+			params: {},
+		} as any)
+
+		expect(
+			result.data.recommendationGraph,
+			`${label} must disable the recommendation graph`,
+		).toBeNull()
+		expect(getRecommendationGraph).toHaveBeenCalledTimes(graphCalls)
+		expect(getDiscoveryResults).toHaveBeenCalledTimes(
+			discoveryCalls + Number(callsDiscovery),
+		)
+	}
+
+	const discoveryCalls = getDiscoveryResults.mock.calls.length
+	const graphCalls = getRecommendationGraph.mock.calls.length
+	const anonymous = await loader({
+		request: new Request(`${BASE_URL}/discover?sort=for-you`),
+		params: {},
+	} as any)
+	expect(anonymous.data.isSignedIn).toBe(false)
+	expect(anonymous.data.recommendationGraph).toBeNull()
+	expect(getRecommendationGraph).toHaveBeenCalledTimes(graphCalls)
+	expect(getDiscoveryResults).toHaveBeenCalledTimes(discoveryCalls + 1)
+	expect(getDiscoveryResults).toHaveBeenLastCalledWith(
+		expect.objectContaining({ sort: 'for-you' }),
+		null,
+	)
 })
 
 test('memory-search GET remains local even when AI is configured', async () => {

--- a/app/routes/discover.tsx
+++ b/app/routes/discover.tsx
@@ -38,6 +38,7 @@ import {
 	getDiscoveryStatuses,
 	parseDiscoveryQuery,
 	type DiscoveryQuery,
+	type DiscoveryResults,
 } from '#app/utils/discovery.server.ts'
 import { splitLegacyThumbnail } from '#app/utils/media-detail.ts'
 import {
@@ -332,7 +333,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 		discoverySession && discoverySession.currentStep > 0
 			? (sessionPlans[discoverySession.currentStep - 1] ?? null)
 			: null
-	const recommendationGraphPromise =
+	const rendersRecommendationGraph = Boolean(
 		viewerId &&
 		filters.mode === 'standard' &&
 		!filters.q &&
@@ -342,7 +343,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 		!filters.status &&
 		filters.provider === 'all' &&
 		filters.sort === 'for-you' &&
-		filters.page === 1
+		filters.page === 1,
+	)
+	const recommendationGraphPromise =
+		rendersRecommendationGraph && viewerId
 			? getRecommendationGraph(viewerId)
 			: Promise.resolve(null)
 	const memoryQueryTooShort = filters.mode === 'memory' && filters.q.length < 3
@@ -401,7 +405,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
 						viewerId,
 						memorySearch.matches.map(match => match.mediaId),
 					)
-				: getDiscoveryResults(filters, viewerId),
+				: rendersRecommendationGraph
+					? Promise.resolve({
+							filters,
+							items: [],
+							total: 0,
+							pageCount: 1,
+							preferredGenres: [],
+						} satisfies DiscoveryResults)
+					: getDiscoveryResults(filters, viewerId),
 		genresPromise,
 		statusesPromise,
 		watchlistsPromise,

--- a/app/utils/discovery.server.test.ts
+++ b/app/utils/discovery.server.test.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
+import { getCacheOperationsSnapshot } from './cache.server.ts'
 import { prisma } from './db.server.ts'
 import {
 	getDiscoveryGenres,
@@ -63,6 +64,128 @@ test('discovery query parsing bounds input and replaces invalid options', () => 
 		sort: 'popular',
 		page: 1,
 	})
+})
+
+test('cached plans still hydrate catalog and viewer state freshly', async () => {
+	vi.stubEnv('NODE_ENV', 'production')
+	vi.stubEnv('VEUD_E2E', '0')
+	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
+	const query = `Fresh hydration ${suffix}`
+
+	try {
+		const [staleCatalogItem, trackedItem, ...fillers] = await Promise.all([
+			prisma.media.create({
+				data: {
+					kind: 'movie',
+					title: `${query} 000 stale`,
+					genres: 'Drama',
+					catalogPopularity: 20,
+				},
+			}),
+			prisma.media.create({
+				data: {
+					kind: 'movie',
+					title: `${query} 001 tracked`,
+					genres: 'Drama',
+					catalogPopularity: 10,
+				},
+			}),
+			...Array.from({ length: 23 }, (_, index) =>
+				prisma.media.create({
+					data: {
+						kind: 'movie',
+						title: `${query} ${String(index + 2).padStart(3, '0')} filler`,
+						genres: 'Drama',
+					},
+				}),
+			),
+		])
+		const publicFilters = filters({
+			q: query,
+			kind: 'movie',
+			sort: 'popular',
+		})
+		const initial = await getDiscoveryResults(publicFilters, null)
+		expect(initial.items.map(item => item.id)).toEqual(
+			expect.arrayContaining([staleCatalogItem.id, trackedItem.id]),
+		)
+		expect(initial.items).toHaveLength(24)
+		expect(initial.total).toBe(25)
+
+		const viewer = await createUser('fresh_hydration')
+		await Promise.all([
+			prisma.media.update({
+				where: { id: staleCatalogItem.id },
+				data: { title: `Removed from ${suffix}` },
+			}),
+			prisma.trackingState.create({
+				data: {
+					ownerId: viewer.id,
+					mediaId: trackedItem.id,
+					status: 'watching',
+				},
+			}),
+		])
+
+		const hydrated = await getDiscoveryResults(publicFilters, viewer.id)
+		expect(hydrated.items.map(item => item.id)).toEqual(
+			expect.arrayContaining([trackedItem.id, ...fillers.map(item => item.id)]),
+		)
+		expect(hydrated.items).toHaveLength(24)
+		expect(hydrated.total).toBe(24)
+		expect(hydrated.pageCount).toBe(1)
+		expect(hydrated.items[0]?.viewerTracking).toEqual({
+			status: 'watching',
+			statusWatchlistId: null,
+		})
+		expect(getCacheOperationsSnapshot()['ranked-discovery']).toMatchObject({
+			hit: 1,
+			miss: 1,
+			refresh: 1,
+		})
+
+		const personalizedQuery = `Viewer exclusion ${suffix}`
+		const exclusionTarget = await prisma.media.create({
+			data: {
+				kind: 'movie',
+				title: `${personalizedQuery} target`,
+				genres: 'Drama',
+				catalogPopularity: 5,
+			},
+		})
+		const personalizedFilters = filters({
+			q: personalizedQuery,
+			kind: 'movie',
+			sort: 'for-you',
+		})
+		const beforeExclusion = await getDiscoveryResults(
+			personalizedFilters,
+			viewer.id,
+		)
+		expect(beforeExclusion.items.map(item => item.id)).toContain(
+			exclusionTarget.id,
+		)
+		expect(beforeExclusion.total).toBe(1)
+
+		await prisma.recommendationFeedback.create({
+			data: {
+				ownerId: viewer.id,
+				mediaId: exclusionTarget.id,
+				feedbackType: 'not_interested',
+			},
+		})
+		const afterExclusion = await getDiscoveryResults(
+			personalizedFilters,
+			viewer.id,
+		)
+		expect(afterExclusion.items.map(item => item.id)).not.toContain(
+			exclusionTarget.id,
+		)
+		expect(afterExclusion.total).toBe(0)
+		expect(afterExclusion.pageCount).toBe(1)
+	} finally {
+		vi.unstubAllEnvs()
+	}
 })
 
 test('grounded media IDs preserve candidate order and ignore stale search filters', async () => {
@@ -387,6 +510,39 @@ test('anime and manga popularity use MAL rank without score or community reshuff
 				trackerCount: 1,
 			}),
 		)
+
+		const duplicateKindPlan: NaturalLanguageDiscoveryPlan = {
+			kinds: [kind, kind],
+			includeGenres: [],
+			excludeGenres: [],
+			includeTerms: [],
+			excludeTerms: [],
+			yearFrom: null,
+			yearTo: null,
+			releaseStatus: null,
+			language: null,
+			toneTerms: [],
+			pace: null,
+			lengthUnit: null,
+			lengthFrom: null,
+			lengthTo: null,
+			sort: 'popular',
+			explanation: `Popular ${kind} with a duplicated kind constraint.`,
+			unsupportedConstraints: [],
+		}
+		const naturalResult = await getDiscoveryResultsForPlan(
+			duplicateKindPlan,
+			null,
+			{
+				page: 1,
+				filters: filters({ mode: 'describe', kind }),
+			},
+		)
+		expect(naturalResult.items.map(item => item.id)).toEqual([
+			rankOne.id,
+			rankTwo.id,
+			unranked.id,
+		])
 	}
 })
 
@@ -872,4 +1028,174 @@ test('favorites teach for-you preferences and stay out of its results', async ()
 		mismatch.id,
 	])
 	expect(result.items.some(item => item.id === favoriteSeed.id)).toBe(false)
+})
+
+test('natural for-you ranks globally and applies every fresh viewer exclusion', async () => {
+	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
+	const viewer = await createUser('natural_for_you_viewer')
+	const listType = await prisma.listType.create({
+		data: {
+			name: `natural-for-you-${suffix}`,
+			header: 'Natural for you',
+			columns: '{}',
+			mediaType: '["movie"]',
+			completionType: '{}',
+		},
+	})
+	await prisma.media.createMany({
+		data: Array.from({ length: 24 }, (_, index) => ({
+			kind: 'movie',
+			title: `Natural filler ${suffix} ${String(index + 1).padStart(2, '0')}`,
+			genres: 'Comedy',
+			catalogPopularity: 10_000 - index,
+		})),
+	})
+	const fillers = await prisma.media.findMany({
+		where: { title: { contains: `Natural filler ${suffix}` } },
+		orderBy: [{ title: 'asc' }],
+		select: { id: true },
+	})
+	const [trackedSeed, favoriteSeed, feedbackSeed, affinityMatch] =
+		await Promise.all([
+			prisma.media.create({
+				data: {
+					kind: 'movie',
+					title: `Natural tracked seed ${suffix}`,
+					genres: 'Mystery',
+					catalogPopularity: 20_000,
+				},
+			}),
+			prisma.media.create({
+				data: {
+					kind: 'movie',
+					title: `Natural favorite seed ${suffix}`,
+					genres: 'Mystery',
+					catalogPopularity: 19_000,
+				},
+			}),
+			prisma.media.create({
+				data: {
+					kind: 'movie',
+					title: `Natural feedback seed ${suffix}`,
+					genres: 'Mystery',
+					catalogPopularity: 18_000,
+				},
+			}),
+			prisma.media.create({
+				data: {
+					kind: 'movie',
+					title: `Natural global affinity ${suffix}`,
+					genres: 'Mystery',
+					catalogPopularity: 1,
+				},
+			}),
+		])
+	await Promise.all([
+		prisma.trackingState.create({
+			data: {
+				ownerId: viewer.id,
+				mediaId: trackedSeed.id,
+				status: 'completed',
+				score: 10,
+			},
+		}),
+		prisma.userFavorite.create({
+			data: {
+				ownerId: viewer.id,
+				mediaId: favoriteSeed.id,
+				typeId: listType.id,
+				position: 1,
+				title: favoriteSeed.title ?? 'Favorite seed',
+			},
+		}),
+		prisma.recommendationFeedback.create({
+			data: {
+				ownerId: viewer.id,
+				mediaId: feedbackSeed.id,
+				feedbackType: 'not-interested',
+			},
+		}),
+		prisma.catalogFeedItem.createMany({
+			data: [
+				...fillers.map((item, index) => ({
+					provider: 'tmdb',
+					kind: 'movie',
+					feed: 'popular',
+					rank: index + 1,
+					rankingScore: 1 - index / 100,
+					rankingVersion: 999,
+					observedAt: new Date(),
+					mediaId: item.id,
+				})),
+				...[
+					trackedSeed.id,
+					favoriteSeed.id,
+					feedbackSeed.id,
+					affinityMatch.id,
+				].map((mediaId, index) => ({
+					provider: 'tmdb',
+					kind: 'movie',
+					feed: 'popular',
+					rank: fillers.length + index + 1,
+					rankingScore: 0.5 - index / 100,
+					rankingVersion: 999,
+					observedAt: new Date(),
+					mediaId,
+				})),
+			],
+		}),
+	])
+	const plan: NaturalLanguageDiscoveryPlan = {
+		kinds: ['movie'],
+		includeGenres: [],
+		excludeGenres: [],
+		includeTerms: [],
+		excludeTerms: [],
+		yearFrom: null,
+		yearTo: null,
+		releaseStatus: null,
+		language: null,
+		toneTerms: [],
+		pace: null,
+		lengthUnit: null,
+		lengthFrom: null,
+		lengthTo: null,
+		sort: 'for-you',
+		explanation: 'Find an unseen movie for this viewer.',
+		unsupportedConstraints: [],
+	}
+
+	const result = await getDiscoveryResultsForPlan(plan, viewer.id, {
+		page: 1,
+		filters: filters({ mode: 'describe', sort: 'for-you' }),
+	})
+
+	expect(result.items[0]?.id).toBe(affinityMatch.id)
+	expect(result.preferredGenres).toEqual(['Mystery'])
+	expect(result.items.map(item => item.id)).not.toEqual(
+		expect.arrayContaining([trackedSeed.id, favoriteSeed.id, feedbackSeed.id]),
+	)
+})
+
+test('top-rated pagination reports only the bounded accessible plan', async () => {
+	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
+	const query = `Bounded ranking ${suffix}`
+	await prisma.media.createMany({
+		data: Array.from({ length: 1_001 }, (_, index) => ({
+			kind: 'movie',
+			title: `${query} ${String(index + 1).padStart(4, '0')}`,
+			catalogScore: 6 + (index % 5),
+			catalogPopularity: index,
+		})),
+	})
+
+	const result = await getDiscoveryResults(
+		filters({ q: query, sort: 'top-rated', page: 1_000 }),
+		null,
+	)
+
+	expect(result.total).toBe(1_000)
+	expect(result.pageCount).toBe(42)
+	expect(result.filters.page).toBe(42)
+	expect(result.items).toHaveLength(16)
 })

--- a/app/utils/discovery.server.ts
+++ b/app/utils/discovery.server.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { type Prisma } from '@prisma/client'
 import { z } from 'zod'
 import { normalizeCatalogTitle } from './catalog-sync.server.ts'
@@ -9,10 +10,17 @@ import {
 } from './media-community.server.ts'
 import { type NaturalLanguageDiscoveryPlan } from './natural-language-discovery.ts'
 import { prismaSearchFilter } from './prisma-search.server.ts'
+import {
+	createRankedDiscoveryViewerFingerprint,
+	getRankedDiscoveryPlan,
+	type RankedDiscoveryPlanRequest,
+} from './ranked-discovery-cache.server.ts'
 import { TMDB_FEED_RANKING_VERSION } from './tmdb-catalog-hydration.server.ts'
 
 export const DISCOVERY_PAGE_SIZE = 24
 const FOR_YOU_CANDIDATE_LIMIT = 500
+const RANKED_DISCOVERY_PLAN_LIMIT = 1_000
+const RANKING_QUERY_CHUNK_SIZE = 400
 const POPULAR_FEED_FRESHNESS_MS = 8 * 24 * 60 * 60 * 1_000
 
 export const discoveryKinds = ['all', 'movie', 'tv', 'anime', 'manga'] as const
@@ -126,6 +134,26 @@ type DiscoveryMedia = Prisma.MediaGetPayload<{
 	select: typeof discoveryMediaSelect
 }>
 
+const discoveryRankCandidateSelect = {
+	id: true,
+	title: true,
+	genres: true,
+	catalogScore: true,
+	catalogPopularity: true,
+	tmdbScore: true,
+	malScore: true,
+	_count: {
+		select: {
+			reviews: true,
+			diaryEntries: true,
+		},
+	},
+} satisfies Prisma.MediaSelect
+
+type DiscoveryRankCandidate = Prisma.MediaGetPayload<{
+	select: typeof discoveryRankCandidateSelect
+}>
+
 type RankedMedia = DiscoveryMedia & {
 	communityScore: number | null
 	ratingCount: number
@@ -135,12 +163,22 @@ type RankedMedia = DiscoveryMedia & {
 	publicTrackerCount: number
 }
 
-type DiscoveryMediaPage = {
-	media: DiscoveryMedia[]
-	publicSummaries: Map<string, PublicTrackingSummary>
+type RankedDiscoveryCandidate = DiscoveryRankCandidate & {
+	communityScore: number | null
+	ratingCount: number
+	popularityScore: number
+	affinityScore: number
+	publicTrackerCount: number
+	sourceAudience: number
+	sourceRatingCount: number
 }
 
 type Preference = { label: string; weight: number }
+
+type ViewerDiscoveryTaste = {
+	preferences: Preference[]
+	fingerprint: string
+}
 
 function boundedSearchValue(value: string | null, maximum: number) {
 	return (value ?? '').trim().slice(0, maximum)
@@ -266,14 +304,20 @@ export async function getDiscoveryResultsForPlan(
 	viewerId: string | null,
 	input: { page: number; filters: DiscoveryQuery },
 ): Promise<DiscoveryResults> {
+	const kinds = [...new Set(plan.kinds)]
 	const year = naturalYearWhere(plan.yearFrom, plan.yearTo)
 	const length = naturalLengthWhere(plan)
 	const releaseStatus = naturalReleaseStatusWhere(plan.releaseStatus)
 	const sort =
 		plan.sort === 'for-you' && !viewerId ? ('popular' as const) : plan.sort
+	const filters = {
+		...input.filters,
+		sort,
+		page: input.page,
+	} satisfies DiscoveryQuery
 	const where = {
 		AND: [
-			{ kind: { in: plan.kinds } },
+			{ kind: { in: kinds } },
 			...plan.includeGenres.map(genre => genreWhere(genre)),
 			...plan.excludeGenres.map(genre => ({ NOT: genreWhere(genre) })),
 			...plan.includeTerms.map(naturalTermWhere),
@@ -291,56 +335,46 @@ export async function getDiscoveryResultsForPlan(
 				: []),
 			...(length ? [length] : []),
 			...(sort === 'top-rated' ? [publicRatingWhere()] : []),
+			...(sort === 'for-you' && viewerId
+				? viewerDiscoveryExclusions(viewerId)
+				: []),
 		],
 	} satisfies Prisma.MediaWhereInput
-	const [total, preferences] = await Promise.all([
-		prisma.media.count({ where }),
-		getGenrePreferences(viewerId),
-	])
-	const { page, pageCount, skip } = pagination(total, input.page)
-	let ranked: RankedMedia[]
-	if (sort === 'popular' || sort === 'for-you') {
-		const pageResult = await popularMediaPage({
+	const taste =
+		sort === 'for-you' && viewerId
+			? await getViewerDiscoveryTaste(viewerId)
+			: null
+	if (isRankedDiscoverySort(sort)) {
+		return rankedDiscoveryResults({
+			request: naturalRankedRequest({ ...plan, kinds }, sort, taste),
 			where,
-			page,
-			pageSize: DISCOVERY_PAGE_SIZE,
+			sort,
 			malKind:
-				plan.kinds.length === 1 &&
-				(plan.kinds[0] === 'anime' || plan.kinds[0] === 'manga')
-					? plan.kinds[0]
+				kinds.length === 1 && (kinds[0] === 'anime' || kinds[0] === 'manga')
+					? kinds[0]
 					: null,
-		})
-		ranked = await rankableMediaWithViewer(
-			pageResult.media,
-			preferences,
+			filters,
 			viewerId,
-			pageResult.publicSummaries,
-		)
-	} else if (sort === 'top-rated') {
-		ranked = await topRatedMediaPage({
-			where,
-			page,
-			pageSize: DISCOVERY_PAGE_SIZE,
-			preferences,
-			viewerId,
+			taste,
+			normalizedQuery: '',
 		})
-	} else {
-		const media = await prisma.media.findMany({
-			where,
-			select: discoveryMediaSelect,
-			orderBy: discoveryOrderBy(sort),
-			skip,
-			take: DISCOVERY_PAGE_SIZE,
-		})
-		ranked = await rankableMediaWithViewer(media, preferences, viewerId)
 	}
-	if (sort === 'for-you') ranked = rankForYou(ranked)
+	const total = await prisma.media.count({ where })
+	const { page, pageCount, skip } = pagination(total, input.page)
+	const media = await prisma.media.findMany({
+		where,
+		select: discoveryMediaSelect,
+		orderBy: discoveryOrderBy(sort),
+		skip,
+		take: DISCOVERY_PAGE_SIZE,
+	})
+	const ranked = await rankableMediaWithViewer(media, [], viewerId)
 	return {
-		filters: { ...input.filters, sort, page },
+		filters: { ...filters, page },
 		items: ranked.map(item => resultFromMedia(item, '')),
 		total,
 		pageCount,
-		preferredGenres: preferences.map(preference => preference.label),
+		preferredGenres: [],
 	}
 }
 
@@ -370,16 +404,13 @@ export async function getDiscoveryResultsForMediaIds(
 		page: 1,
 		sort: 'popular' as const,
 	}
-	const [media, preferences] = await Promise.all([
-		prisma.media.findMany({
-			where: {
-				AND: [discoveryWhere(filters, viewerId), { id: { in: orderedIds } }],
-			},
-			select: discoveryMediaSelect,
-		}),
-		getGenrePreferences(viewerId),
-	])
-	const ranked = await rankableMediaWithViewer(media, preferences, viewerId)
+	const media = await prisma.media.findMany({
+		where: {
+			AND: [discoveryWhere(filters, viewerId), { id: { in: orderedIds } }],
+		},
+		select: discoveryMediaSelect,
+	})
+	const ranked = await rankableMediaWithViewer(media, [], viewerId)
 	const byId = new Map(ranked.map(item => [item.id, item]))
 	const items = orderedIds.flatMap(id => {
 		const item = byId.get(id)
@@ -390,7 +421,7 @@ export async function getDiscoveryResultsForMediaIds(
 		items,
 		total: items.length,
 		pageCount: 1,
-		preferredGenres: preferences.map(preference => preference.label),
+		preferredGenres: [],
 	}
 }
 
@@ -402,7 +433,19 @@ export function splitGenres(value: string | null | undefined) {
 		.filter(Boolean)
 }
 
-function titleForSort(media: DiscoveryMedia) {
+type TitledMedia = { id: string; title: string | null }
+
+type PopularityRankable = TitledMedia & {
+	catalogPopularity: number | null
+	popularityScore: number
+	publicTrackerCount: number
+	_count: {
+		reviews: number
+		diaryEntries: number
+	}
+}
+
+function titleForSort(media: TitledMedia) {
 	return (media.title ?? '').toLocaleLowerCase()
 }
 
@@ -414,14 +457,17 @@ export function catalogPopularityScore(counts: {
 	return counts.trackingStates * 4 + counts.reviews * 3 + counts.diaryEntries
 }
 
-function compareTitle(left: DiscoveryMedia, right: DiscoveryMedia) {
+function compareTitle(left: TitledMedia, right: TitledMedia) {
 	return (
 		titleForSort(left).localeCompare(titleForSort(right)) ||
 		left.id.localeCompare(right.id)
 	)
 }
 
-function comparePopularity(left: RankedMedia, right: RankedMedia) {
+function comparePopularity(
+	left: PopularityRankable,
+	right: PopularityRankable,
+) {
 	return (
 		(right.catalogPopularity ?? 0) - (left.catalogPopularity ?? 0) ||
 		right.popularityScore - left.popularityScore ||
@@ -431,7 +477,9 @@ function comparePopularity(left: RankedMedia, right: RankedMedia) {
 	)
 }
 
-function rankForYou(media: RankedMedia[]) {
+function rankForYou<T extends PopularityRankable & { affinityScore: number }>(
+	media: T[],
+) {
 	return media.sort(
 		(left, right) =>
 			right.affinityScore - left.affinityScore ||
@@ -444,7 +492,11 @@ function yearFor(media: DiscoveryMedia) {
 	return media.startYear || media.airYear || null
 }
 
-function providerScore(media: DiscoveryMedia) {
+function providerScore(media: {
+	catalogScore: number | null
+	tmdbScore: { toString(): string } | number | null
+	malScore: { toString(): string } | number | null
+}) {
 	const values = [
 		media.catalogScore,
 		media.tmdbScore === null ? null : Number(media.tmdbScore),
@@ -453,7 +505,7 @@ function providerScore(media: DiscoveryMedia) {
 	return values.length ? Math.max(...values) : null
 }
 
-function weightedRatingScore(media: RankedMedia) {
+function weightedRatingScore(media: RankedDiscoveryCandidate) {
 	if (media.communityScore !== null) {
 		const priorScore = 7
 		const priorRatings = 20
@@ -464,14 +516,8 @@ function weightedRatingScore(media: RankedMedia) {
 	}
 	const score = providerScore(media)
 	if (score === null) return Number.NEGATIVE_INFINITY
-	const ratingCount = Math.max(
-		0,
-		...media.externalIds.map(source => source.sourceRatingCount ?? 0),
-	)
-	const audience = Math.max(
-		0,
-		...media.externalIds.map(source => source.sourceAudience ?? 0),
-	)
+	const ratingCount = Math.max(0, media.sourceRatingCount)
+	const audience = Math.max(0, media.sourceAudience)
 	const confidenceWeight = ratingCount
 		? Math.sqrt(ratingCount)
 		: Math.sqrt(audience) * 0.35
@@ -483,13 +529,96 @@ function weightedRatingScore(media: RankedMedia) {
 	)
 }
 
-function rankTopRated(media: RankedMedia[]) {
+function rankTopRated(media: RankedDiscoveryCandidate[]) {
 	return media.sort(
 		(left, right) =>
 			weightedRatingScore(right) - weightedRatingScore(left) ||
 			right.ratingCount - left.ratingCount ||
 			comparePopularity(left, right),
 	)
+}
+
+type ProviderConfidence = {
+	sourceAudience: number
+	sourceRatingCount: number
+}
+
+async function getProviderConfidenceByMediaId(mediaIds: readonly string[]) {
+	const uniqueIds = [...new Set(mediaIds)]
+	const confidence = new Map<string, ProviderConfidence>()
+	for (
+		let offset = 0;
+		offset < uniqueIds.length;
+		offset += RANKING_QUERY_CHUNK_SIZE
+	) {
+		const rows = await prisma.mediaExternalId.groupBy({
+			by: ['mediaId'],
+			where: {
+				mediaId: {
+					in: uniqueIds.slice(offset, offset + RANKING_QUERY_CHUNK_SIZE),
+				},
+				tombstonedAt: null,
+			},
+			_max: {
+				sourceAudience: true,
+				sourceRatingCount: true,
+			},
+		})
+		for (const row of rows) {
+			confidence.set(row.mediaId, {
+				sourceAudience: row._max.sourceAudience ?? 0,
+				sourceRatingCount: row._max.sourceRatingCount ?? 0,
+			})
+		}
+	}
+	return confidence
+}
+
+async function rankDiscoveryCandidates(
+	media: DiscoveryRankCandidate[],
+	preferences: readonly Preference[],
+	{ withProviderConfidence = false }: { withProviderConfidence?: boolean } = {},
+): Promise<RankedDiscoveryCandidate[]> {
+	const mediaIds = media.map(item => item.id)
+	const [publicSummaries, providerConfidence] = await Promise.all([
+		getPublicTrackingSummariesByMediaId(mediaIds),
+		withProviderConfidence
+			? getProviderConfidenceByMediaId(mediaIds)
+			: Promise.resolve(new Map<string, ProviderConfidence>()),
+	])
+	const preferenceWeights = new Map(
+		preferences.map(preference => [
+			preference.label.toLocaleLowerCase(),
+			preference.weight,
+		]),
+	)
+	return media.map(item => {
+		const summary = publicSummaries.get(item.id) ?? {
+			trackerCount: 0,
+			ratingCount: 0,
+			communityScore: null,
+		}
+		const confidence = providerConfidence.get(item.id) ?? {
+			sourceAudience: 0,
+			sourceRatingCount: 0,
+		}
+		return {
+			...item,
+			communityScore: summary.communityScore,
+			ratingCount: summary.ratingCount,
+			publicTrackerCount: summary.trackerCount,
+			popularityScore: catalogPopularityScore({
+				...item._count,
+				trackingStates: summary.trackerCount,
+			}),
+			affinityScore: splitGenres(item.genres).reduce(
+				(total, genre) =>
+					total + (preferenceWeights.get(genre.toLocaleLowerCase()) ?? 0),
+				0,
+			),
+			...confidence,
+		}
+	})
 }
 
 function resultFromMedia(
@@ -527,20 +656,47 @@ function resultFromMedia(
 	}
 }
 
-async function getGenrePreferences(viewerId: string | null) {
-	if (!viewerId) return []
-	const [states, favorites] = await Promise.all([
+function updateFingerprint(
+	hash: ReturnType<typeof createHash>,
+	values: readonly string[],
+) {
+	for (const value of values) {
+		const bytes = Buffer.byteLength(value, 'utf8')
+		hash.update(String(bytes)).update(':').update(value)
+	}
+}
+
+async function getViewerDiscoveryTaste(
+	viewerId: string,
+): Promise<ViewerDiscoveryTaste> {
+	const [states, favorites, feedback] = await Promise.all([
 		prisma.trackingState.findMany({
 			where: { ownerId: viewerId },
 			select: {
+				mediaId: true,
 				status: true,
 				score: true,
 				media: { select: { genres: true } },
 			},
+			orderBy: [{ mediaId: 'asc' }],
 		}),
 		prisma.userFavorite.findMany({
 			where: { ownerId: viewerId, mediaId: { not: null } },
-			select: { media: { select: { genres: true } } },
+			select: {
+				id: true,
+				mediaId: true,
+				media: { select: { genres: true } },
+			},
+			orderBy: [{ mediaId: 'asc' }, { id: 'asc' }],
+		}),
+		prisma.recommendationFeedback.findMany({
+			where: { ownerId: viewerId },
+			select: {
+				mediaId: true,
+				feedbackType: true,
+				media: { select: { genres: true } },
+			},
+			orderBy: [{ mediaId: 'asc' }],
 		}),
 	])
 	const preferences = new Map<string, Preference>()
@@ -561,12 +717,50 @@ async function getGenrePreferences(viewerId: string | null) {
 		addGenres(state.media.genres, Math.max(1, score + statusBoost))
 	}
 	for (const favorite of favorites) addGenres(favorite.media?.genres, 8)
-	return [...preferences.values()]
+	const rankedPreferences = [...preferences.values()]
 		.sort(
 			(left, right) =>
 				right.weight - left.weight || left.label.localeCompare(right.label),
 		)
 		.slice(0, 5)
+	const fingerprint = createHash('sha256')
+	updateFingerprint(fingerprint, ['viewer-discovery-taste-v1'])
+	for (const state of states) {
+		updateFingerprint(fingerprint, [
+			'tracking',
+			state.mediaId,
+			state.status,
+			state.score?.toString() ?? '',
+			state.media.genres ?? '',
+		])
+	}
+	for (const favorite of favorites) {
+		updateFingerprint(fingerprint, [
+			'favorite',
+			favorite.mediaId ?? '',
+			favorite.media?.genres ?? '',
+		])
+	}
+	for (const item of feedback) {
+		updateFingerprint(fingerprint, [
+			'feedback',
+			item.mediaId,
+			item.feedbackType,
+			item.media.genres ?? '',
+		])
+	}
+	return {
+		preferences: rankedPreferences,
+		fingerprint: fingerprint.digest('base64url'),
+	}
+}
+
+function viewerDiscoveryExclusions(viewerId: string): Prisma.MediaWhereInput[] {
+	return [
+		{ trackingStates: { none: { ownerId: viewerId } } },
+		{ favorites: { none: { ownerId: viewerId } } },
+		{ recommendationFeedback: { none: { ownerId: viewerId } } },
+	]
 }
 
 function genreWhere(genre: string): Prisma.MediaWhereInput {
@@ -666,15 +860,7 @@ function discoveryWhere(
 					]),
 			...(filters.sort === 'top-rated' ? [publicRatingWhere()] : []),
 			...(filters.sort === 'for-you' && viewerId
-				? [
-						{ trackingStates: { none: { ownerId: viewerId } } },
-						{ favorites: { none: { ownerId: viewerId } } },
-						{
-							recommendationFeedback: {
-								none: { ownerId: viewerId },
-							},
-						},
-					]
+				? viewerDiscoveryExclusions(viewerId)
 				: []),
 		],
 	}
@@ -701,30 +887,18 @@ function discoveryOrderBy(
 	]
 }
 
-async function popularMediaPage(input: {
-	where: Prisma.MediaWhereInput
-	page: number
-	pageSize: number
-	malKind?: 'anime' | 'manga' | null
-}): Promise<DiscoveryMediaPage> {
-	if (input.malKind) {
-		return {
-			media: await malPopularMediaPage({ ...input, kind: input.malKind }),
-			publicSummaries: new Map(),
-		}
-	}
+async function tmdbPopularIdPlan(where: Prisma.MediaWhereInput) {
 	const freshAfter = new Date(Date.now() - POPULAR_FEED_FRESHNESS_MS)
 	const feedSelect = {
 		mediaId: true,
 		rank: true,
 		rankingScore: true,
-		media: { select: discoveryMediaSelect },
 	} satisfies Prisma.CatalogFeedItemSelect
 	const feedWhere = {
 		provider: 'tmdb',
 		feed: 'popular',
 		rankingVersion: { gte: TMDB_FEED_RANKING_VERSION },
-		media: { is: input.where },
+		media: { is: where },
 	} satisfies Prisma.CatalogFeedItemWhereInput
 	const freshFeedRows = await prisma.catalogFeedItem.findMany({
 		where: {
@@ -756,51 +930,39 @@ async function popularMediaPage(input: {
 	const publicSummaries = await getPublicTrackingSummariesByMediaId(
 		feedRows.map(row => row.mediaId),
 	)
-	const ranked = [...new Map(feedRows.map(row => [row.mediaId, row])).values()]
+	const rankedIds = [
+		...new Map(feedRows.map(row => [row.mediaId, row])).values(),
+	]
 		.sort((left, right) => {
-			const boundedCommunityBoost = (media: DiscoveryMedia) =>
+			const boundedCommunityBoost = (mediaId: string) =>
 				Math.min(
 					0.02,
-					(publicSummaries.get(media.id)?.trackerCount ?? 0) / 50_000,
+					(publicSummaries.get(mediaId)?.trackerCount ?? 0) / 50_000,
 				)
 			return (
 				(right.rankingScore ?? 0) +
-					boundedCommunityBoost(right.media) -
-					((left.rankingScore ?? 0) + boundedCommunityBoost(left.media)) ||
+					boundedCommunityBoost(right.mediaId) -
+					((left.rankingScore ?? 0) + boundedCommunityBoost(left.mediaId)) ||
 				left.rank - right.rank ||
 				left.mediaId.localeCompare(right.mediaId)
 			)
 		})
-		.map(row => row.media)
-	const rankedIds = ranked.map(media => media.id)
-	const start = (input.page - 1) * input.pageSize
-	const rankedSlice =
-		start < ranked.length ? ranked.slice(start, start + input.pageSize) : []
-	const remaining = input.pageSize - rankedSlice.length
-	if (!remaining) return { media: rankedSlice, publicSummaries }
-	const fallbackSkip = Math.max(0, start - ranked.length)
+		.map(row => row.mediaId)
+	const remaining = RANKED_DISCOVERY_PLAN_LIMIT - rankedIds.length
+	if (!remaining) return rankedIds
 	const fallback = await prisma.media.findMany({
 		where: {
-			AND: [
-				input.where,
-				...(rankedIds.length ? [{ id: { notIn: rankedIds } }] : []),
-			],
+			AND: [where, ...(rankedIds.length ? [{ id: { notIn: rankedIds } }] : [])],
 		},
-		select: discoveryMediaSelect,
+		select: { id: true },
 		orderBy: [{ title: 'asc' }, { id: 'asc' }],
-		skip: fallbackSkip,
 		take: remaining,
 	})
-	return {
-		media: [...rankedSlice, ...fallback],
-		publicSummaries,
-	}
+	return [...rankedIds, ...fallback.map(item => item.id)]
 }
 
-async function malPopularMediaPage(input: {
+async function malPopularIdPlan(input: {
 	where: Prisma.MediaWhereInput
-	page: number
-	pageSize: number
 	kind: 'anime' | 'manga'
 }) {
 	const feedWhere = {
@@ -809,21 +971,15 @@ async function malPopularMediaPage(input: {
 		feed: 'popular',
 		media: { is: input.where },
 	} satisfies Prisma.CatalogFeedItemWhereInput
-	const start = (input.page - 1) * input.pageSize
-	const rankedCount = await prisma.catalogFeedItem.count({ where: feedWhere })
-	const ranked =
-		start < rankedCount
-			? await prisma.catalogFeedItem.findMany({
-					where: feedWhere,
-					orderBy: [{ rank: 'asc' }, { mediaId: 'asc' }],
-					skip: start,
-					take: input.pageSize,
-					select: { media: { select: discoveryMediaSelect } },
-				})
-			: []
-	const rankedMedia = ranked.map(row => row.media)
-	const remaining = input.pageSize - rankedMedia.length
-	if (!remaining) return rankedMedia
+	const ranked = await prisma.catalogFeedItem.findMany({
+		where: feedWhere,
+		orderBy: [{ rank: 'asc' }, { mediaId: 'asc' }],
+		take: RANKED_DISCOVERY_PLAN_LIMIT,
+		select: { mediaId: true },
+	})
+	const rankedIds = ranked.map(row => row.mediaId)
+	const remaining = RANKED_DISCOVERY_PLAN_LIMIT - rankedIds.length
+	if (!remaining) return rankedIds
 	const fallback = await prisma.media.findMany({
 		where: {
 			AND: [
@@ -839,24 +995,29 @@ async function malPopularMediaPage(input: {
 				},
 			],
 		},
-		select: discoveryMediaSelect,
+		select: { id: true },
 		orderBy: [{ title: 'asc' }, { id: 'asc' }],
-		skip: Math.max(0, start - rankedCount),
 		take: remaining,
 	})
-	return [...rankedMedia, ...fallback]
+	return [...rankedIds, ...fallback.map(item => item.id)]
 }
 
-async function topRatedMediaPage(input: {
+async function popularIdPlan(input: {
 	where: Prisma.MediaWhereInput
-	page: number
-	pageSize: number
+	malKind: 'anime' | 'manga' | null
+}) {
+	return input.malKind
+		? malPopularIdPlan({ where: input.where, kind: input.malKind })
+		: tmdbPopularIdPlan(input.where)
+}
+
+async function topRatedIdPlan(input: {
+	where: Prisma.MediaWhereInput
 	preferences: Preference[]
-	viewerId: string | null
 }) {
 	const candidates = await prisma.media.findMany({
 		where: input.where,
-		select: discoveryMediaSelect,
+		select: discoveryRankCandidateSelect,
 		orderBy: [
 			{ catalogScore: 'desc' },
 			{ tmdbScore: 'desc' },
@@ -864,16 +1025,60 @@ async function topRatedMediaPage(input: {
 			{ title: 'asc' },
 			{ id: 'asc' },
 		],
-		take: 1_000,
+		take: RANKED_DISCOVERY_PLAN_LIMIT,
 	})
-	const start = (input.page - 1) * input.pageSize
-	const ranked = rankTopRated(
-		await rankableMedia(candidates, input.preferences),
-	)
-	return withViewerTracking(
-		ranked.slice(start, start + input.pageSize),
-		input.viewerId,
-	)
+	return rankTopRated(
+		await rankDiscoveryCandidates(candidates, input.preferences, {
+			withProviderConfidence: true,
+		}),
+	).map(item => item.id)
+}
+
+async function forYouIdPlan(input: {
+	where: Prisma.MediaWhereInput
+	preferences: Preference[]
+}) {
+	const preferredWhere: Prisma.MediaWhereInput | null = input.preferences.length
+		? {
+				AND: [
+					input.where,
+					{
+						OR: input.preferences.map(preference => ({
+							genres: prismaSearchFilter('contains', preference.label),
+						})),
+					},
+				],
+			}
+		: null
+	const [preferredCandidates, popularCandidates] = await Promise.all([
+		preferredWhere
+			? prisma.media.findMany({
+					where: preferredWhere,
+					select: discoveryRankCandidateSelect,
+					orderBy: discoveryOrderBy('popular'),
+					take: FOR_YOU_CANDIDATE_LIMIT / 2,
+				})
+			: Promise.resolve([]),
+		prisma.media.findMany({
+			where: input.where,
+			select: discoveryRankCandidateSelect,
+			orderBy: discoveryOrderBy('popular'),
+			take: preferredWhere
+				? FOR_YOU_CANDIDATE_LIMIT / 2
+				: FOR_YOU_CANDIDATE_LIMIT,
+		}),
+	])
+	const candidates = [
+		...new Map(
+			[...preferredCandidates, ...popularCandidates].map(item => [
+				item.id,
+				item,
+			]),
+		).values(),
+	]
+	return rankForYou(
+		await rankDiscoveryCandidates(candidates, input.preferences),
+	).map(item => item.id)
 }
 
 async function rankableMedia(
@@ -978,6 +1183,206 @@ function pagination(total: number, requestedPage: number) {
 	}
 }
 
+type RankedDiscoverySort = 'popular' | 'top-rated' | 'for-you'
+
+function isRankedDiscoverySort(
+	sort: DiscoveryQuery['sort'],
+): sort is RankedDiscoverySort {
+	return sort === 'popular' || sort === 'top-rated' || sort === 'for-you'
+}
+
+function standardRankedRequest(
+	filters: DiscoveryQuery,
+	taste: ViewerDiscoveryTaste | null,
+): RankedDiscoveryPlanRequest {
+	const request = {
+		source: 'standard' as const,
+		q: filters.q,
+		kind: filters.kind,
+		genre: filters.genre,
+		year: filters.year,
+		status: filters.status,
+		provider: filters.provider,
+	}
+	if (filters.sort === 'for-you') {
+		if (!taste) {
+			throw new TypeError('For-you discovery requires viewer taste.')
+		}
+		return {
+			...request,
+			sort: 'for-you',
+			viewerFingerprint: createRankedDiscoveryViewerFingerprint({
+				stateDigest: taste.fingerprint,
+			}),
+		}
+	}
+	if (filters.sort !== 'popular' && filters.sort !== 'top-rated') {
+		throw new TypeError('The discovery sort is not cacheable.')
+	}
+	return { ...request, sort: filters.sort }
+}
+
+function naturalRankedRequest(
+	plan: NaturalLanguageDiscoveryPlan,
+	sort: RankedDiscoverySort,
+	taste: ViewerDiscoveryTaste | null,
+): RankedDiscoveryPlanRequest {
+	const request = {
+		source: 'natural' as const,
+		kinds: plan.kinds,
+		includeGenres: plan.includeGenres,
+		excludeGenres: plan.excludeGenres,
+		includeTerms: plan.includeTerms,
+		excludeTerms: plan.excludeTerms,
+		yearFrom: plan.yearFrom,
+		yearTo: plan.yearTo,
+		releaseStatus: plan.releaseStatus,
+		language: plan.language,
+		toneTerms: plan.toneTerms,
+		pace: plan.pace,
+		lengthUnit: plan.lengthUnit,
+		lengthFrom: plan.lengthFrom,
+		lengthTo: plan.lengthTo,
+	}
+	if (sort === 'for-you') {
+		if (!taste) {
+			throw new TypeError('For-you discovery requires viewer taste.')
+		}
+		return {
+			...request,
+			sort,
+			viewerFingerprint: createRankedDiscoveryViewerFingerprint({
+				stateDigest: taste.fingerprint,
+			}),
+		}
+	}
+	return { ...request, sort }
+}
+
+async function buildRankedDiscoveryIds({
+	sort,
+	where,
+	malKind,
+	preferences,
+}: {
+	sort: RankedDiscoverySort
+	where: Prisma.MediaWhereInput
+	malKind: 'anime' | 'manga' | null
+	preferences: Preference[]
+}) {
+	if (sort === 'popular') return popularIdPlan({ where, malKind })
+	if (sort === 'top-rated') return topRatedIdPlan({ where, preferences: [] })
+	return forYouIdPlan({ where, preferences })
+}
+
+async function filterEligibleRankedDiscoveryIds(
+	ids: readonly string[],
+	where: Prisma.MediaWhereInput,
+) {
+	const eligibleIds = new Set<string>()
+	for (
+		let offset = 0;
+		offset < ids.length;
+		offset += RANKING_QUERY_CHUNK_SIZE
+	) {
+		const rows = await prisma.media.findMany({
+			where: {
+				AND: [
+					where,
+					{
+						id: {
+							in: ids.slice(offset, offset + RANKING_QUERY_CHUNK_SIZE),
+						},
+					},
+				],
+			},
+			select: { id: true },
+		})
+		for (const row of rows) eligibleIds.add(row.id)
+	}
+	return ids.filter(id => eligibleIds.has(id))
+}
+
+async function hydrateRankedDiscoveryPage({
+	ids,
+	where,
+	viewerId,
+	preferences,
+}: {
+	ids: readonly string[]
+	where: Prisma.MediaWhereInput
+	viewerId: string | null
+	preferences: Preference[]
+}) {
+	if (!ids.length) return []
+	const media = await prisma.media.findMany({
+		where: { AND: [where, { id: { in: [...ids] } }] },
+		select: discoveryMediaSelect,
+		take: DISCOVERY_PAGE_SIZE,
+	})
+	const ranked = await rankableMediaWithViewer(media, preferences, viewerId)
+	const byId = new Map(ranked.map(item => [item.id, item]))
+	return ids.flatMap(id => {
+		const item = byId.get(id)
+		return item ? [item] : []
+	})
+}
+
+async function rankedDiscoveryResults({
+	request,
+	where,
+	sort,
+	malKind,
+	filters,
+	viewerId,
+	taste,
+	normalizedQuery,
+}: {
+	request: RankedDiscoveryPlanRequest
+	where: Prisma.MediaWhereInput
+	sort: RankedDiscoverySort
+	malKind: 'anime' | 'manga' | null
+	filters: DiscoveryQuery
+	viewerId: string | null
+	taste: ViewerDiscoveryTaste | null
+	normalizedQuery: string
+}): Promise<DiscoveryResults> {
+	const preferences = taste?.preferences ?? []
+	const scope =
+		sort === 'for-you'
+			? ({ kind: 'viewer', viewerId: viewerId! } as const)
+			: ({ kind: 'public' } as const)
+	const plan = await getRankedDiscoveryPlan({
+		request,
+		scope,
+		getFreshValue: async () => ({
+			ids: await buildRankedDiscoveryIds({
+				sort,
+				where,
+				malKind,
+				preferences,
+			}),
+		}),
+	})
+	const eligibleIds = await filterEligibleRankedDiscoveryIds(plan.ids, where)
+	const { page, pageCount, skip } = pagination(eligibleIds.length, filters.page)
+	const pageIds = eligibleIds.slice(skip, skip + DISCOVERY_PAGE_SIZE)
+	const ranked = await hydrateRankedDiscoveryPage({
+		ids: pageIds,
+		where,
+		viewerId,
+		preferences,
+	})
+	return {
+		filters: { ...filters, page },
+		items: ranked.map(item => resultFromMedia(item, normalizedQuery)),
+		total: eligibleIds.length,
+		pageCount,
+		preferredGenres:
+			sort === 'for-you' ? preferences.map(preference => preference.label) : [],
+	}
+}
+
 export async function getDiscoveryResults(
 	input: DiscoveryQuery,
 	viewerId: string | null,
@@ -986,103 +1391,46 @@ export async function getDiscoveryResults(
 		...input,
 		sort: input.sort === 'for-you' && !viewerId ? 'popular' : input.sort,
 	} satisfies DiscoveryQuery
-	const preferences = await getGenrePreferences(viewerId)
-	const where = discoveryWhere(filters, viewerId)
 	const normalizedQuery = normalizeCatalogTitle(filters.q)
-
-	if (filters.sort === 'for-you' && preferences.length) {
-		const preferenceWhere: Prisma.MediaWhereInput = {
-			AND: [
-				where,
-				{
-					OR: preferences.map(preference => ({
-						genres: prismaSearchFilter('contains', preference.label),
-					})),
-				},
-			],
-		}
-		const [preferredCandidates, popularCandidates] = await Promise.all([
-			prisma.media.findMany({
-				where: preferenceWhere,
-				select: discoveryMediaSelect,
-				orderBy: discoveryOrderBy('popular'),
-				take: FOR_YOU_CANDIDATE_LIMIT / 2,
-			}),
-			prisma.media.findMany({
-				where,
-				select: discoveryMediaSelect,
-				orderBy: discoveryOrderBy('popular'),
-				take: FOR_YOU_CANDIDATE_LIMIT / 2,
-			}),
-		])
-		const candidates = [
-			...new Map(
-				[...preferredCandidates, ...popularCandidates].map(item => [
-					item.id,
-					item,
-				]),
-			).values(),
-		]
-		const ranked = rankForYou(await rankableMedia(candidates, preferences))
-		const { page, pageCount, skip } = pagination(ranked.length, filters.page)
-		return {
-			filters: { ...filters, page },
-			items: ranked
-				.slice(skip, skip + DISCOVERY_PAGE_SIZE)
-				.map(item => resultFromMedia(item, normalizedQuery)),
-			total: ranked.length,
-			pageCount,
-			preferredGenres: preferences.map(preference => preference.label),
-		}
-	}
-
-	const total = await prisma.media.count({ where })
-	const { page, pageCount, skip } = pagination(total, filters.page)
-	let ranked: RankedMedia[]
-	if (filters.sort === 'popular') {
-		const pageResult = await popularMediaPage({
+	const taste =
+		filters.sort === 'for-you' && viewerId
+			? await getViewerDiscoveryTaste(viewerId)
+			: null
+	const where = discoveryWhere(
+		filters,
+		filters.sort === 'for-you' ? viewerId : null,
+	)
+	if (isRankedDiscoverySort(filters.sort)) {
+		return rankedDiscoveryResults({
+			request: standardRankedRequest(filters, taste),
 			where,
-			page,
-			pageSize: DISCOVERY_PAGE_SIZE,
+			sort: filters.sort,
 			malKind:
 				filters.kind === 'anime' || filters.kind === 'manga'
 					? filters.kind
 					: null,
-		})
-		ranked = await rankableMediaWithViewer(
-			pageResult.media,
-			preferences,
+			filters,
 			viewerId,
-			pageResult.publicSummaries,
-		)
-	} else if (filters.sort === 'top-rated') {
-		ranked = await topRatedMediaPage({
-			where,
-			page,
-			pageSize: DISCOVERY_PAGE_SIZE,
-			preferences,
-			viewerId,
+			taste,
+			normalizedQuery,
 		})
-	} else {
-		const media = await prisma.media.findMany({
-			where,
-			select: discoveryMediaSelect,
-			orderBy: discoveryOrderBy(filters.sort),
-			skip,
-			take: DISCOVERY_PAGE_SIZE,
-		})
-		ranked = await rankableMediaWithViewer(
-			media,
-			preferences,
-			filters.sort === 'for-you' ? null : viewerId,
-		)
 	}
+	const total = await prisma.media.count({ where })
+	const { page, pageCount, skip } = pagination(total, filters.page)
+	const media = await prisma.media.findMany({
+		where,
+		select: discoveryMediaSelect,
+		orderBy: discoveryOrderBy(filters.sort),
+		skip,
+		take: DISCOVERY_PAGE_SIZE,
+	})
+	const ranked = await rankableMediaWithViewer(media, [], viewerId)
 	return {
 		filters: { ...filters, page },
 		items: ranked.map(item => resultFromMedia(item, normalizedQuery)),
 		total,
 		pageCount,
-		preferredGenres: preferences.map(preference => preference.label),
+		preferredGenres: [],
 	}
 }
 

--- a/app/utils/ranked-discovery-cache.server.test.ts
+++ b/app/utils/ranked-discovery-cache.server.test.ts
@@ -1,0 +1,559 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+	getCacheOperationsSnapshot,
+	lruCache,
+	resetCacheResourcesForTest,
+} from './cache.server.ts'
+import {
+	createRankedDiscoveryCacheRuntimeForTest,
+	createRankedDiscoveryViewerFingerprint,
+	getRankedDiscoveryPlan,
+	RANKED_DISCOVERY_CACHE_TTL_MS,
+	RANKED_DISCOVERY_PLAN_MAX_IDS,
+	type RankedDiscoveryPlan,
+	type RankedDiscoveryPlanRequest,
+} from './ranked-discovery-cache.server.ts'
+
+type StandardPublicRequest = Extract<
+	RankedDiscoveryPlanRequest,
+	{ source: 'standard'; sort: 'popular' | 'top-rated' }
+>
+type NaturalPublicRequest = Extract<
+	RankedDiscoveryPlanRequest,
+	{ source: 'natural'; sort: 'popular' | 'top-rated' }
+>
+type StandardViewerRequest = Extract<
+	RankedDiscoveryPlanRequest,
+	{ source: 'standard'; sort: 'for-you' }
+>
+
+function standardRequest(
+	overrides: Partial<StandardPublicRequest> = {},
+): StandardPublicRequest {
+	return {
+		source: 'standard',
+		q: '',
+		kind: 'all',
+		genre: '',
+		year: null,
+		status: '',
+		provider: 'all',
+		sort: 'popular',
+		...overrides,
+	}
+}
+
+function naturalRequest(
+	overrides: Partial<NaturalPublicRequest> = {},
+): NaturalPublicRequest {
+	return {
+		source: 'natural',
+		kinds: ['movie', 'tv'],
+		includeGenres: ['Mystery'],
+		excludeGenres: ['Horror'],
+		includeTerms: ['locked room'],
+		excludeTerms: ['slasher'],
+		yearFrom: 1990,
+		yearTo: 2026,
+		releaseStatus: 'completed',
+		language: 'English',
+		toneTerms: ['atmospheric'],
+		pace: 'slow',
+		lengthUnit: 'minutes',
+		lengthFrom: 60,
+		lengthTo: 180,
+		sort: 'top-rated',
+		...overrides,
+	}
+}
+
+function viewerRequest(
+	overrides: Partial<StandardViewerRequest> = {},
+): StandardViewerRequest {
+	return {
+		...standardRequest(),
+		sort: 'for-you',
+		viewerFingerprint: createRankedDiscoveryViewerFingerprint({
+			stateDigest: 'viewer-state-a',
+		}),
+		...overrides,
+	}
+}
+
+beforeEach(() => {
+	resetCacheResourcesForTest()
+})
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+	resetCacheResourcesForTest()
+})
+
+describe('ranked discovery plan boundaries', () => {
+	test('bypasses by default in tests without creating cache state or metrics', async () => {
+		const fresh = vi
+			.fn<() => Promise<RankedDiscoveryPlan>>()
+			.mockResolvedValue({ ids: ['media-a', 'media-b'] })
+		const entriesBefore = lruCache.snapshot().entries
+
+		const first = await getRankedDiscoveryPlan({
+			request: standardRequest(),
+			scope: { kind: 'public' },
+			getFreshValue: fresh,
+		})
+		const second = await getRankedDiscoveryPlan({
+			request: standardRequest(),
+			scope: { kind: 'public' },
+			getFreshValue: fresh,
+		})
+
+		expect(first).toEqual({ ids: ['media-a', 'media-b'] })
+		expect(second).toEqual(first)
+		expect(fresh).toHaveBeenCalledTimes(2)
+		expect(lruCache.snapshot().entries).toBe(entriesBefore)
+		expect(getCacheOperationsSnapshot()).toEqual({})
+		expect(Object.isFrozen(first)).toBe(true)
+		expect(Object.isFrozen(first.ids)).toBe(true)
+	})
+
+	test('checks the E2E bypass environment on every call', async () => {
+		vi.stubEnv('NODE_ENV', 'production')
+		vi.stubEnv('VEUD_E2E', '0')
+		const fresh = vi.fn(() => ({ ids: ['media-a'] as const }))
+
+		await getRankedDiscoveryPlan({
+			request: standardRequest(),
+			scope: { kind: 'public' },
+			getFreshValue: fresh,
+		})
+		const entriesBeforeBypass = lruCache.snapshot().entries
+		const metricsBeforeBypass = getCacheOperationsSnapshot()
+
+		vi.stubEnv('VEUD_E2E', '1')
+		await getRankedDiscoveryPlan({
+			request: standardRequest(),
+			scope: { kind: 'public' },
+			getFreshValue: fresh,
+		})
+
+		expect(fresh).toHaveBeenCalledTimes(2)
+		expect(lruCache.snapshot().entries).toBe(entriesBeforeBypass)
+		expect(getCacheOperationsSnapshot()).toEqual(metricsBeforeBypass)
+	})
+
+	test('rejects pages, explanations, and other non-semantic request fields', async () => {
+		const fresh = vi.fn(() => ({ ids: ['media-a'] as const }))
+
+		await expect(
+			getRankedDiscoveryPlan({
+				request: {
+					...standardRequest(),
+					page: 2,
+				} as unknown as RankedDiscoveryPlanRequest,
+				scope: { kind: 'public' },
+				getFreshValue: fresh,
+			}),
+		).rejects.toThrow()
+		await expect(
+			getRankedDiscoveryPlan({
+				request: {
+					...naturalRequest(),
+					explanation: 'This must never fragment the ranked plan.',
+				} as unknown as RankedDiscoveryPlanRequest,
+				scope: { kind: 'public' },
+				getFreshValue: fresh,
+			}),
+		).rejects.toThrow()
+		await expect(
+			getRankedDiscoveryPlan({
+				request: {
+					...standardRequest(),
+					q: ' surrounding whitespace ',
+				},
+				scope: { kind: 'public' },
+				getFreshValue: fresh,
+			}),
+		).rejects.toThrow()
+		expect(fresh).not.toHaveBeenCalled()
+	})
+
+	test('validates natural request relationships before producing a plan', async () => {
+		const fresh = vi.fn(() => ({ ids: [] as const }))
+		for (const request of [
+			naturalRequest({ yearFrom: 2020, yearTo: 2000 }),
+			naturalRequest({ lengthUnit: null, lengthFrom: 60 }),
+			naturalRequest({ lengthFrom: 200, lengthTo: 100 }),
+			naturalRequest({
+				kinds: ['manga'],
+				lengthUnit: 'episodes',
+			}),
+			naturalRequest({
+				includeGenres: ['Mystery'],
+				excludeGenres: ['mystery'],
+			}),
+			naturalRequest({
+				includeTerms: ['locked room'],
+				excludeTerms: ['LOCKED ROOM'],
+			}),
+		]) {
+			await expect(
+				getRankedDiscoveryPlan({
+					request,
+					scope: { kind: 'public' },
+					getFreshValue: fresh,
+				}),
+			).rejects.toThrow()
+		}
+		expect(fresh).not.toHaveBeenCalled()
+	})
+
+	test('requires public scope for public plans and viewer scope for for-you', async () => {
+		const fresh = vi.fn(() => ({ ids: [] as const }))
+
+		await expect(
+			getRankedDiscoveryPlan({
+				request: standardRequest(),
+				scope: { kind: 'viewer', viewerId: 'viewer-a' },
+				getFreshValue: fresh,
+			}),
+		).rejects.toThrow('require public scope')
+		await expect(
+			getRankedDiscoveryPlan({
+				request: viewerRequest(),
+				scope: { kind: 'public' },
+				getFreshValue: fresh,
+			}),
+		).rejects.toThrow('require viewer scope')
+		expect(fresh).not.toHaveBeenCalled()
+	})
+
+	test('rejects malformed or non-exact viewer scopes even while bypassed', async () => {
+		const fresh = vi.fn(() => ({ ids: [] as const }))
+
+		for (const scope of [
+			{ kind: 'viewer', viewerId: ' viewer-a' },
+			{ kind: 'viewer', viewerId: '' },
+			{ kind: 'viewer', viewerId: 'x'.repeat(513) },
+			{ kind: 'viewer', viewerId: 'viewer-a', displayName: 'Private Name' },
+		]) {
+			await expect(
+				getRankedDiscoveryPlan({
+					request: viewerRequest(),
+					scope: scope as never,
+					getFreshValue: fresh,
+				}),
+			).rejects.toThrow()
+		}
+		expect(fresh).not.toHaveBeenCalled()
+	})
+
+	test('accepts only an exact, unique, bounded ID envelope', async () => {
+		async function expectInvalid(value: unknown) {
+			await expect(
+				getRankedDiscoveryPlan({
+					request: standardRequest(),
+					scope: { kind: 'public' },
+					getFreshValue: () => value as RankedDiscoveryPlan,
+				}),
+			).rejects.toThrow()
+		}
+
+		await expectInvalid({
+			ids: ['media-a'],
+			total: 1,
+		})
+		await expectInvalid({ ids: ['media-a', 'media-a'] })
+		await expectInvalid({ ids: [' media-a'] })
+		await expectInvalid({ ids: ['media/a'] })
+		await expectInvalid({
+			ids: Array.from(
+				{ length: RANKED_DISCOVERY_PLAN_MAX_IDS + 1 },
+				(_, index) => `media-${index}`,
+			),
+		})
+	})
+
+	test('clones and freezes producer values instead of retaining aliases', async () => {
+		const runtime = createRankedDiscoveryCacheRuntimeForTest()
+		const producerIds = ['media-a']
+		const first = await getRankedDiscoveryPlan({
+			request: standardRequest(),
+			scope: { kind: 'public' },
+			runtime,
+			getFreshValue: () => ({ ids: producerIds }),
+		})
+
+		producerIds.push('media-b')
+		expect(first).toEqual({ ids: ['media-a'] })
+		expect(() => (first.ids as string[]).push('media-c')).toThrow()
+
+		const cached = await getRankedDiscoveryPlan({
+			request: standardRequest(),
+			scope: { kind: 'public' },
+			runtime,
+			getFreshValue: () => ({ ids: ['unexpected'] }),
+		})
+		expect(cached).toEqual({ ids: ['media-a'] })
+		expect(Object.isFrozen(cached)).toBe(true)
+		expect(Object.isFrozen(cached.ids)).toBe(true)
+	})
+
+	test('passes a deeply immutable parsed request to the producer', async () => {
+		const runtime = createRankedDiscoveryCacheRuntimeForTest()
+		let producerRequest: RankedDiscoveryPlanRequest | undefined
+
+		await getRankedDiscoveryPlan({
+			request: naturalRequest({
+				kinds: ['tv', 'movie'],
+				includeGenres: ['Mystery', 'Drama'],
+			}),
+			scope: { kind: 'public' },
+			runtime,
+			getFreshValue: request => {
+				producerRequest = request
+				return { ids: ['media-a'] }
+			},
+		})
+
+		expect(Object.isFrozen(producerRequest)).toBe(true)
+		const parsedRequest = producerRequest
+		if (parsedRequest?.source !== 'natural') {
+			throw new TypeError('Expected a natural request.')
+		}
+		expect(Object.isFrozen(parsedRequest.kinds)).toBe(true)
+		expect(Object.isFrozen(parsedRequest.includeGenres)).toBe(true)
+		expect(() => (parsedRequest.kinds as string[]).push('anime')).toThrow()
+		expect(parsedRequest.kinds).toEqual(['tv', 'movie'])
+	})
+})
+
+describe('ranked discovery cache semantics', () => {
+	test('serves hits from one memory-only test runtime', async () => {
+		const runtime = createRankedDiscoveryCacheRuntimeForTest()
+		const fresh = vi.fn(() => ({ ids: ['media-a'] as const }))
+
+		const first = await getRankedDiscoveryPlan({
+			request: standardRequest(),
+			scope: { kind: 'public' },
+			runtime,
+			getFreshValue: fresh,
+		})
+		const second = await getRankedDiscoveryPlan({
+			request: standardRequest(),
+			scope: { kind: 'public' },
+			runtime,
+			getFreshValue: fresh,
+		})
+
+		expect(first).toEqual({ ids: ['media-a'] })
+		expect(second).toEqual(first)
+		expect(fresh).toHaveBeenCalledOnce()
+		expect(runtime.cache.snapshot().entries).toBe(1)
+		expect(getCacheOperationsSnapshot()['ranked-discovery']).toMatchObject({
+			hit: 1,
+			miss: 1,
+			refresh: 1,
+		})
+	})
+
+	test('keeps the ranked-plan TTL at two minutes', () => {
+		expect(RANKED_DISCOVERY_CACHE_TTL_MS).toBe(120_000)
+	})
+
+	test('coalesces concurrent refreshes for the same semantic plan', async () => {
+		const runtime = createRankedDiscoveryCacheRuntimeForTest()
+		let release: (() => void) | undefined
+		const gate = new Promise<void>(resolve => {
+			release = resolve
+		})
+		const fresh = vi.fn(async () => {
+			await gate
+			return { ids: ['media-a'] as const }
+		})
+
+		const calls = Array.from({ length: 8 }, () =>
+			getRankedDiscoveryPlan({
+				request: standardRequest({ q: 'one private query' }),
+				scope: { kind: 'public' },
+				runtime,
+				getFreshValue: fresh,
+			}),
+		)
+		await vi.waitFor(() => expect(fresh).toHaveBeenCalledOnce())
+		release?.()
+
+		await expect(Promise.all(calls)).resolves.toEqual(
+			Array.from({ length: 8 }, () => ({ ids: ['media-a'] })),
+		)
+		expect(fresh).toHaveBeenCalledOnce()
+		expect(runtime.cache.snapshot().entries).toBe(1)
+	})
+
+	test('uses every standard and natural ranking input in opaque keys', async () => {
+		const runtime = createRankedDiscoveryCacheRuntimeForTest()
+		let sequence = 0
+		const fresh = vi.fn(() => ({ ids: [`media-${++sequence}`] }))
+
+		const standardInputs = [
+			standardRequest(),
+			standardRequest({ q: 'different query' }),
+			standardRequest({ kind: 'anime' }),
+			standardRequest({ genre: 'Drama' }),
+			standardRequest({ year: 2025 }),
+			standardRequest({ status: 'Finished Airing' }),
+			standardRequest({ provider: 'mal' }),
+			standardRequest({ sort: 'top-rated' }),
+		]
+		for (const request of standardInputs) {
+			await getRankedDiscoveryPlan({
+				request,
+				scope: { kind: 'public' },
+				runtime,
+				getFreshValue: fresh,
+			})
+		}
+
+		const naturalInputs = [
+			naturalRequest(),
+			naturalRequest({ kinds: ['anime'] }),
+			naturalRequest({ includeGenres: ['Drama'] }),
+			naturalRequest({ excludeGenres: ['Comedy'] }),
+			naturalRequest({ includeTerms: ['detective'] }),
+			naturalRequest({ excludeTerms: ['war'] }),
+			naturalRequest({ yearFrom: 2000 }),
+			naturalRequest({ yearTo: 2020 }),
+			naturalRequest({ releaseStatus: 'ongoing' }),
+			naturalRequest({ language: 'Japanese' }),
+			naturalRequest({ toneTerms: ['hopeful'] }),
+			naturalRequest({ pace: 'fast' }),
+			naturalRequest({ lengthUnit: null, lengthFrom: null, lengthTo: null }),
+			naturalRequest({ lengthFrom: 90 }),
+			naturalRequest({ lengthTo: 120 }),
+			naturalRequest({ sort: 'popular' }),
+		]
+		for (const request of naturalInputs) {
+			await getRankedDiscoveryPlan({
+				request,
+				scope: { kind: 'public' },
+				runtime,
+				getFreshValue: fresh,
+			})
+		}
+
+		expect(fresh).toHaveBeenCalledTimes(
+			standardInputs.length + naturalInputs.length,
+		)
+		expect(runtime.cache.snapshot().entries).toBe(
+			standardInputs.length + naturalInputs.length,
+		)
+	})
+
+	test('keeps exact producer-visible array semantics in cache keys', async () => {
+		const runtime = createRankedDiscoveryCacheRuntimeForTest()
+		const fresh = vi.fn(() => ({ ids: ['media-a'] as const }))
+		const first = naturalRequest({
+			kinds: ['tv', 'movie'],
+			includeGenres: ['Mystery', 'Drama', 'Mystery'],
+			includeTerms: ['locked room', 'detective'],
+		})
+		const reordered = naturalRequest({
+			kinds: ['movie', 'tv'],
+			includeGenres: ['Drama', 'Mystery'],
+			includeTerms: ['detective', 'locked room'],
+		})
+
+		await getRankedDiscoveryPlan({
+			request: first,
+			scope: { kind: 'public' },
+			runtime,
+			getFreshValue: fresh,
+		})
+		await getRankedDiscoveryPlan({
+			request: reordered,
+			scope: { kind: 'public' },
+			runtime,
+			getFreshValue: fresh,
+		})
+
+		expect(fresh).toHaveBeenCalledTimes(2)
+		expect(runtime.cache.snapshot().entries).toBe(2)
+	})
+
+	test('isolates viewers and fingerprints without exposing raw material', async () => {
+		const runtime = createRankedDiscoveryCacheRuntimeForTest()
+		const fresh = vi.fn(() => ({ ids: ['media-a'] as const }))
+		const secretQuery = 'a query that must remain private'
+		const secretViewer = 'private-viewer-identifier'
+		const firstFingerprint = createRankedDiscoveryViewerFingerprint({
+			stateDigest: 'private-taste-and-exclusion-digest-a',
+		})
+		const secondFingerprint = createRankedDiscoveryViewerFingerprint({
+			stateDigest: 'private-taste-and-exclusion-digest-b',
+		})
+
+		for (const [viewerId, viewerFingerprint] of [
+			[secretViewer, firstFingerprint],
+			['other-viewer', firstFingerprint],
+			[secretViewer, secondFingerprint],
+		] as const) {
+			await getRankedDiscoveryPlan({
+				request: viewerRequest({
+					q: secretQuery,
+					viewerFingerprint,
+				}),
+				scope: { kind: 'viewer', viewerId },
+				runtime,
+				getFreshValue: fresh,
+			})
+		}
+
+		expect(fresh).toHaveBeenCalledTimes(3)
+		expect(runtime.cache.snapshot().entries).toBe(3)
+		for (const key of runtime.cache.keys()) {
+			expect(key).toMatch(/^ck1_ranked-discovery_v1_[A-Za-z0-9_-]{43}$/)
+			expect(key).not.toContain(secretQuery)
+			expect(key).not.toContain(secretViewer)
+			expect(key).not.toContain('private-taste')
+		}
+		expect(Object.keys(getCacheOperationsSnapshot())).toEqual([
+			'ranked-discovery',
+		])
+	})
+
+	test('builds deterministic, opaque fingerprints from compact state', () => {
+		const first = createRankedDiscoveryViewerFingerprint({
+			counts: { feedback: 2, favorites: 3, tracking: 10 },
+			stateDigest: 'complete-streaming-digest',
+		})
+		const reordered = createRankedDiscoveryViewerFingerprint({
+			stateDigest: 'complete-streaming-digest',
+			counts: { tracking: 10, favorites: 3, feedback: 2 },
+		})
+		const changed = createRankedDiscoveryViewerFingerprint({
+			counts: { feedback: 2, favorites: 4, tracking: 10 },
+			stateDigest: 'complete-streaming-digest',
+		})
+
+		expect(first).toBe(reordered)
+		expect(first).not.toBe(changed)
+		expect(first).toMatch(/^rdf1_[A-Za-z0-9_-]{43}$/)
+		expect(first).not.toContain('complete-streaming-digest')
+	})
+
+	test('does not allow production callers to inject a cache runtime', async () => {
+		const runtime = createRankedDiscoveryCacheRuntimeForTest()
+		vi.stubEnv('NODE_ENV', 'production')
+
+		await expect(
+			getRankedDiscoveryPlan({
+				request: standardRequest(),
+				scope: { kind: 'public' },
+				runtime,
+				getFreshValue: () => ({ ids: [] }),
+			}),
+		).rejects.toThrow('only be used by tests')
+		expect(() => createRankedDiscoveryCacheRuntimeForTest()).toThrow(
+			'only be created by tests',
+		)
+	})
+})

--- a/app/utils/ranked-discovery-cache.server.ts
+++ b/app/utils/ranked-discovery-cache.server.ts
@@ -1,0 +1,411 @@
+import { createHash } from 'node:crypto'
+import { z } from 'zod'
+import {
+	canonicalCachePayload,
+	createOpaqueCacheKey,
+	type CacheKeyScope,
+	type CanonicalCacheValue,
+} from './cache-key.server.ts'
+import {
+	cachifiedSafely,
+	createMemoryCache,
+	type InspectableMemoryCache,
+} from './cache.server.ts'
+
+const RANKED_DISCOVERY_CACHE_NAMESPACE = 'ranked-discovery'
+const RANKED_DISCOVERY_CACHE_KEY_VERSION = 1
+const VIEWER_FINGERPRINT_PATTERN = /^rdf1_[A-Za-z0-9_-]{43}$/
+const MEDIA_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+const MAX_VIEWER_ID_BYTES = 512
+
+export const RANKED_DISCOVERY_CACHE_TTL_MS = 2 * 60 * 1_000
+export const RANKED_DISCOVERY_PLAN_MAX_IDS = 1_000
+
+const publicScopeSchema = z
+	.object({
+		kind: z.literal('public'),
+	})
+	.strict()
+
+const viewerScopeSchema = z
+	.object({
+		kind: z.literal('viewer'),
+		viewerId: z
+			.string()
+			.min(1)
+			.refine(value => value === value.trim(), {
+				message: 'viewerId must not have surrounding whitespace',
+			})
+			.refine(
+				value => Buffer.byteLength(value, 'utf8') <= MAX_VIEWER_ID_BYTES,
+				{
+					message: 'viewerId is too long',
+				},
+			),
+	})
+	.strict()
+
+const rankedDiscoveryScopeSchema = z.union([
+	publicScopeSchema,
+	viewerScopeSchema,
+])
+
+const rankedSortSchema = z.enum(['popular', 'top-rated'])
+const viewerRankedSortSchema = z.literal('for-you')
+const viewerFingerprintSchema = z.string().regex(VIEWER_FINGERPRINT_PATTERN)
+
+function exactString(minimum: number, maximum: number) {
+	return z
+		.string()
+		.min(minimum)
+		.max(maximum)
+		.refine(value => value === value.trim(), {
+			message: 'value must not have surrounding whitespace',
+		})
+}
+
+const standardRequestShape = {
+	source: z.literal('standard'),
+	q: exactString(0, 100),
+	kind: z.enum(['all', 'movie', 'tv', 'anime', 'manga']),
+	genre: exactString(0, 80),
+	year: z.number().int().min(1870).max(2200).nullable(),
+	status: exactString(0, 60),
+	provider: z.enum(['all', 'tmdb', 'mal']),
+}
+
+const standardPublicRequestSchema = z
+	.object({
+		...standardRequestShape,
+		sort: rankedSortSchema,
+	})
+	.strict()
+
+const standardViewerRequestSchema = z
+	.object({
+		...standardRequestShape,
+		sort: viewerRankedSortSchema,
+		viewerFingerprint: viewerFingerprintSchema,
+	})
+	.strict()
+
+const naturalRequestShape = {
+	source: z.literal('natural'),
+	kinds: z
+		.array(z.enum(['movie', 'tv', 'anime', 'manga']))
+		.min(1)
+		.max(4),
+	includeGenres: z.array(exactString(1, 80)).max(8),
+	excludeGenres: z.array(exactString(1, 80)).max(8),
+	includeTerms: z.array(exactString(2, 80)).max(12),
+	excludeTerms: z.array(exactString(2, 80)).max(12),
+	yearFrom: z.number().int().min(1870).max(2200).nullable(),
+	yearTo: z.number().int().min(1870).max(2200).nullable(),
+	releaseStatus: z
+		.enum(['upcoming', 'ongoing', 'completed', 'hiatus', 'cancelled'])
+		.nullable(),
+	language: exactString(2, 60).nullable(),
+	toneTerms: z.array(exactString(2, 80)).max(6),
+	pace: z.enum(['slow', 'moderate', 'fast']).nullable(),
+	lengthUnit: z.enum(['minutes', 'episodes', 'chapters', 'volumes']).nullable(),
+	lengthFrom: z.number().int().min(0).max(1_000_000).nullable(),
+	lengthTo: z.number().int().min(0).max(1_000_000).nullable(),
+}
+
+const naturalPublicRequestSchema = z
+	.object({
+		...naturalRequestShape,
+		sort: rankedSortSchema,
+	})
+	.strict()
+
+const naturalViewerRequestSchema = z
+	.object({
+		...naturalRequestShape,
+		sort: viewerRankedSortSchema,
+		viewerFingerprint: viewerFingerprintSchema,
+	})
+	.strict()
+
+const rankedDiscoveryPlanRequestSchema = z
+	.union([
+		standardPublicRequestSchema,
+		standardViewerRequestSchema,
+		naturalPublicRequestSchema,
+		naturalViewerRequestSchema,
+	])
+	.superRefine((request, context) => {
+		if (request.source !== 'natural') return
+		const includedGenres = new Set(
+			request.includeGenres.map(value => value.toLocaleLowerCase('en-US')),
+		)
+		const excludedGenres = new Set(
+			request.excludeGenres.map(value => value.toLocaleLowerCase('en-US')),
+		)
+		const includedTerms = new Set(
+			[...request.includeTerms, ...request.toneTerms].map(value =>
+				value.toLocaleLowerCase('en-US'),
+			),
+		)
+		const excludedTerms = new Set(
+			request.excludeTerms.map(value => value.toLocaleLowerCase('en-US')),
+		)
+		if ([...includedGenres].some(value => excludedGenres.has(value))) {
+			context.addIssue({
+				code: 'custom',
+				path: ['excludeGenres'],
+				message: 'a genre cannot be both included and excluded',
+			})
+		}
+		if ([...includedTerms].some(value => excludedTerms.has(value))) {
+			context.addIssue({
+				code: 'custom',
+				path: ['excludeTerms'],
+				message: 'a concept cannot be both included and excluded',
+			})
+		}
+		if (
+			request.yearFrom !== null &&
+			request.yearTo !== null &&
+			request.yearFrom > request.yearTo
+		) {
+			context.addIssue({
+				code: 'custom',
+				path: ['yearTo'],
+				message: 'yearTo must be greater than or equal to yearFrom',
+			})
+		}
+		if (
+			(request.lengthFrom !== null || request.lengthTo !== null) &&
+			request.lengthUnit === null
+		) {
+			context.addIssue({
+				code: 'custom',
+				path: ['lengthUnit'],
+				message: 'lengthUnit is required when a length bound is supplied',
+			})
+		}
+		if (
+			request.lengthFrom !== null &&
+			request.lengthTo !== null &&
+			request.lengthFrom > request.lengthTo
+		) {
+			context.addIssue({
+				code: 'custom',
+				path: ['lengthTo'],
+				message: 'lengthTo must be greater than or equal to lengthFrom',
+			})
+		}
+		const compatibleKinds = {
+			minutes: ['movie', 'tv', 'anime'],
+			episodes: ['tv', 'anime'],
+			chapters: ['manga'],
+			volumes: ['manga'],
+		} as const
+		const allowedKinds: readonly string[] = request.lengthUnit
+			? compatibleKinds[request.lengthUnit]
+			: []
+		if (
+			request.lengthUnit &&
+			request.kinds.some(kind => !allowedKinds.includes(kind))
+		) {
+			context.addIssue({
+				code: 'custom',
+				path: ['lengthUnit'],
+				message:
+					'length bounds are incompatible with one or more selected media kinds',
+			})
+		}
+	})
+
+const rankedDiscoveryPlanSchema = z
+	.object({
+		ids: z
+			.array(z.string().regex(MEDIA_ID_PATTERN))
+			.max(RANKED_DISCOVERY_PLAN_MAX_IDS),
+	})
+	.strict()
+	.superRefine((plan, context) => {
+		const ids = new Set<string>()
+		for (const [index, id] of plan.ids.entries()) {
+			if (ids.has(id)) {
+				context.addIssue({
+					code: 'custom',
+					path: ['ids', index],
+					message: 'ranked discovery IDs must be unique',
+				})
+			}
+			ids.add(id)
+		}
+	})
+
+type DeepReadonly<Value> = Value extends readonly (infer Item)[]
+	? readonly DeepReadonly<Item>[]
+	: Value extends object
+		? { readonly [Key in keyof Value]: DeepReadonly<Value[Key]> }
+		: Value
+
+export type RankedDiscoveryPlanRequest = DeepReadonly<
+	z.infer<typeof rankedDiscoveryPlanRequestSchema>
+>
+export type RankedDiscoveryPlan = Readonly<{
+	ids: readonly string[]
+}>
+
+function canonicalClone(value: unknown) {
+	return JSON.parse(canonicalCachePayload(value)) as unknown
+}
+
+function parseRequest(value: unknown): RankedDiscoveryPlanRequest {
+	const request = rankedDiscoveryPlanRequestSchema.parse(canonicalClone(value))
+	if (request.source === 'standard') return Object.freeze(request)
+	return Object.freeze({
+		...request,
+		// Preserve exact array order and cardinality: the producer receives this
+		// immutable request, so its complete semantics and the key cannot diverge.
+		kinds: Object.freeze([...request.kinds]),
+		includeGenres: Object.freeze([...request.includeGenres]),
+		excludeGenres: Object.freeze([...request.excludeGenres]),
+		includeTerms: Object.freeze([...request.includeTerms]),
+		excludeTerms: Object.freeze([...request.excludeTerms]),
+		toneTerms: Object.freeze([...request.toneTerms]),
+	})
+}
+
+function parseScope(value: unknown): CacheKeyScope {
+	return rankedDiscoveryScopeSchema.parse(canonicalClone(value))
+}
+
+function parsePlan(value: unknown): RankedDiscoveryPlan {
+	const plan = rankedDiscoveryPlanSchema.parse(canonicalClone(value))
+	return Object.freeze({
+		ids: Object.freeze([...plan.ids]),
+	})
+}
+
+function assertScopeMatchesRequest(
+	request: RankedDiscoveryPlanRequest,
+	scope: CacheKeyScope,
+) {
+	if (request.sort === 'for-you' && scope.kind !== 'viewer') {
+		throw new TypeError('For-you ranked discovery plans require viewer scope.')
+	}
+	if (request.sort !== 'for-you' && scope.kind !== 'public') {
+		throw new TypeError('Public ranked discovery plans require public scope.')
+	}
+}
+
+/**
+ * Hash compact, complete viewer taste and exclusion state before it reaches a
+ * cache key. The caller owns selecting every semantic input; this boundary
+ * ensures those inputs cannot be recovered from the request or cache reports.
+ */
+export function createRankedDiscoveryViewerFingerprint(
+	material: CanonicalCacheValue,
+) {
+	return `rdf1_${createHash('sha256')
+		.update(canonicalCachePayload(material), 'utf8')
+		.digest('base64url')}` as const
+}
+
+const rankedDiscoveryTestRuntimeBrand = Symbol('ranked-discovery-test-runtime')
+
+export type RankedDiscoveryCacheRuntime = Readonly<{
+	bypass: boolean
+	cache: InspectableMemoryCache
+	datasourceUrl: string
+	[rankedDiscoveryTestRuntimeBrand]: true
+}>
+
+/**
+ * Production callers cannot replace the shared cache or override bypass
+ * policy. Tests can use this explicit runtime to verify hits and single-flight
+ * behavior while Vitest's default NODE_ENV=test policy remains a hard bypass.
+ */
+export function createRankedDiscoveryCacheRuntimeForTest({
+	bypass = false,
+	cache = createMemoryCache({ name: 'ranked-discovery-test-cache' }),
+	datasourceUrl = 'file::memory:',
+}: {
+	bypass?: boolean
+	cache?: InspectableMemoryCache
+	datasourceUrl?: string
+} = {}): RankedDiscoveryCacheRuntime {
+	if (process.env.NODE_ENV !== 'test') {
+		throw new Error(
+			'Ranked discovery cache runtimes can only be created by tests.',
+		)
+	}
+	if (typeof bypass !== 'boolean') {
+		throw new TypeError('Ranked discovery cache bypass must be a boolean.')
+	}
+	return Object.freeze({
+		bypass,
+		cache,
+		datasourceUrl,
+		[rankedDiscoveryTestRuntimeBrand]: true as const,
+	})
+}
+
+function isBypassed(runtime: RankedDiscoveryCacheRuntime | undefined) {
+	if (runtime) {
+		if (
+			process.env.NODE_ENV !== 'test' ||
+			runtime[rankedDiscoveryTestRuntimeBrand] !== true
+		) {
+			throw new Error(
+				'Ranked discovery cache runtimes can only be used by tests.',
+			)
+		}
+		return runtime.bypass
+	}
+	return process.env.NODE_ENV === 'test' || process.env.VEUD_E2E === '1'
+}
+
+export async function getRankedDiscoveryPlan({
+	request: rawRequest,
+	scope: rawScope,
+	getFreshValue,
+	runtime,
+}: {
+	request: RankedDiscoveryPlanRequest
+	scope: CacheKeyScope
+	getFreshValue: (
+		request: RankedDiscoveryPlanRequest,
+	) => RankedDiscoveryPlan | Promise<RankedDiscoveryPlan>
+	runtime?: RankedDiscoveryCacheRuntime
+}): Promise<RankedDiscoveryPlan> {
+	const request = parseRequest(rawRequest)
+	const scope = parseScope(rawScope)
+	assertScopeMatchesRequest(request, scope)
+
+	if (isBypassed(runtime)) {
+		return parsePlan(await getFreshValue(request))
+	}
+
+	const key = createOpaqueCacheKey({
+		namespace: RANKED_DISCOVERY_CACHE_NAMESPACE,
+		version: RANKED_DISCOVERY_CACHE_KEY_VERSION,
+		scope,
+		payload: request,
+		...(runtime ? { datasourceUrl: runtime.datasourceUrl } : {}),
+	})
+	const plan = await cachifiedSafely(
+		RANKED_DISCOVERY_CACHE_NAMESPACE,
+		{
+			key,
+			ttl: RANKED_DISCOVERY_CACHE_TTL_MS,
+			checkValue(value) {
+				try {
+					parsePlan(value)
+					return true
+				} catch {
+					return false
+				}
+			},
+			getFreshValue: async () => parsePlan(await getFreshValue(request)),
+		},
+		runtime?.cache,
+	)
+	return parsePlan(plan)
+}

--- a/tests/e2e/discover.test.ts
+++ b/tests/e2e/discover.test.ts
@@ -187,6 +187,63 @@ test('member can filter the catalog and discover an unseen personalized title', 
 	}
 })
 
+test('ranked discovery recomputes plans during browser tests', async ({
+	page,
+}) => {
+	const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+	const query = `Browser Cache Bypass ${suffix}`
+	const initial = await prisma.media.create({
+		data: {
+			kind: 'movie',
+			title: `${query} Initial`,
+			catalogScore: 6,
+			externalIds: {
+				create: {
+					provider: 'tmdb',
+					kind: 'movie',
+					externalId: `cache-initial-${suffix}`,
+					sourceRatingCount: 100,
+				},
+			},
+		},
+	})
+	let addedId: string | null = null
+
+	try {
+		const url = `/discover?q=${encodeURIComponent(query)}&kind=movie&sort=top-rated`
+		await page.goto(url)
+		await expect(page.getByText(initial.title!, { exact: true })).toBeVisible()
+
+		const added = await prisma.media.create({
+			data: {
+				kind: 'movie',
+				title: `${query} Added`,
+				catalogScore: 10,
+				externalIds: {
+					create: {
+						provider: 'tmdb',
+						kind: 'movie',
+						externalId: `cache-added-${suffix}`,
+						sourceRatingCount: 1_000_000,
+					},
+				},
+			},
+		})
+		addedId = added.id
+
+		await page.reload()
+		await expect(page.getByText(added.title!, { exact: true })).toBeVisible()
+	} finally {
+		await prisma.media
+			.deleteMany({
+				where: {
+					id: { in: [initial.id, ...(addedId ? [addedId] : [])] },
+				},
+			})
+			.catch(() => {})
+	}
+})
+
 test('global advanced search returns five grounded local matches without provider inference', async ({
 	page,
 }) => {


### PR DESCRIPTION
## Summary
- add strict opaque public/viewer ranked ID-plan caching for popular, top-rated, and for-you discovery
- revalidate fresh eligibility before honest pagination and hydrate only the selected 24 rows with current catalog/community/viewer state
- slim and bound ranking queries, correct natural-language for-you exclusions/global ranking, and skip redundant discovery work on graph-only views
- add cache isolation, freshness, pagination, route-predicate, and production-mode E2E bypass regressions

## Validation
- 162 test files / 836 tests with coverage
- full lint, typecheck, production build, and bundle budgets
- all 98 Chromium scenarios
- isolated PostgreSQL migration, drift, smoke, 2,000-row load, concurrency, and cleanup gates
- three independent adversarial reviews plus narrow re-reviews: clear

Recommendation graphs remain intentionally uncached pending durable privacy-safe revision invalidation.