### PR TITLE
Bound profile analytics and activity reads

### DIFF
--- a/app/routes/_home+/home-feed.route.test.ts
+++ b/app/routes/_home+/home-feed.route.test.ts
@@ -196,6 +196,33 @@ test('anonymous home loader does not expose a personalized feed', async () => {
 	})
 })
 
+test('anonymous home hides public-marked activity with unresolved list provenance', async () => {
+	vi.stubEnv('OPENAI_API_KEY', '')
+	const actor = await createUser('anonymous_privacy')
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Anonymous privacy fixture' },
+	})
+	const unresolved = await prisma.activityEvent.create({
+		data: {
+			type: 'score',
+			actorId: actor.id,
+			mediaId: media.id,
+			statusLabel: 'Former private list',
+			score: 10,
+			isPublic: true,
+		},
+	})
+
+	const result = await loader({
+		request: new Request(BASE_URL),
+		params: {},
+	} as any)
+
+	expect(
+		result.data.anonymousHomeProof?.activity.map(item => item.id),
+	).not.toContain(`tracking:${unresolved.id}`)
+})
+
 test('new members receive discovery suggestions that exclude themselves', async () => {
 	const [viewer, candidate] = await Promise.all([
 		createUser('new_viewer'),

--- a/app/routes/lists+/.$username+/.$list-type+/$watchlist.tsx
+++ b/app/routes/lists+/.$username+/.$list-type+/$watchlist.tsx
@@ -1,14 +1,19 @@
 import { invariantResponse } from '@epic-web/invariant'
-import { data as json, type LoaderFunctionArgs } from 'react-router'
-import { useLoaderData, useNavigate, useRevalidator } from 'react-router'
+import {
+	data as json,
+	type LoaderFunctionArgs,
+	useLoaderData,
+	useNavigate,
+	useRevalidator,
+} from 'react-router'
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx'
 import { listNavButtons } from '#app/components/list-nav-buttons.tsx'
 import { TrackingAssistantDialog } from '#app/components/tracking-assistant-dialog.tsx'
+import { ResponsiveWatchlist } from '#app/routes/lists+/.$username+/.$list-type+/grid/responsive-watchlist.tsx'
 import { getUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import { mediaIdentityKey } from '#app/utils/media-identity.ts'
-import { ResponsiveWatchlist } from '#app/routes/lists+/.$username+/.$list-type+/grid/responsive-watchlist.tsx'
 import {
+	prepareWatchlistEntryForViewer,
 	publicEntryPayload,
 	publicListOwnerSelect,
 	publicListTypeSelect,
@@ -16,6 +21,7 @@ import {
 } from '#app/utils/lists/public-watchlist.server.ts'
 import { visibleWatchlistWhere } from '#app/utils/lists/visibility.server.ts'
 import { normalizeWatchlistEntryScores } from '#app/utils/lists/watchlist-entry-scores.server.ts'
+import { mediaIdentityKey } from '#app/utils/media-identity.ts'
 import { useOptionalUser } from '#app/utils/user.ts'
 import '#app/styles/watchlist.scss'
 
@@ -51,7 +57,7 @@ export async function loader(params: LoaderFunctionArgs) {
 
 	let watchListData
 
-	const watchListsSorted = watchLists.sort((a, b) => a.position - b.position)
+	watchLists.sort((a, b) => a.position - b.position)
 
 	for (const watchList of watchLists) {
 		if (watchList.typeId == listTypeData.id) {
@@ -97,6 +103,8 @@ export async function loader(params: LoaderFunctionArgs) {
 				},
 				trackingState: {
 					select: {
+						ownerId: true,
+						mediaId: true,
 						status: true,
 						statusWatchlistId: true,
 						score: true,
@@ -104,8 +112,14 @@ export async function loader(params: LoaderFunctionArgs) {
 						completedAt: true,
 						repeatCount: true,
 						progress: {
+							where: {
+								unit: { in: ['episode', 'chapter', 'volume'] },
+							},
+							orderBy: { unit: 'asc' },
+							take: 3,
 							select: { unit: true, current: true, total: true },
 						},
+						statusWatchlist: { select: { ownerId: true, isPublic: true } },
 					},
 				},
 			},
@@ -138,15 +152,16 @@ export async function loader(params: LoaderFunctionArgs) {
 			: Promise.resolve([]),
 	])
 
+	const isOwner = viewerId === listOwner.id
 	const normalizedEntries = listEntries
+		.map(entry => prepareWatchlistEntryForViewer(entry, listOwner.id, isOwner))
 		.map(normalizeWatchlistEntryScores)
 		.sort((a, b) => a.position - b.position)
-	const listEntriesSorted =
-		viewerId === listOwner.id
-			? normalizedEntries
-			: normalizedEntries.map(entry =>
-					publicEntryPayload(entry, watchListData.displayedColumns),
-				)
+	const listEntriesSorted = isOwner
+		? normalizedEntries
+		: normalizedEntries.map(entry =>
+				publicEntryPayload(entry, watchListData.displayedColumns),
+			)
 
 	const typedFavorites = favorites.reduce<Record<string, typeof favorites>>(
 		(x, y) => {

--- a/app/routes/lists+/.fetch+/add-row.$request.ts
+++ b/app/routes/lists+/.fetch+/add-row.$request.ts
@@ -1,10 +1,7 @@
 import { type ActionFunctionArgs } from 'react-router'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import {
-	requireOwnedWatchlist,
-	stripProtectedFields,
-} from '#app/utils/lists/authorization.server.ts'
+import { stripProtectedFields } from '#app/utils/lists/authorization.server.ts'
 import {
 	ensureMediaForIdentity,
 	hydrateMediaCatalog,
@@ -14,36 +11,13 @@ import { parseMediaRelationCandidates } from '#app/utils/media-relations.ts'
 import { syncMediaRelations } from '#app/utils/media-relations.server.ts'
 import { ensureTrackingStateForEntry } from '#app/utils/tracking-state.server.ts'
 import { claimWatchlistRevisions } from '#app/utils/lists/watchlist-revision.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 
 export async function addEntryCommand(ownerId: string, row: unknown) {
 	if (!row || typeof row !== 'object' || Array.isArray(row)) {
 		throw new Response('Invalid row payload', { status: 400 })
 	}
 	const rowObj = row as Record<string, unknown>
-
-	const watchlist = await requireOwnedWatchlist(
-		ownerId,
-		rowObj.watchlistId as string | null | undefined,
-	)
-
-	const listType = await prisma.listType.findUnique({
-		where: { id: watchlist.typeId },
-		select: { name: true },
-	})
-	if (!listType) throw new Response('List type not found', { status: 400 })
-	const mediaIdentity = parseMediaIdentityForListType(
-		rowObj.mediaIdentity,
-		listType.name,
-		typeof rowObj.thumbnail === 'string' ? rowObj.thumbnail : null,
-	)
-	if (!mediaIdentity) {
-		throw new Response('Choose a catalog title before adding it to a list', {
-			status: 400,
-		})
-	}
-	const mediaRelations = mediaIdentity
-		? parseMediaRelationCandidates(rowObj.mediaRelations, mediaIdentity)
-		: null
 
 	// Identity and relations are server-managed. The client may describe a provider
 	// identity, but it cannot directly connect an entry to an arbitrary Media row.
@@ -59,6 +33,30 @@ export async function addEntryCommand(ownerId: string, row: unknown) {
 	])
 
 	return await prisma.$transaction(async tx => {
+		await serializeUserLibraryMutation(tx, ownerId)
+		const watchlistId =
+			typeof rowObj.watchlistId === 'string' ? rowObj.watchlistId : null
+		const watchlist = watchlistId
+			? await tx.watchlist.findFirst({
+					where: { id: watchlistId, ownerId },
+					include: { type: { select: { name: true } } },
+				})
+			: null
+		if (!watchlist) throw new Response('Not found', { status: 404 })
+		const mediaIdentity = parseMediaIdentityForListType(
+			rowObj.mediaIdentity,
+			watchlist.type.name,
+			typeof rowObj.thumbnail === 'string' ? rowObj.thumbnail : null,
+		)
+		if (!mediaIdentity) {
+			throw new Response('Choose a catalog title before adding it to a list', {
+				status: 400,
+			})
+		}
+		const mediaRelations = parseMediaRelationCandidates(
+			rowObj.mediaRelations,
+			mediaIdentity,
+		)
 		const entryCount = await tx.entry.count({
 			where: { watchlistId: watchlist.id },
 		})

--- a/app/routes/lists+/.fetch+/advanced-edit.$request.ts
+++ b/app/routes/lists+/.fetch+/advanced-edit.$request.ts
@@ -14,6 +14,7 @@ import {
 } from '#app/utils/media-detail.ts'
 import { syncTrackingStateForEntry } from '#app/utils/tracking-state.server.ts'
 import { trackingStateFromEntry } from '#app/utils/tracking-state.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 
 const categoryScoreFields = [
 	'story',
@@ -139,7 +140,7 @@ export async function advancedEditEntryCommand(
 		throw new Response('Invalid advanced edit payload', { status: 400 })
 	}
 	const editable = fields as Record<string, unknown>
-	const { entry, watchlist } = await requireOwnedEntry(ownerId, entryId)
+	const { entry } = await requireOwnedEntry(ownerId, entryId)
 	const unknownField = Object.keys(editable).find(
 		field => !editableFields.has(field),
 	)
@@ -194,25 +195,15 @@ export async function advancedEditEntryCommand(
 		throw new Response('Invalid status', { status: 400 })
 	}
 
-	if (
-		Object.hasOwn(editable, 'started') ||
-		Object.hasOwn(editable, 'finished') ||
-		repeatCount !== null
-	) {
-		const history = parseHistory(entry.history)
-		if (Object.hasOwn(editable, 'started')) {
-			history.started = parseDate(editable.started)
-		}
-		if (Object.hasOwn(editable, 'finished')) {
-			history.finished = parseDate(editable.finished)
-		}
-		if (repeatCount !== null) history.repeatCount = repeatCount
-		history.lastUpdated = Date.now()
-		data.history = JSON.stringify(history)
-	}
+	const hasStarted = Object.hasOwn(editable, 'started')
+	const hasFinished = Object.hasOwn(editable, 'finished')
+	const started = hasStarted ? parseDate(editable.started) : undefined
+	const finished = hasFinished ? parseDate(editable.finished) : undefined
+	const hasHistoryEdits = hasStarted || hasFinished || repeatCount !== null
 
 	if (
 		!Object.keys(data).length &&
+		!hasHistoryEdits &&
 		progress === null &&
 		destinationWatchlistId === null
 	) {
@@ -221,6 +212,7 @@ export async function advancedEditEntryCommand(
 
 	try {
 		return await prisma.$transaction(async tx => {
+			await serializeUserLibraryMutation(tx, ownerId)
 			const current = await tx.entry.findUnique({
 				where: { id: entry.id },
 				include: {
@@ -242,9 +234,18 @@ export async function advancedEditEntryCommand(
 				throw new Response('Not found', { status: 404 })
 			}
 
+			const transactionData = { ...data }
+			if (hasHistoryEdits) {
+				const history = parseHistory(current.history)
+				if (hasStarted) history.started = started
+				if (hasFinished) history.finished = finished
+				if (repeatCount !== null) history.repeatCount = repeatCount
+				history.lastUpdated = Date.now()
+				transactionData.history = JSON.stringify(history)
+			}
 			const mediaKind = mediaKindForEntry(current)
 			const allowedProgress = new Set(progressUnitsForMediaKind(mediaKind))
-			let pendingEntry = { ...current, ...data }
+			let pendingEntry = { ...current, ...transactionData }
 			if (progress) {
 				for (const [unit, currentProgress] of Object.entries(progress)) {
 					if (!allowedProgress.has(unit as any)) {
@@ -274,14 +275,14 @@ export async function advancedEditEntryCommand(
 						previousCurrent: saved?.current ?? legacy?.current ?? 0,
 						total,
 					})
-					Object.assign(data, progressUpdate)
+					Object.assign(transactionData, progressUpdate)
 					pendingEntry = { ...pendingEntry, ...progressUpdate }
 				}
 			}
 
 			await tx.entry.update({
 				where: { id: current.id },
-				data: data as Prisma.EntryUpdateInput,
+				data: transactionData as Prisma.EntryUpdateInput,
 			})
 
 			if (
@@ -297,7 +298,7 @@ export async function advancedEditEntryCommand(
 			}
 
 			await tx.watchlist.update({
-				where: { id: watchlist.id },
+				where: { id: current.watchlist.id },
 				data: { updatedAt: new Date() },
 			})
 			await syncTrackingStateForEntry(tx, current.id)

--- a/app/routes/lists+/.fetch+/create-watchlist.$request.ts
+++ b/app/routes/lists+/.fetch+/create-watchlist.$request.ts
@@ -2,6 +2,10 @@ import { type ActionFunctionArgs } from 'react-router'
 import { z } from 'zod'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import {
+	assertWatchlistCreationAllowed,
+	WatchlistLimitError,
+} from '#app/utils/watchlist-limits.ts'
 
 const wrapped = <T extends z.ZodTypeAny>(value: T) =>
 	z.object({ value, type: z.string() })
@@ -55,55 +59,66 @@ export async function createWatchlistCommand(
 	})
 	if (!type) throw new Response('List type not found', { status: 400 })
 
-	return prisma.$transaction(async tx => {
-		const count = await tx.watchlist.count({
-			where: { ownerId, typeId: type.id },
+	try {
+		return await prisma.$transaction(async tx => {
+			await assertWatchlistCreationAllowed(tx, {
+				ownerId,
+				typeId: type.id,
+			})
+			const count = await tx.watchlist.count({
+				where: { ownerId, typeId: type.id },
+			})
+			const position = Math.min(input.position ?? count + 1, count + 1)
+			const requestedSlug = watchlistSlug(input.name ?? input.header)
+			const existingNames = new Set(
+				(
+					await tx.watchlist.findMany({
+						where: { ownerId, typeId: type.id },
+						select: { name: true },
+					})
+				).map(watchlist => watchlist.name),
+			)
+			let name = requestedSlug
+			for (let suffix = 2; existingNames.has(name); suffix++) {
+				name = `${requestedSlug.slice(0, 72)}-${suffix}`
+			}
+			const displayedColumns =
+				input.displayedColumns ??
+				Object.keys(JSON.parse(type.columns) as Record<string, unknown>)
+					.filter(
+						column =>
+							column !== 'id' &&
+							column !== 'watchlistId' &&
+							column !== 'watchlist',
+					)
+					.join(', ')
+			await tx.watchlist.updateMany({
+				where: {
+					ownerId,
+					typeId: type.id,
+					position: { gte: position },
+				},
+				data: { position: { increment: 1 } },
+			})
+			return tx.watchlist.create({
+				data: {
+					ownerId,
+					typeId: type.id,
+					position,
+					name,
+					header: input.header,
+					displayedColumns,
+					description: input.description,
+					isPublic: input.isPublic,
+				},
+			})
 		})
-		const position = Math.min(input.position ?? count + 1, count + 1)
-		const requestedSlug = watchlistSlug(input.name ?? input.header)
-		const existingNames = new Set(
-			(
-				await tx.watchlist.findMany({
-					where: { ownerId, typeId: type.id },
-					select: { name: true },
-				})
-			).map(watchlist => watchlist.name),
-		)
-		let name = requestedSlug
-		for (let suffix = 2; existingNames.has(name); suffix++) {
-			name = `${requestedSlug.slice(0, 72)}-${suffix}`
+	} catch (error) {
+		if (error instanceof WatchlistLimitError) {
+			throw new Response(error.message, { status: error.status })
 		}
-		const displayedColumns =
-			input.displayedColumns ??
-			Object.keys(JSON.parse(type.columns) as Record<string, unknown>)
-				.filter(
-					column =>
-						column !== 'id' &&
-						column !== 'watchlistId' &&
-						column !== 'watchlist',
-				)
-				.join(', ')
-		await tx.watchlist.updateMany({
-			where: {
-				ownerId,
-				typeId: type.id,
-				position: { gte: position },
-			},
-			data: { position: { increment: 1 } },
-		})
-		return tx.watchlist.create({
-			data: {
-				ownerId,
-				typeId: type.id,
-				position,
-				name,
-				header: input.header,
-				displayedColumns,
-				description: input.description,
-				isPublic: input.isPublic,
-			},
-		})
-	})
+		throw error
+	}
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {

--- a/app/routes/lists+/.fetch+/delete-empty-rows.$request.ts
+++ b/app/routes/lists+/.fetch+/delete-empty-rows.$request.ts
@@ -1,36 +1,38 @@
 import { type ActionFunctionArgs } from 'react-router'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import { requireOwnedWatchlist } from '#app/utils/lists/authorization.server.ts'
 import { normalizeEntryPositions } from '#app/utils/lists/entry-order.server.ts'
 import { claimWatchlistRevisions } from '#app/utils/lists/watchlist-revision.server.ts'
 import {
 	deleteTrackingStateIfOrphan,
 	reconcileTrackingStateBeforeEntryDeletion,
 } from '#app/utils/tracking-state.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 
 export async function deleteEmptyEntriesCommand(
 	ownerId: string,
 	watchlistId: string | null,
 ) {
-	const watchlist = await requireOwnedWatchlist(ownerId, watchlistId)
+	return prisma.$transaction(async tx => {
+		await serializeUserLibraryMutation(tx, ownerId)
+		const watchlist = watchlistId
+			? await tx.watchlist.findFirst({
+					where: { id: watchlistId, ownerId },
+				})
+			: null
+		if (!watchlist) throw new Response('Not found', { status: 404 })
+		const entries = await tx.entry.findMany({
+			where: { watchlistId: watchlist.id },
+		})
 
-	const entries = await prisma.entry.findMany({
-		where: {
-			watchlistId: watchlist.id,
-		},
-	})
+		// An "empty" row has neither a meaningful title nor type.
+		const removedEntries = entries.filter(
+			entry =>
+				(!entry.title || entry.title.replace(/\W/g, '') === '') &&
+				(!entry.type || entry.type.replace(/\W/g, '') === ''),
+		)
 
-	// An "empty" row has neither a meaningful title nor type.
-	const removedEntries = entries.filter(
-		entry =>
-			(!entry.title || entry.title.replace(/\W/g, '') === '') &&
-			(!entry.type || entry.type.replace(/\W/g, '') === ''),
-	)
-
-	// Remove them in a single atomic statement rather than one query per row.
-	if (removedEntries.length > 0) {
-		await prisma.$transaction(async tx => {
+		if (removedEntries.length > 0) {
 			const removedEntryIds = removedEntries.map(entry => entry.id)
 			for (const trackingStateId of new Set(
 				removedEntries.map(entry => entry.trackingStateId).filter(Boolean),
@@ -49,10 +51,9 @@ export async function deleteEmptyEntriesCommand(
 			)) {
 				await deleteTrackingStateIfOrphan(tx, trackingStateId)
 			}
-		})
-	}
-
-	return removedEntries
+		}
+		return removedEntries
+	})
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {

--- a/app/routes/lists+/.fetch+/delete-row.$request.ts
+++ b/app/routes/lists+/.fetch+/delete-row.$request.ts
@@ -1,21 +1,29 @@
 import { type ActionFunctionArgs } from 'react-router'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import { requireOwnedEntry } from '#app/utils/lists/authorization.server.ts'
 import { normalizeEntryPositions } from '#app/utils/lists/entry-order.server.ts'
 import { claimWatchlistRevisions } from '#app/utils/lists/watchlist-revision.server.ts'
 import {
 	deleteTrackingStateIfOrphan,
 	reconcileTrackingStateBeforeEntryDeletion,
 } from '#app/utils/tracking-state.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 
 export async function deleteEntryCommand(
 	ownerId: string,
 	entryId: string | null,
 ) {
-	const { entry, watchlist } = await requireOwnedEntry(ownerId, entryId)
-
 	return await prisma.$transaction(async tx => {
+		await serializeUserLibraryMutation(tx, ownerId)
+		const entry = entryId
+			? await tx.entry.findUnique({
+					where: { id: entryId },
+					include: { watchlist: true },
+				})
+			: null
+		if (!entry || entry.watchlist.ownerId !== ownerId) {
+			throw new Response('Not found', { status: 404 })
+		}
 		await reconcileTrackingStateBeforeEntryDeletion(tx, entry.trackingStateId, {
 			id: entry.id,
 		})
@@ -23,7 +31,7 @@ export async function deleteEntryCommand(
 			where: { id: entry.id },
 		})
 		await normalizeEntryPositions(tx, deleted.watchlistId)
-		await claimWatchlistRevisions(tx, [watchlist])
+		await claimWatchlistRevisions(tx, [entry.watchlist])
 		await deleteTrackingStateIfOrphan(tx, deleted.trackingStateId)
 		return deleted
 	})

--- a/app/routes/lists+/.fetch+/delete-watchlist.$request.ts
+++ b/app/routes/lists+/.fetch+/delete-watchlist.$request.ts
@@ -1,8 +1,8 @@
 import { type ActionFunctionArgs } from 'react-router'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import { syncWatchlistActivityVisibility } from '#app/utils/lists/activity-visibility.server.ts'
 import { requireOwnedWatchlist } from '#app/utils/lists/authorization.server.ts'
-import { syncWatchlistActivityVisibility } from '#app/utils/lists/visibility.server.ts'
 import {
 	deleteTrackingStateIfOrphan,
 	reconcileTrackingStateBeforeEntryDeletion,

--- a/app/routes/lists+/.fetch+/delete-watchlist.$request.ts
+++ b/app/routes/lists+/.fetch+/delete-watchlist.$request.ts
@@ -2,10 +2,12 @@ import { type ActionFunctionArgs } from 'react-router'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { requireOwnedWatchlist } from '#app/utils/lists/authorization.server.ts'
+import { syncWatchlistActivityVisibility } from '#app/utils/lists/visibility.server.ts'
 import {
 	deleteTrackingStateIfOrphan,
 	reconcileTrackingStateBeforeEntryDeletion,
 } from '#app/utils/tracking-state.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 
 export async function deleteWatchlistCommand(
 	ownerId: string,
@@ -17,6 +19,7 @@ export async function deleteWatchlistCommand(
 	// watchlists of this type — all atomically, so a mid-sequence failure can't leave a
 	// half-deleted list or gaps in the ordering.
 	await prisma.$transaction(async tx => {
+		await serializeUserLibraryMutation(tx, ownerId)
 		const trackingStateIds = (
 			await tx.entry.findMany({
 				where: { watchlistId: watchlist.id, trackingStateId: { not: null } },
@@ -30,6 +33,13 @@ export async function deleteWatchlistCommand(
 			})
 		}
 
+		// Foreign-key deletion clears immutable watchlist ids. Quarantine linked
+		// activity first so a deleted public list cannot turn an old event into a
+		// seemingly listless public event.
+		await syncWatchlistActivityVisibility(tx, {
+			...watchlist,
+			isPublic: false,
+		})
 		await tx.watchlist.delete({ where: { id: watchlist.id } })
 
 		await tx.entry.deleteMany({

--- a/app/routes/lists+/.fetch+/fix-watchlist-order.$request.ts
+++ b/app/routes/lists+/.fetch+/fix-watchlist-order.$request.ts
@@ -1,18 +1,9 @@
 import { type ActionFunctionArgs } from 'react-router'
-import { prisma } from '#app/utils/db.server.ts'
-import { requireEntryOwner } from '#app/utils/lists/authorization.server.ts'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { deleteEntryCommand } from './delete-row.$request.ts'
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const searchParams = new URLSearchParams(params.request)
-
-  const id = searchParams.get('id')
-
-  // The entry must belong to a watchlist the current user owns.
-  await requireEntryOwner(request, id)
-
-  return await prisma.entry.delete({
-    where: {
-      id: id as string,
-    },
-  })
+	const ownerId = await requireUserId(request)
+	const searchParams = new URLSearchParams(params.request)
+	return deleteEntryCommand(ownerId, searchParams.get('id'))
 }

--- a/app/routes/lists+/.fetch+/get-list-entries.$request.ts
+++ b/app/routes/lists+/.fetch+/get-list-entries.$request.ts
@@ -1,8 +1,11 @@
 import { type LoaderFunctionArgs } from 'react-router'
 import { prisma } from '#app/utils/db.server.ts'
-import { normalizeWatchlistEntryScores } from '#app/utils/lists/watchlist-entry-scores.server.ts'
-import { publicEntryPayload } from '#app/utils/lists/public-watchlist.server.ts'
+import {
+	prepareWatchlistEntryForViewer,
+	publicEntryPayload,
+} from '#app/utils/lists/public-watchlist.server.ts'
 import { requireVisibleWatchlist } from '#app/utils/lists/visibility.server.ts'
+import { normalizeWatchlistEntryScores } from '#app/utils/lists/watchlist-entry-scores.server.ts'
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const searchParams = new URLSearchParams(params.request)
@@ -19,11 +22,26 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		},
 		include: {
 			media: { select: { tmdbScore: true, malScore: true } },
-			trackingState: { select: { score: true } },
+			trackingState: {
+				select: {
+					ownerId: true,
+					mediaId: true,
+					statusWatchlistId: true,
+					score: true,
+					startedAt: true,
+					completedAt: true,
+					statusWatchlist: { select: { ownerId: true, isPublic: true } },
+				},
+			},
 		},
 	})
-	const normalized = entries.map(normalizeWatchlistEntryScores)
-	return viewerId === watchlist.ownerId
+	const isOwner = viewerId === watchlist.ownerId
+	const normalized = entries
+		.map(entry =>
+			prepareWatchlistEntryForViewer(entry, watchlist.ownerId, isOwner),
+		)
+		.map(normalizeWatchlistEntryScores)
+	return isOwner
 		? normalized
 		: normalized.map(entry =>
 				publicEntryPayload(entry, watchlist.displayedColumns),

--- a/app/routes/lists+/.fetch+/update-cell.$request.ts
+++ b/app/routes/lists+/.fetch+/update-cell.$request.ts
@@ -2,14 +2,16 @@ import { type Prisma } from '@prisma/client'
 import { type ActionFunctionArgs } from 'react-router'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import { requireOwnedEntry } from '#app/utils/lists/authorization.server.ts'
 import { syncTrackingStateForEntry } from '#app/utils/tracking-state.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 
 async function updateEntryAndTrackingState(
 	tx: Prisma.TransactionClient,
+	ownerId: string,
 	entryId: string,
 	data: Record<string, unknown>,
 ) {
+	await serializeUserLibraryMutation(tx, ownerId)
 	await tx.entry.update({
 		where: { id: entryId },
 		data: data as any,
@@ -63,192 +65,191 @@ export async function updateEntryCellCommand(
 	},
 ) {
 	try {
-		const rowIndex = input.entryId
-		const colId = input.columnId
-		const newValue = input.value
-		const { entry, watchlist } = await requireOwnedEntry(ownerId, rowIndex)
-		const listType = await prisma.listType.findUnique({
-			where: { id: watchlist.typeId },
-			select: { columns: true, mediaType: true },
-		})
-		if (!listType) throw new Response('List type not found', { status: 400 })
-
-		let columnTypes: Record<string, unknown>
-		try {
-			const parsed = JSON.parse(listType.columns) as unknown
-			if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-				throw new Error('Invalid columns')
+		return await prisma.$transaction(async tx => {
+			await serializeUserLibraryMutation(tx, ownerId)
+			const entry = input.entryId
+				? await tx.entry.findUnique({
+						where: { id: input.entryId },
+						include: {
+							watchlist: {
+								include: {
+									type: { select: { columns: true, mediaType: true } },
+								},
+							},
+						},
+					})
+				: null
+			if (!entry || entry.watchlist.ownerId !== ownerId) {
+				throw new Response('Not found', { status: 404 })
 			}
-			columnTypes = parsed as Record<string, unknown>
-		} catch {
-			throw new Response('Invalid list type columns', { status: 500 })
-		}
 
-		const historyAliases: Record<string, string> = {
-			started: 'startDate',
-			finished: 'finishedDate',
-			added: 'dateAdded',
-			lastUpdated: 'lastUpdated',
-		}
-		const protectedColumns = new Set([
-			'id',
-			'watchlistId',
-			'watchlist',
-			'position',
-			'mediaId',
-			'media',
-			'trackingStateId',
-			'trackingState',
-		])
-		const schemaColumn = historyAliases[colId ?? ''] ?? colId
-		const expectedType = schemaColumn ? columnTypes[schemaColumn] : undefined
-		if (
-			!colId ||
-			protectedColumns.has(colId) ||
-			typeof expectedType !== 'string'
-		) {
-			throw new Response('Invalid editable column', { status: 400 })
-		}
-
-		const historyObject: any = entry
-
-		// The stored `history` is free-form JSON manipulated dynamically below, so it's `any`.
-		let parsedHistoryObject: any = {}
-		try {
-			parsedHistoryObject = JSON.parse(historyObject.history)
-
-			if (Object.keys(parsedHistoryObject).length < 1) throw new Error()
-
-			parsedHistoryObject.lastUpdated = Date.now()
-
-			if (['length', 'chapters', 'volumes'].includes(colId as string)) {
-				const lengthRegex = /\d+\s*\/\s*\d+ eps/g
-
-				if (lengthRegex.test(newValue as string) || colId != 'length') {
-					const mediaTotal = [...(newValue as string).matchAll(/\d+/g)]
-					let matchResult: string | undefined
-
-					try {
-						matchResult = mediaTotal[0][0]
-					} catch (e) {}
-
-					if (matchResult) {
-						if (!parsedHistoryObject.progress) {
-							parsedHistoryObject.progress = {}
-						}
-
-						if (colId == 'length') {
-							if (!parsedHistoryObject.progress[matchResult]) {
-								parsedHistoryObject.progress[matchResult] = {
-									completed: false,
-									finishDate: [],
-								}
-							}
-
-							parsedHistoryObject.progress[matchResult].completed = true
-							parsedHistoryObject.progress[matchResult].finishDate.push(
-								Date.now(),
-							)
-						} else {
-							let mediaType: string
-							const mediaTypeArray = JSON.parse(listType.mediaType) as string[]
-							const mediaTypesFormatted = mediaTypeArray.map(
-								mediaTypeRaw => `${mediaTypeRaw}s`,
-							)
-							const typeIndex = mediaTypesFormatted.findIndex(e => e === colId)
-
-							if (!mediaTypesFormatted || mediaTypesFormatted.length < 1) {
-								mediaType = 'episode'
-							} else if (typeIndex > 0) {
-								mediaType = mediaTypeArray[typeIndex]
-							} else {
-								mediaType = mediaTypeArray[0]
-							}
-
-							if (!parsedHistoryObject.progress[mediaType]) {
-								parsedHistoryObject.progress[mediaType] = {
-									[matchResult]: {
-										completed: false,
-										finishDate: [],
-									},
-								}
-							}
-
-							if (!parsedHistoryObject.progress[mediaType][matchResult]) {
-								parsedHistoryObject.progress[mediaType][matchResult] = {
-									completed: false,
-									finishDate: [],
-								}
-							}
-
-							parsedHistoryObject.progress[mediaType][matchResult].completed =
-								true
-							parsedHistoryObject.progress[mediaType][
-								matchResult
-							].finishDate.push(Date.now())
-						}
-					}
+			let columnTypes: Record<string, unknown>
+			try {
+				const parsed = JSON.parse(entry.watchlist.type.columns) as unknown
+				if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+					throw new Error('Invalid columns')
 				}
-
-				return await prisma.$transaction(tx =>
-					updateEntryAndTrackingState(tx, rowIndex as string, {
-						history: JSON.stringify(parsedHistoryObject),
-					}),
-				)
+				columnTypes = parsed as Record<string, unknown>
+			} catch {
+				throw new Response('Invalid list type columns', { status: 500 })
 			}
-		} catch (e) {
+
+			const colId = input.columnId
+			const historyAliases: Record<string, string> = {
+				started: 'startDate',
+				finished: 'finishedDate',
+				added: 'dateAdded',
+				lastUpdated: 'lastUpdated',
+			}
+			const protectedColumns = new Set([
+				'id',
+				'watchlistId',
+				'watchlist',
+				'position',
+				'mediaId',
+				'media',
+				'trackingStateId',
+				'trackingState',
+			])
+			const schemaColumn = historyAliases[colId ?? ''] ?? colId
+			const expectedType = schemaColumn ? columnTypes[schemaColumn] : undefined
 			if (
-				!parsedHistoryObject ||
-				typeof parsedHistoryObject !== 'object' ||
-				Array.isArray(parsedHistoryObject) ||
-				Object.keys(parsedHistoryObject).length === 0
+				!colId ||
+				protectedColumns.has(colId) ||
+				typeof expectedType !== 'string'
 			) {
-				parsedHistoryObject = {
+				throw new Response('Invalid editable column', { status: 400 })
+			}
+
+			let history: Record<string, any>
+			try {
+				const parsed = JSON.parse(entry.history ?? '') as unknown
+				if (
+					!parsed ||
+					typeof parsed !== 'object' ||
+					Array.isArray(parsed) ||
+					Object.keys(parsed).length === 0
+				) {
+					throw new Error('Invalid history')
+				}
+				history = parsed as Record<string, any>
+			} catch {
+				history = {
 					added: Date.now(),
 					started: null,
 					finished: null,
 					progress: null,
-					lastUpdated: Date.now(),
 				}
 			}
-		}
 
-		let valueFormatted: unknown
-		const columnName = colId
-
-			if (expectedType.toLowerCase().includes('history')) {
-				if (colId == 'length') {
-					parsedHistoryObject['progress'] = JSON.parse(newValue as string)
-				} else {
-					if (
-						newValue &&
-						newValue !== 'null' &&
-						typeof newValue !== 'string' &&
-						typeof newValue !== 'number'
-					) {
-						throw new Response('Invalid history date', { status: 400 })
+			if (['length', 'chapters', 'volumes'].includes(colId)) {
+				const textValue = String(input.value ?? '')
+				if (/\d+\s*\/\s*\d+ eps/.test(textValue) || colId !== 'length') {
+					const matchResult = textValue.match(/\d+/)?.[0]
+					if (matchResult) {
+						if (
+							!history.progress ||
+							typeof history.progress !== 'object' ||
+							Array.isArray(history.progress)
+						) {
+							history.progress = {}
+						}
+						if (colId === 'length') {
+							if (
+								!history.progress[matchResult] ||
+								typeof history.progress[matchResult] !== 'object' ||
+								Array.isArray(history.progress[matchResult])
+							) {
+								history.progress[matchResult] = {
+									completed: false,
+									finishDate: [],
+								}
+							}
+							history.progress[matchResult].finishDate = Array.isArray(
+								history.progress[matchResult].finishDate,
+							)
+								? history.progress[matchResult].finishDate
+								: []
+							history.progress[matchResult].completed = true
+							history.progress[matchResult].finishDate.push(Date.now())
+						} else {
+							const mediaTypes = JSON.parse(
+								entry.watchlist.type.mediaType,
+							) as string[]
+							const typeIndex = mediaTypes
+								.map(mediaType => `${mediaType}s`)
+								.findIndex(mediaType => mediaType === colId)
+							const mediaType =
+								typeIndex >= 0 ? mediaTypes[typeIndex] : mediaTypes[0]
+							if (mediaType) {
+								if (
+									!history.progress[mediaType] ||
+									typeof history.progress[mediaType] !== 'object' ||
+									Array.isArray(history.progress[mediaType])
+								) {
+									history.progress[mediaType] = {}
+								}
+								if (
+									!history.progress[mediaType][matchResult] ||
+									typeof history.progress[mediaType][matchResult] !==
+										'object' ||
+									Array.isArray(history.progress[mediaType][matchResult])
+								) {
+									history.progress[mediaType][matchResult] = {
+										completed: false,
+										finishDate: [],
+									}
+								}
+								history.progress[mediaType][matchResult].finishDate =
+									Array.isArray(
+										history.progress[mediaType][matchResult].finishDate,
+									)
+										? history.progress[mediaType][matchResult].finishDate
+										: []
+								history.progress[mediaType][matchResult].completed = true
+								history.progress[mediaType][matchResult].finishDate.push(
+									Date.now(),
+								)
+							}
+						}
 					}
-					parsedHistoryObject[colId as string] =
-						newValue && newValue != 'null'
-							? new Date(newValue as string | number).toISOString()
-							: null
+				}
+				history.lastUpdated = Date.now()
+				return updateEntryAndTrackingState(tx, ownerId, entry.id, {
+					history: JSON.stringify(history),
+				})
 			}
 
-			return await prisma.$transaction(tx =>
-				updateEntryAndTrackingState(tx, rowIndex as string, {
-					history: JSON.stringify(parsedHistoryObject),
-				}),
-			)
-		} else {
-			valueFormatted = castType(newValue, expectedType)
+			if (expectedType.toLowerCase().includes('history')) {
+				if (
+					input.value &&
+					input.value !== 'null' &&
+					typeof input.value !== 'string' &&
+					typeof input.value !== 'number'
+				) {
+					throw new Response('Invalid history date', { status: 400 })
+				}
+				if (input.value && input.value !== 'null') {
+					const date = new Date(input.value as string | number)
+					if (Number.isNaN(date.getTime())) {
+						throw new Response('Invalid history date', { status: 400 })
+					}
+					history[colId] = date.toISOString()
+				} else {
+					history[colId] = null
+				}
+				if (colId !== 'lastUpdated') history.lastUpdated = Date.now()
+				return updateEntryAndTrackingState(tx, ownerId, entry.id, {
+					history: JSON.stringify(history),
+				})
+			}
 
-			return await prisma.$transaction(tx =>
-				updateEntryAndTrackingState(tx, rowIndex as string, {
-					[columnName as string]: valueFormatted,
-					history: JSON.stringify(parsedHistoryObject),
-				}),
-			)
-		}
+			history.lastUpdated = Date.now()
+			return updateEntryAndTrackingState(tx, ownerId, entry.id, {
+				[colId]: castType(input.value, expectedType),
+				history: JSON.stringify(history),
+			})
+		})
 	} catch (e) {
 		// Auth/ownership failures are already Responses (401/404) — let them through.
 		if (e instanceof Response) throw e

--- a/app/routes/lists+/.fetch+/update-row.$request.ts
+++ b/app/routes/lists+/.fetch+/update-row.$request.ts
@@ -1,10 +1,7 @@
 import { type ActionFunctionArgs } from 'react-router'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import {
-	requireOwnedEntry,
-	stripProtectedFields,
-} from '#app/utils/lists/authorization.server.ts'
+import { stripProtectedFields } from '#app/utils/lists/authorization.server.ts'
 import {
 	ensureMediaForIdentity,
 	hydrateMediaCatalog,
@@ -14,28 +11,18 @@ import {
 	deleteTrackingStateIfOrphan,
 	ensureTrackingStateForEntry,
 } from '#app/utils/tracking-state.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 
 export async function updateEntryCommand(
 	ownerId: string,
 	entryId: string | null,
 	row: unknown,
 ) {
-	const { entry, watchlist } = await requireOwnedEntry(ownerId, entryId)
 	if (!row || typeof row !== 'object' || Array.isArray(row)) {
 		throw new Response('Invalid row payload', { status: 400 })
 	}
 
 	const rowObj = row as Record<string, unknown>
-	const listType = await prisma.listType.findUnique({
-		where: { id: watchlist.typeId },
-		select: { name: true },
-	})
-	if (!listType) throw new Response('List type not found', { status: 400 })
-	const mediaIdentity = parseMediaIdentityForListType(
-		rowObj.mediaIdentity,
-		listType.name,
-		typeof rowObj.thumbnail === 'string' ? rowObj.thumbnail : null,
-	)
 
 	// A data update must not change identity/relations directly or move the row to
 	// another watchlist. A validated provider identity can establish mediaId below.
@@ -52,6 +39,30 @@ export async function updateEntryCommand(
 	])
 
 	return await prisma.$transaction(async tx => {
+		await serializeUserLibraryMutation(tx, ownerId)
+		const entry = entryId
+			? await tx.entry.findUnique({
+					where: { id: entryId },
+					include: {
+						watchlist: {
+							select: {
+								id: true,
+								name: true,
+								ownerId: true,
+								type: { select: { name: true } },
+							},
+						},
+					},
+				})
+			: null
+		if (!entry || entry.watchlist.ownerId !== ownerId) {
+			throw new Response('Not found', { status: 404 })
+		}
+		const mediaIdentity = parseMediaIdentityForListType(
+			rowObj.mediaIdentity,
+			entry.watchlist.type.name,
+			typeof rowObj.thumbnail === 'string' ? rowObj.thumbnail : null,
+		)
 		const mediaId = mediaIdentity
 			? await ensureMediaForIdentity(tx, mediaIdentity)
 			: (entry.mediaId ?? undefined)
@@ -77,8 +88,8 @@ export async function updateEntryCommand(
 						ownerId,
 						mediaId,
 						mediaKind,
-						status: watchlist.name,
-						statusWatchlistId: watchlist.id,
+						status: entry.watchlist.name,
+						statusWatchlistId: entry.watchlist.id,
 						entry: { ...entry, ...data },
 						mode: 'all',
 						recordActivity: true,

--- a/app/routes/lists+/.fetch+/update-settings.$request.ts
+++ b/app/routes/lists+/.fetch+/update-settings.$request.ts
@@ -9,6 +9,7 @@ import {
 	normalizeWatchlistSortDirection,
 } from '#app/utils/lists/default-sort.ts'
 import { syncWatchlistActivityVisibility } from '#app/utils/lists/visibility.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 
 // Only these watchlist fields may be changed via the settings form. Everything else
 // (id, position, typeId, ownerId, timestamps, relations) is off-limits, so a client can't
@@ -96,29 +97,27 @@ export async function updateWatchlistSettingsCommand(
 		}
 	}
 
-	// Apply the (whitelisted) settings and renumber the owner's watchlists of this type
-	// atomically, so a failure can't leave settings half-applied or the ordering off.
+	// Apply the whitelisted settings atomically. Settings do not change list
+	// positions, so unrelated sibling rows are deliberately left untouched.
 	const updated = await prisma.$transaction(async tx => {
+		await serializeUserLibraryMutation(tx, ownerId)
+		const current = await tx.watchlist.findFirst({
+			where: { id: watchlist.id, ownerId },
+		})
+		if (!current) throw new Response('Not found', { status: 404 })
 		const result =
 			Object.keys(data).length > 0
 				? await tx.watchlist.update({
-						where: { id: watchlist.id },
+						where: { id: current.id },
 						data: data as any,
 					})
-				: watchlist
+				: current
 
-		await syncWatchlistActivityVisibility(tx, result)
-
-		const remaining = await tx.watchlist.findMany({
-			where: { typeId: watchlist.typeId, ownerId },
-			orderBy: { position: 'asc' },
-		})
-
-		for (let i = 0; i < remaining.length; i++) {
-			await tx.watchlist.update({
-				where: { id: remaining[i].id },
-				data: { position: i + 1 },
-			})
+		if (
+			result.isPublic !== current.isPublic ||
+			result.header !== current.header
+		) {
+			await syncWatchlistActivityVisibility(tx, result, current.header)
 		}
 
 		return result

--- a/app/routes/lists+/.fetch+/update-settings.$request.ts
+++ b/app/routes/lists+/.fetch+/update-settings.$request.ts
@@ -2,13 +2,13 @@ import { type ActionFunctionArgs } from 'react-router'
 import { z } from 'zod'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import { syncWatchlistActivityVisibility } from '#app/utils/lists/activity-visibility.server.ts'
 import { requireOwnedWatchlist } from '#app/utils/lists/authorization.server.ts'
 import {
 	getSortableWatchlistColumns,
 	normalizeWatchlistSortColumn,
 	normalizeWatchlistSortDirection,
 } from '#app/utils/lists/default-sort.ts'
-import { syncWatchlistActivityVisibility } from '#app/utils/lists/visibility.server.ts'
 import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 
 // Only these watchlist fields may be changed via the settings form. Everything else

--- a/app/routes/lists+/create-watchlist.route.test.ts
+++ b/app/routes/lists+/create-watchlist.route.test.ts
@@ -3,6 +3,10 @@ import { expect, test } from 'vitest'
 import { action } from '#app/routes/lists+/.fetch+/create-watchlist.$request.ts'
 import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import {
+	MAX_WATCHLISTS_PER_TYPE,
+	MAX_WATCHLISTS_PER_USER,
+} from '#app/utils/watchlist-limits.ts'
 import { BASE_URL, getSessionCookieHeader } from '#tests/utils.ts'
 
 async function fixture() {
@@ -52,6 +56,28 @@ function validList(typeId: string) {
 	}
 }
 
+async function seedWatchlists({
+	ownerId,
+	typeId,
+	count,
+	prefix,
+}: {
+	ownerId: string
+	typeId: string
+	count: number
+	prefix: string
+}) {
+	await prisma.watchlist.createMany({
+		data: Array.from({ length: count }, (_, index) => ({
+			ownerId,
+			typeId,
+			position: index + 1,
+			name: `${prefix}-${index + 1}`,
+			header: `${prefix} ${index + 1}`,
+		})),
+	})
+}
+
 test('creates only validated server-owned watchlist fields', async () => {
 	const data = await fixture()
 	const created = await action({
@@ -95,4 +121,100 @@ test('rejects malformed and oversized watchlist fields', async () => {
 		expect(response).toBeInstanceOf(Response)
 		expect((response as Response).status).toBe(400)
 	}
+})
+
+test('allows 50 watchlists per type and rejects the next without reordering', async () => {
+	const data = await fixture()
+	await seedWatchlists({
+		ownerId: data.owner.id,
+		typeId: data.type.id,
+		count: MAX_WATCHLISTS_PER_TYPE - 1,
+		prefix: 'type-limit',
+	})
+
+	const boundary = await action({
+		request: data.request,
+		params: params(validList(data.type.id)),
+	} as any)
+	expect(boundary.position).toBe(1)
+	expect(
+		await prisma.watchlist.count({
+			where: { ownerId: data.owner.id, typeId: data.type.id },
+		}),
+	).toBe(MAX_WATCHLISTS_PER_TYPE)
+
+	const response = await action({
+		request: data.request,
+		params: params(validList(data.type.id)),
+	} as any).catch(error => error)
+	expect(response).toBeInstanceOf(Response)
+	expect((response as Response).status).toBe(409)
+	expect(await (response as Response).text()).toContain(
+		`${MAX_WATCHLISTS_PER_TYPE} watchlists for each media type`,
+	)
+	expect(
+		await prisma.watchlist.findFirstOrThrow({
+			where: {
+				ownerId: data.owner.id,
+				typeId: data.type.id,
+				name: 'watching',
+			},
+			select: { position: true },
+		}),
+	).toEqual({ position: 1 })
+})
+
+test('allows 100 watchlists in total and rejects the next', async () => {
+	const data = await fixture()
+	const secondType = await prisma.listType.create({
+		data: {
+			name: `second_${data.type.id}`,
+			header: 'Television',
+			columns: '{}',
+			mediaType: '["series"]',
+			completionType: '{"past":"watched"}',
+		},
+	})
+	const thirdType = await prisma.listType.create({
+		data: {
+			name: `third_${data.type.id}`,
+			header: 'Manga',
+			columns: '{}',
+			mediaType: '["chapter"]',
+			completionType: '{"past":"read"}',
+		},
+	})
+	await seedWatchlists({
+		ownerId: data.owner.id,
+		typeId: data.type.id,
+		count: MAX_WATCHLISTS_PER_TYPE,
+		prefix: 'total-a',
+	})
+	await seedWatchlists({
+		ownerId: data.owner.id,
+		typeId: secondType.id,
+		count: MAX_WATCHLISTS_PER_USER - MAX_WATCHLISTS_PER_TYPE - 1,
+		prefix: 'total-b',
+	})
+
+	await action({
+		request: data.request,
+		params: params(validList(thirdType.id)),
+	} as any)
+	expect(
+		await prisma.watchlist.count({ where: { ownerId: data.owner.id } }),
+	).toBe(MAX_WATCHLISTS_PER_USER)
+
+	const response = await action({
+		request: data.request,
+		params: params(validList(thirdType.id)),
+	} as any).catch(error => error)
+	expect(response).toBeInstanceOf(Response)
+	expect((response as Response).status).toBe(409)
+	expect(await (response as Response).text()).toContain(
+		`${MAX_WATCHLISTS_PER_USER} watchlists`,
+	)
+	expect(
+		await prisma.watchlist.count({ where: { ownerId: data.owner.id } }),
+	).toBe(MAX_WATCHLISTS_PER_USER)
 })

--- a/app/routes/lists+/delete-watchlist.route.test.ts
+++ b/app/routes/lists+/delete-watchlist.route.test.ts
@@ -7,8 +7,10 @@
 import { faker } from '@faker-js/faker'
 import { expect, test } from 'vitest'
 import * as deleteWatchlistRoute from '#app/routes/lists+/.fetch+/delete-watchlist.$request.ts'
+import { updateWatchlistSettingsCommand } from '#app/routes/lists+/.fetch+/update-settings.$request.ts'
 import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import { publicActivityEventWhere } from '#app/utils/lists/visibility.ts'
 import { BASE_URL, getSessionCookieHeader } from '#tests/utils.ts'
 
 const { action } = deleteWatchlistRoute
@@ -150,6 +152,71 @@ test('deleting the current list restores a surviving private tracking status', a
 			isPublic: false,
 		}),
 	)
+})
+
+test('deleting a list quarantines linked activity across later header reuse', async () => {
+	const { userId, watchlistId, listTypeId } = await seedOwnedWatchlist()
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Deleted provenance fixture' },
+	})
+	const event = await prisma.activityEvent.create({
+		data: {
+			type: 'score',
+			actorId: userId,
+			mediaId: media.id,
+			statusWatchlistId: watchlistId,
+			statusLabel: 'LiveAction',
+			score: 8,
+			isPublic: true,
+			publicEligible: true,
+		},
+	})
+
+	await action({
+		request: await authedRequestFor(userId),
+		params: { request: requestParamFor(watchlistId) },
+	} as any)
+
+	expect(
+		await prisma.activityEvent.findUniqueOrThrow({
+			where: { id: event.id },
+			select: {
+				statusWatchlistId: true,
+				isPublic: true,
+				publicEligible: true,
+			},
+		}),
+	).toEqual({
+		statusWatchlistId: null,
+		isPublic: false,
+		publicEligible: true,
+	})
+
+	const replacement = await prisma.watchlist.create({
+		data: {
+			ownerId: userId,
+			typeId: listTypeId,
+			name: 'replacement',
+			header: 'LiveAction',
+			position: 1,
+			isPublic: false,
+		},
+	})
+	await updateWatchlistSettingsCommand(userId, replacement.id, {
+		isPublic: true,
+	})
+
+	expect(
+		await prisma.activityEvent.findUniqueOrThrow({
+			where: { id: event.id },
+			select: { statusWatchlistId: true, isPublic: true },
+		}),
+	).toEqual({ statusWatchlistId: null, isPublic: false })
+	expect(
+		await prisma.activityEvent.findFirst({
+			where: { id: event.id, AND: [publicActivityEventWhere] },
+		}),
+	).toBeNull()
 })
 
 test('a logged-in non-owner cannot delete the watchlist (404, and it survives)', async () => {

--- a/app/routes/lists+/entry-order.route.test.ts
+++ b/app/routes/lists+/entry-order.route.test.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { expect, test } from 'vitest'
 import { action as deleteRow } from '#app/routes/lists+/.fetch+/delete-row.$request.ts'
+import { action as legacyDeleteRow } from '#app/routes/lists+/.fetch+/fix-watchlist-order.$request.ts'
 import { action as moveRow } from '#app/routes/lists+/.fetch+/move-row.$request.ts'
 import { action as reorderRows } from '#app/routes/lists+/.fetch+/reorder-rows.$request.ts'
 import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
@@ -248,7 +249,9 @@ test('rejects a canonical media kind that does not match the destination type', 
 	expect(response).toBeInstanceOf(Response)
 	expect((response as Response).status).toBe(400)
 	expect(
-		await prisma.entry.findUniqueOrThrow({ where: { id: incompatibleEntry.id } }),
+		await prisma.entry.findUniqueOrThrow({
+			where: { id: incompatibleEntry.id },
+		}),
 	).toMatchObject({ watchlistId: data.source.id, position: 4 })
 })
 
@@ -310,4 +313,23 @@ test('deleting an entry closes its position gap in the same transaction', async 
 		{ id: data.first.id, position: 1, title: 'First' },
 		{ id: data.third.id, position: 2, title: 'Third' },
 	])
+})
+
+test('the legacy delete endpoint delegates to the reconciled deletion command', async () => {
+	const data = await fixture()
+	await legacyDeleteRow({
+		request: data.request,
+		params: {
+			request: new URLSearchParams({ id: data.moved.id }).toString(),
+		},
+	} as any)
+	expect(await orderedEntries(data.source.id)).toEqual([
+		{ id: data.first.id, position: 1, title: 'First' },
+		{ id: data.third.id, position: 2, title: 'Third' },
+	])
+	expect(
+		await prisma.trackingState.findUnique({
+			where: { id: data.trackingState.id },
+		}),
+	).toBeNull()
 })

--- a/app/routes/lists+/media-identity.route.test.ts
+++ b/app/routes/lists+/media-identity.route.test.ts
@@ -155,6 +155,7 @@ test('new rows reuse canonical media and ignore client-supplied relation ids', a
 			statusLabel: 'Watching',
 			statusWatchlistId: owner.watchlistId,
 			isPublic: true,
+			publicEligible: true,
 		}),
 	])
 })
@@ -183,6 +184,7 @@ test('tracking activity created from a private list stays private', async () => 
 		expect.objectContaining({
 			statusWatchlistId: owner.watchlistId,
 			isPublic: false,
+			publicEligible: false,
 		}),
 	)
 })
@@ -246,6 +248,7 @@ test('deleting the current public entry restores a surviving private status', as
 			statusWatchlistId: privateList.id,
 			previousStatusWatchlistId: owner.watchlistId,
 			isPublic: false,
+			publicEligible: false,
 		}),
 	)
 })

--- a/app/routes/lists+/update-cell.route.test.ts
+++ b/app/routes/lists+/update-cell.route.test.ts
@@ -92,6 +92,40 @@ test('the owner can update a cell', async () => {
 	expect((result as { title?: string }).title).toBe('Updated Title')
 })
 
+test('a regular cell edit preserves current history and refreshes its timestamp', async () => {
+	const { userId, entryId } = await createOwnerWithEntry()
+	await prisma.entry.update({
+		where: { id: entryId },
+		data: {
+			history: JSON.stringify({
+				added: 1,
+				progress: { episode: 7 },
+				concurrentMarker: 'keep',
+				lastUpdated: 2,
+			}),
+		},
+	})
+	const request = await authedRequestFor(userId)
+
+	await action({
+		request,
+		params: { request: updateTitleParams(entryId, 'History-safe title') },
+	} as any)
+
+	const saved = await prisma.entry.findUniqueOrThrow({
+		where: { id: entryId },
+		select: { history: true },
+	})
+	const history = JSON.parse(saved.history ?? '{}') as {
+		progress?: { episode?: number }
+		concurrentMarker?: string
+		lastUpdated?: number
+	}
+	expect(history.progress?.episode).toBe(7)
+	expect(history.concurrentMarker).toBe('keep')
+	expect(history.lastUpdated).toBeGreaterThan(2)
+})
+
 test('a logged-in non-owner cannot update the cell (404)', async () => {
 	const { entryId } = await createOwnerWithEntry()
 	const other = await createUserRecord()

--- a/app/routes/lists+/update-settings.route.test.ts
+++ b/app/routes/lists+/update-settings.route.test.ts
@@ -9,6 +9,7 @@
 import { faker } from '@faker-js/faker'
 import { expect, test } from 'vitest'
 import { action } from '#app/routes/lists+/.fetch+/update-settings.$request.ts'
+import { loader as profileActivityLoader } from '#app/routes/users+/$username.activity.tsx'
 import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { BASE_URL, getSessionCookieHeader } from '#tests/utils.ts'
@@ -53,11 +54,19 @@ async function seedOwnedWatchlist() {
 				},
 			},
 		},
-		select: { id: true, watchlists: { select: { id: true, typeId: true } } },
+		select: {
+			id: true,
+			username: true,
+			watchlists: { select: { id: true, typeId: true } },
+		},
 	})
 	const wl = owner.watchlists[0]
 	if (!wl) throw new Error('test setup: watchlist was not created')
-	return { userId: owner.id, watchlistId: wl.id }
+	return {
+		userId: owner.id,
+		username: owner.username,
+		watchlistId: wl.id,
+	}
 }
 
 function settingsParams(listId: string, pairs: Array<[string, unknown]>) {
@@ -90,6 +99,46 @@ test('applies whitelisted settings', async () => {
 	expect(wl?.isPublic).toBe(false)
 	expect(wl?.defaultSortColumn).toBe('title')
 	expect(wl?.defaultSortDirection).toBe('desc')
+})
+
+test('non-visibility settings do not rewrite linked activity', async () => {
+	const { userId, watchlistId } = await seedOwnedWatchlist()
+	const request = await authedRequestFor(userId)
+	const watchlist = await prisma.watchlist.findUniqueOrThrow({
+		where: { id: watchlistId },
+	})
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Unrelated settings fixture' },
+	})
+	const event = await prisma.activityEvent.create({
+		data: {
+			type: 'status',
+			actorId: userId,
+			mediaId: media.id,
+			statusLabel: watchlist.header,
+			statusWatchlistId: watchlist.id,
+			publicEligible: true,
+			isPublic: false,
+		},
+	})
+
+	await action({
+		request,
+		params: {
+			request: settingsParams(watchlistId, [
+				['header', watchlist.header],
+				['isPublic', watchlist.isPublic],
+				['description', 'Only the description changed.'],
+			]),
+		},
+	} as any)
+
+	expect(
+		await prisma.activityEvent.findUniqueOrThrow({
+			where: { id: event.id },
+			select: { isPublic: true },
+		}),
+	).toEqual({ isPublic: false })
 })
 
 test.each([
@@ -137,6 +186,7 @@ test('visibility changes hide linked and legacy list activity', async () => {
 				trackingStateId: state.id,
 				statusLabel: watchlist.header,
 				statusWatchlistId: watchlistId,
+				publicEligible: true,
 			},
 		}),
 		prisma.activityEvent.create({
@@ -182,6 +232,192 @@ test('visibility changes hide linked and legacy list activity', async () => {
 			select: { isPublic: true },
 		}),
 	).toEqual({ isPublic: false })
+})
+
+test.each(['rename then privatize', 'rename and privatize together'] as const)(
+	'legacy list activity stays private after %s',
+	async sequence => {
+		const { userId, username, watchlistId } = await seedOwnedWatchlist()
+		const request = await authedRequestFor(userId)
+		const watchlist = await prisma.watchlist.findUniqueOrThrow({
+			where: { id: watchlistId },
+		})
+		const media = await prisma.media.create({
+			data: { kind: 'movie', title: `Rename privacy ${sequence}` },
+		})
+		const legacy = await prisma.activityEvent.create({
+			data: {
+				type: 'score',
+				actorId: userId,
+				mediaId: media.id,
+				statusLabel: watchlist.header,
+				score: 9,
+				isPublic: true,
+			},
+		})
+
+		if (sequence === 'rename then privatize') {
+			await action({
+				request,
+				params: {
+					request: settingsParams(watchlistId, [['header', 'Renamed Header']]),
+				},
+			} as any)
+			expect(
+				await prisma.activityEvent.findUniqueOrThrow({
+					where: { id: legacy.id },
+					select: { statusWatchlistId: true, isPublic: true },
+				}),
+			).toEqual({ statusWatchlistId: null, isPublic: false })
+			await action({
+				request,
+				params: {
+					request: settingsParams(watchlistId, [['isPublic', false]]),
+				},
+			} as any)
+		} else {
+			await action({
+				request,
+				params: {
+					request: settingsParams(watchlistId, [
+						['header', 'Renamed Header'],
+						['isPublic', false],
+					]),
+				},
+			} as any)
+		}
+
+		expect(
+			await prisma.activityEvent.findUniqueOrThrow({
+				where: { id: legacy.id },
+				select: { statusWatchlistId: true, isPublic: true },
+			}),
+		).toEqual({ statusWatchlistId: null, isPublic: false })
+		const visitorActivity = await profileActivityLoader({
+			request: new Request(`${BASE_URL}/users/${username}/activity`),
+			params: { username },
+		} as any)
+		expect(
+			visitorActivity.data.activityEvents.map(event => event.id),
+		).not.toContain(`tracking:${legacy.id}`)
+	},
+)
+
+test('ambiguous label-only legacy activity is hidden instead of attached to the wrong list', async () => {
+	const { userId, username, watchlistId } = await seedOwnedWatchlist()
+	const request = await authedRequestFor(userId)
+	const watchlist = await prisma.watchlist.findUniqueOrThrow({
+		where: { id: watchlistId },
+	})
+	await prisma.watchlist.create({
+		data: {
+			ownerId: userId,
+			typeId: watchlist.typeId,
+			name: 'duplicate-header',
+			header: watchlist.header,
+			position: 2,
+		},
+	})
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Ambiguous legacy activity' },
+	})
+	const legacy = await prisma.activityEvent.create({
+		data: {
+			type: 'score',
+			actorId: userId,
+			mediaId: media.id,
+			statusLabel: watchlist.header,
+			score: 8,
+			isPublic: true,
+		},
+	})
+
+	await action({
+		request,
+		params: {
+			request: settingsParams(watchlistId, [['header', 'Renamed Header']]),
+		},
+	} as any)
+
+	expect(
+		await prisma.activityEvent.findUniqueOrThrow({
+			where: { id: legacy.id },
+			select: { statusWatchlistId: true, isPublic: true },
+		}),
+	).toEqual({ statusWatchlistId: null, isPublic: false })
+	const visitorActivity = await profileActivityLoader({
+		request: new Request(`${BASE_URL}/users/${username}/activity`),
+		params: { username },
+	} as any)
+	expect(
+		visitorActivity.data.activityEvents.map(event => event.id),
+	).not.toContain(`tracking:${legacy.id}`)
+})
+
+test('activity created while private never republishes an old sensitive label', async () => {
+	const { userId, username, watchlistId } = await seedOwnedWatchlist()
+	const request = await authedRequestFor(userId)
+	const watchlist = await prisma.watchlist.update({
+		where: { id: watchlistId },
+		data: { header: 'Secret queue', isPublic: false },
+	})
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Private label fixture' },
+	})
+	const event = await prisma.activityEvent.create({
+		data: {
+			type: 'status',
+			actorId: userId,
+			mediaId: media.id,
+			status: 'watching',
+			statusLabel: watchlist.header,
+			statusWatchlistId: watchlist.id,
+			isPublic: false,
+			publicEligible: false,
+		},
+	})
+	await prisma.entry.create({
+		data: {
+			watchlistId: watchlist.id,
+			mediaId: media.id,
+			position: 1,
+			title: media.title!,
+			history: JSON.stringify({
+				'Secret private activity': Date.UTC(2026, 6, 28),
+			}),
+		},
+	})
+
+	await action({
+		request,
+		params: {
+			request: settingsParams(watchlistId, [
+				['header', 'Public queue'],
+				['isPublic', true],
+			]),
+		},
+	} as any)
+
+	expect(
+		await prisma.activityEvent.findUniqueOrThrow({
+			where: { id: event.id },
+			select: { isPublic: true, publicEligible: true },
+		}),
+	).toEqual({ isPublic: false, publicEligible: false })
+	const visitorActivity = await profileActivityLoader({
+		request: new Request(`${BASE_URL}/users/${username}/activity`),
+		params: { username },
+	} as any)
+	expect(
+		visitorActivity.data.activityEvents.map(activity => activity.id),
+	).not.toContain(`tracking:${event.id}`)
+	expect(
+		visitorActivity.data.activityEvents.some(
+			activity =>
+				activity.id.startsWith('legacy:') ||
+				activity.action.includes('Secret private activity'),
+		),
+	).toBe(false)
 })
 
 test('rejects non-boolean visibility values', async () => {

--- a/app/routes/lists+/watchlist-privacy.route.test.ts
+++ b/app/routes/lists+/watchlist-privacy.route.test.ts
@@ -226,9 +226,9 @@ test('watchlist detail loader returns browser-safe canonical scores', async () =
 	expect(entry).toMatchObject({
 		personal: 7.6,
 		tmdbScore: 8.4,
-		trackingState: { score: 7.6 },
 		media: { tmdbScore: 8.4 },
 	})
+	expect(entry).not.toHaveProperty('trackingState')
 	expect(typeof entry.personal).toBe('number')
 	expect(typeof entry.tmdbScore).toBe('number')
 })
@@ -324,4 +324,445 @@ test('public watchlist payload excludes account data and hidden entry fields', a
 		expect(v1Entries.data.data[0]).not.toHaveProperty('notes')
 		expect(v1Entries.data.data[0]).not.toHaveProperty('history')
 	}
+})
+
+test('public list DTO exposes only configured tracking fields', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const owner = await prisma.user.create({
+		data: {
+			email: `dto_${suffix}@example.com`,
+			username: `dto_${suffix}`,
+		},
+	})
+	const listType = await prisma.listType.create({
+		data: {
+			name: `dto-${suffix}`,
+			header: 'DTO fixtures',
+			columns:
+				'{"title":"string","personal":"number","started":"date","finished":"date","length":"string"}',
+			mediaType: '["episode"]',
+			completionType: '{"present":"watching"}',
+		},
+	})
+	const watchlist = await prisma.watchlist.create({
+		data: {
+			ownerId: owner.id,
+			typeId: listType.id,
+			name: 'watching',
+			header: 'Watching',
+			position: 1,
+			displayedColumns: 'title',
+			isPublic: true,
+		},
+	})
+	const media = await prisma.media.create({
+		data: { kind: 'anime', title: 'DTO title' },
+	})
+	const startedAt = new Date('2026-06-01T00:00:00.000Z')
+	const state = await prisma.trackingState.create({
+		data: {
+			ownerId: owner.id,
+			mediaId: media.id,
+			statusWatchlistId: watchlist.id,
+			status: 'watching',
+			score: 9.5,
+			startedAt,
+			completedAt: new Date('2026-06-20T00:00:00.000Z'),
+			repeatCount: 4,
+			progress: {
+				create: { unit: 'episode', current: 10, total: 12 },
+			},
+		},
+	})
+	const entry = await prisma.entry.create({
+		data: {
+			watchlistId: watchlist.id,
+			mediaId: media.id,
+			trackingStateId: state.id,
+			position: 1,
+			title: 'DTO title',
+			personal: 8,
+			length: '10 / 12 eps',
+			history: JSON.stringify({
+				started: '2025-01-01T00:00:00.000Z',
+				finished: '2025-01-10T00:00:00.000Z',
+				progress: { private: true },
+				privateNote: 'never serialize this',
+			}),
+		},
+	})
+
+	const loadSurfaces = async () => {
+		const detail = await watchlistLoader({
+			request: new Request(
+				`${BASE_URL}/lists/${owner.username}/${listType.name}/${watchlist.name}`,
+			),
+			params: {
+				username: owner.username,
+				'list-type': listType.name,
+				watchlist: watchlist.name,
+			},
+		} as any)
+		const legacy = await entryLoader({
+			request: new Request(BASE_URL),
+			params: {
+				request: new URLSearchParams({
+					watchlistId: watchlist.id,
+				}).toString(),
+			},
+		} as any)
+		const v1Request = new Request(
+			`${BASE_URL}/resources/lists/v1/entries?watchlistId=${watchlist.id}`,
+		)
+		const v1 = await v1EntryLoader({
+			request: v1Request,
+			url: new URL(v1Request.url),
+			params: {},
+		} as any)
+		expect(v1.data.ok).toBe(true)
+		if (!v1.data.ok) throw new Error('Expected a public list response')
+		return [detail.data.listEntries, legacy, v1.data.data]
+	}
+
+	for (const entries of await loadSurfaces()) {
+		expect(entries[0]).toMatchObject({ title: 'DTO title' })
+		for (const field of ['personal', 'length', 'history', 'trackingState']) {
+			expect(entries[0]).not.toHaveProperty(field)
+		}
+	}
+
+	await prisma.watchlist.update({
+		where: { id: watchlist.id },
+		data: { displayedColumns: 'title, started' },
+	})
+	for (const entries of await loadSurfaces()) {
+		expect(entries[0]).not.toHaveProperty('personal')
+		expect(entries[0]).not.toHaveProperty('trackingState')
+		expect(JSON.parse(String(entries[0]?.history))).toEqual({
+			started: startedAt.toISOString(),
+		})
+		expect(String(entries[0]?.history)).not.toContain('privateNote')
+		expect(String(entries[0]?.history)).not.toContain('progress')
+		expect(String(entries[0]?.history)).not.toContain('finished')
+	}
+
+	await prisma.trackingState.update({
+		where: { id: state.id },
+		data: { startedAt: null },
+	})
+	await prisma.entry.update({
+		where: { id: entry.id },
+		data: {
+			history: JSON.stringify({
+				started: { privateNote: 'never serialize a structured date value' },
+			}),
+		},
+	})
+	for (const entries of await loadSurfaces()) {
+		expect(JSON.parse(String(entries[0]?.history))).toEqual({ started: null })
+		expect(String(entries[0]?.history)).not.toContain('privateNote')
+	}
+
+	await prisma.entry.update({
+		where: { id: entry.id },
+		data: {
+			history: JSON.stringify({
+				started: '2026-01-01T00:00:00.000Z',
+				padding: 'private'.repeat(10_000),
+			}),
+		},
+	})
+	for (const entries of await loadSurfaces()) {
+		expect(JSON.parse(String(entries[0]?.history))).toEqual({ started: null })
+		expect(String(entries[0]?.history)).not.toContain('private')
+	}
+})
+
+test('public duplicate entries cannot expose private or invalid tracking state', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const [owner, other] = await Promise.all([
+		prisma.user.create({
+			data: {
+				email: `state_owner_${suffix}@example.com`,
+				username: `state_owner_${suffix}`,
+			},
+		}),
+		prisma.user.create({
+			data: {
+				email: `state_other_${suffix}@example.com`,
+				username: `state_other_${suffix}`,
+			},
+		}),
+	])
+	const listType = await prisma.listType.create({
+		data: {
+			name: `state-privacy-${suffix}`,
+			header: 'State privacy fixtures',
+			columns: JSON.stringify({
+				title: 'string',
+				personal: 'number',
+				differencePersonal: 'number',
+				differenceObjective: 'number',
+				started: 'date',
+				length: 'number',
+				chapters: 'number',
+				volumes: 'number',
+			}),
+			mediaType: '["episode","chapter","volume"]',
+			completionType: '{"present":"watching"}',
+		},
+	})
+	const [publicList, privateList] = await Promise.all([
+		prisma.watchlist.create({
+			data: {
+				ownerId: owner.id,
+				typeId: listType.id,
+				name: 'public',
+				header: 'Public',
+				position: 1,
+				displayedColumns:
+					'title, personal, differencePersonal, differenceObjective, started, length, chapters, volumes',
+				isPublic: true,
+			},
+		}),
+		prisma.watchlist.create({
+			data: {
+				ownerId: owner.id,
+				typeId: listType.id,
+				name: 'private',
+				header: 'Private',
+				position: 2,
+				isPublic: false,
+			},
+		}),
+	])
+	const [hiddenMedia, publicMedia, crossOwnerMedia, stateMedia, entryMedia] =
+		await Promise.all(
+			[
+				'Hidden canonical title',
+				'Visible canonical title',
+				'Cross-owner title',
+				'Mismatched state title',
+				'Mismatched entry title',
+			].map(title =>
+				prisma.media.create({
+					data: { kind: 'tv', title },
+				}),
+			),
+		)
+	const [hiddenState, publicState, crossOwnerState, mismatchedState] =
+		await Promise.all([
+			prisma.trackingState.create({
+				data: {
+					ownerId: owner.id,
+					mediaId: hiddenMedia.id,
+					statusWatchlistId: privateList.id,
+					status: 'watching',
+					score: 9.75,
+					progress: {
+						create: [
+							{ unit: 'episode', current: 11, total: 24 },
+							{ unit: 'chapter', current: 12, total: 40 },
+							{ unit: 'volume', current: 3, total: 10 },
+							{ unit: 'minute', current: 90, total: 120 },
+						],
+					},
+				},
+			}),
+			prisma.trackingState.create({
+				data: {
+					ownerId: owner.id,
+					mediaId: publicMedia.id,
+					statusWatchlistId: publicList.id,
+					status: 'watching',
+					score: 7.25,
+				},
+			}),
+			prisma.trackingState.create({
+				data: {
+					ownerId: other.id,
+					mediaId: crossOwnerMedia.id,
+					status: 'watching',
+					score: 8.5,
+				},
+			}),
+			prisma.trackingState.create({
+				data: {
+					ownerId: owner.id,
+					mediaId: stateMedia.id,
+					statusWatchlistId: publicList.id,
+					status: 'watching',
+					score: 8.75,
+				},
+			}),
+		])
+	await prisma.entry.create({
+		data: {
+			watchlistId: privateList.id,
+			mediaId: hiddenMedia.id,
+			trackingStateId: hiddenState.id,
+			position: 1,
+			title: 'Private canonical entry',
+			personal: 9.75,
+			history: '{"finished":"private canonical history"}',
+		},
+	})
+	await prisma.entry.createMany({
+		data: [
+			{
+				watchlistId: publicList.id,
+				mediaId: hiddenMedia.id,
+				trackingStateId: hiddenState.id,
+				position: 1,
+				title: 'Public duplicate',
+				personal: 8.25,
+				differencePersonal: 6.5,
+				differenceObjective: 5.5,
+				history: '{"finished":"private mirrored history"}',
+				length: '11',
+				chapters: '12',
+				volumes: '3',
+			},
+			{
+				watchlistId: publicList.id,
+				mediaId: publicMedia.id,
+				trackingStateId: publicState.id,
+				position: 2,
+				title: 'Visible state',
+				personal: 7,
+			},
+			{
+				watchlistId: publicList.id,
+				mediaId: crossOwnerMedia.id,
+				trackingStateId: crossOwnerState.id,
+				position: 3,
+				title: 'Cross-owner state',
+				personal: 8,
+				history: '{"finished":"cross-owner history"}',
+			},
+			{
+				watchlistId: publicList.id,
+				mediaId: entryMedia.id,
+				trackingStateId: mismatchedState.id,
+				position: 4,
+				title: 'Mismatched state',
+				personal: 8,
+				history: '{"finished":"mismatched history"}',
+			},
+		],
+	})
+
+	const [ownerCookie, otherCookie] = await Promise.all([
+		sessionCookie(owner.id),
+		sessionCookie(other.id),
+	])
+	const headers = (cookie?: string) => (cookie ? { cookie } : undefined)
+	const loadSurfaces = async (cookie?: string) => {
+		const detail = await watchlistLoader({
+			request: new Request(
+				`${BASE_URL}/lists/${owner.username}/${listType.name}/${publicList.name}`,
+				{ headers: headers(cookie) },
+			),
+			params: {
+				username: owner.username,
+				'list-type': listType.name,
+				watchlist: publicList.name,
+			},
+		} as any)
+		const legacy = await entryLoader({
+			request: new Request(BASE_URL, { headers: headers(cookie) }),
+			params: {
+				request: new URLSearchParams({
+					watchlistId: publicList.id,
+				}).toString(),
+			},
+		} as any)
+		const v1Request = new Request(
+			`${BASE_URL}/resources/lists/v1/entries?watchlistId=${publicList.id}`,
+			{ headers: headers(cookie) },
+		)
+		const v1 = await v1EntryLoader({
+			request: v1Request,
+			url: new URL(v1Request.url),
+			params: {},
+		} as any)
+		expect(v1.data.ok).toBe(true)
+		if (!v1.data.ok) throw new Error('Expected the public v1 list response')
+		return {
+			detail: detail.data.listEntries,
+			legacy,
+			v1: v1.data.data,
+		}
+	}
+
+	const expectVisitorPrivacy = (entries: Array<Record<string, unknown>>) => {
+		for (const title of [
+			'Public duplicate',
+			'Cross-owner state',
+			'Mismatched state',
+		]) {
+			expect(entries.find(entry => entry.title === title)).toMatchObject({
+				personal: null,
+				differencePersonal: null,
+				differenceObjective: null,
+				length: null,
+				chapters: null,
+				volumes: null,
+			})
+			const hidden = entries.find(entry => entry.title === title)
+			expect(hidden).not.toHaveProperty('trackingState')
+			expect(JSON.parse(String(hidden?.history))).toEqual({ started: null })
+		}
+		const visible = entries.find(entry => entry.title === 'Visible state')
+		expect(visible).toMatchObject({
+			personal: 7.25,
+		})
+		expect(visible).not.toHaveProperty('trackingState')
+		expect(JSON.parse(String(visible?.history))).toEqual({ started: null })
+	}
+
+	for (const cookie of [undefined, otherCookie]) {
+		const surfaces = await loadSurfaces(cookie)
+		for (const entries of Object.values(surfaces)) {
+			expectVisitorPrivacy(entries as Array<Record<string, unknown>>)
+		}
+	}
+
+	const ownerSurfaces = await loadSurfaces(ownerCookie)
+	for (const entries of Object.values(ownerSurfaces)) {
+		expect(
+			entries.find(entry => entry.title === 'Public duplicate'),
+		).toMatchObject({
+			personal: 9.75,
+			differencePersonal: 6.5,
+			differenceObjective: 5.5,
+			history: '{"finished":"private mirrored history"}',
+			length: '11',
+			chapters: '12',
+			volumes: '3',
+			trackingState: { score: 9.75 },
+		})
+		for (const title of ['Cross-owner state', 'Mismatched state']) {
+			expect(entries.find(entry => entry.title === title)).toMatchObject({
+				personal: null,
+				history: null,
+				trackingState: null,
+			})
+		}
+	}
+	const ownerDetailState = ownerSurfaces.detail.find(
+		entry => entry.title === 'Public duplicate',
+	)?.trackingState
+	const ownerDetailProgress = (
+		ownerDetailState as { progress: Array<{ unit: string }> } | null | undefined
+	)?.progress
+	expect(ownerDetailProgress?.map(progress => progress.unit)).toEqual([
+		'chapter',
+		'episode',
+		'volume',
+	])
+	expect(ownerDetailState).not.toHaveProperty('ownerId')
+	expect(ownerDetailState).not.toHaveProperty('mediaId')
+	expect(ownerDetailState).toHaveProperty('statusWatchlistId', privateList.id)
+	expect(ownerDetailState).not.toHaveProperty('statusWatchlist')
 })

--- a/app/routes/media+/$mediaId.tsx
+++ b/app/routes/media+/$mediaId.tsx
@@ -71,6 +71,7 @@ import {
 	type TrackingEntryLike,
 } from '#app/utils/tracking-state.ts'
 import { setMediaTrackingStatus } from '#app/utils/tracking-status.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 
 const catalogEntrySelect = {
 	id: true,
@@ -838,6 +839,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
 		throw new Response('Invalid media update', { status: 400 })
 
 	return prisma.$transaction(async tx => {
+		if (
+			parsed.data.intent === 'status' ||
+			parsed.data.intent === 'score' ||
+			parsed.data.intent === 'progress'
+		) {
+			await serializeUserLibraryMutation(tx, userId)
+		}
 		const media = await tx.media.findUnique({
 			where: { id: mediaId },
 			select: {

--- a/app/routes/resources+/lists.v1.entries.ts
+++ b/app/routes/resources+/lists.v1.entries.ts
@@ -4,7 +4,10 @@ import {
 	ListEntriesQuerySchema,
 	type ListMutationError,
 } from '#app/utils/lists/mutation-contracts.ts'
-import { publicEntryPayload } from '#app/utils/lists/public-watchlist.server.ts'
+import {
+	prepareWatchlistEntryForViewer,
+	publicEntryPayload,
+} from '#app/utils/lists/public-watchlist.server.ts'
 import { requireVisibleWatchlist } from '#app/utils/lists/visibility.server.ts'
 import { normalizeWatchlistEntryScores } from '#app/utils/lists/watchlist-entry-scores.server.ts'
 
@@ -41,16 +44,30 @@ export async function loader({ request }: LoaderFunctionArgs) {
 			orderBy: { position: 'asc' },
 			include: {
 				media: { select: { tmdbScore: true, malScore: true } },
-				trackingState: { select: { score: true } },
+				trackingState: {
+					select: {
+						ownerId: true,
+						mediaId: true,
+						statusWatchlistId: true,
+						score: true,
+						startedAt: true,
+						completedAt: true,
+						statusWatchlist: { select: { ownerId: true, isPublic: true } },
+					},
+				},
 			},
 		})
-		const normalized = entries.map(normalizeWatchlistEntryScores)
-		const browserEntries =
-			viewerId === watchlist.ownerId
-				? normalized
-				: normalized.map(entry =>
-						publicEntryPayload(entry, watchlist.displayedColumns),
-					)
+		const isOwner = viewerId === watchlist.ownerId
+		const normalized = entries
+			.map(entry =>
+				prepareWatchlistEntryForViewer(entry, watchlist.ownerId, isOwner),
+			)
+			.map(normalizeWatchlistEntryScores)
+		const browserEntries = isOwner
+			? normalized
+			: normalized.map(entry =>
+					publicEntryPayload(entry, watchlist.displayedColumns),
+				)
 		return json(
 			{
 				ok: true as const,

--- a/app/routes/users+/$username.index.tsx
+++ b/app/routes/users+/$username.index.tsx
@@ -15,8 +15,8 @@ import {
 	ProfileVisualizationBoundary,
 	ProfileVisualizationLoading,
 } from '#app/routes/users+/$username_/stats_/visualization-boundary.tsx'
-import { buildCompletionHistory } from '#app/utils/profile-completion-history.ts'
-import { loadProfileAnalytics } from '#app/utils/profile-data.server.ts'
+import { type ProfileAnalyticsDiagnostic } from '#app/utils/profile-analytics.ts'
+import { loadProfileOverview } from '#app/utils/profile-data.server.ts'
 import { profileHeaders } from '#app/utils/profile-headers.ts'
 import { type ProfileShellData } from '#app/utils/profile.ts'
 import { makeTimings } from '#app/utils/timing.server.ts'
@@ -25,12 +25,12 @@ export { ProfileTabErrorBoundary as ErrorBoundary } from '#app/components/profil
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const timings = makeTimings('profile_overview', 'profile overview loader')
-	const analytics = await loadProfileAnalytics(
+	const overview = await loadProfileOverview(
 		request,
 		params['username'],
 		timings,
 	)
-	return json(analytics, {
+	return json(overview, {
 		headers: { 'Server-Timing': timings.toString() },
 	})
 }
@@ -43,39 +43,62 @@ const DeferredCompletionHistoryChart = lazy(() =>
 	})),
 )
 
-function getMonthName(monthNum: any) {
-	const date = new Date(2000, monthNum - 1, 1)
+function getMonthName(monthNum: string) {
+	const date = new Date(2000, Number(monthNum) - 1, 1)
 	return date.toLocaleString('default', { month: 'long' })
+}
+
+export function overviewDiagnosticText(diagnostic: ProfileAnalyticsDiagnostic) {
+	const details: string[] = []
+	if (diagnostic.truncated) details.push('entry limit reached')
+	if (diagnostic.watchlistsTruncated) details.push('watchlist limit reached')
+	if (diagnostic.completionDaysTruncated) {
+		details.push('completion timeline limited')
+	}
+	if (
+		diagnostic.historyEntriesRejected > 0 ||
+		diagnostic.historyFinishEventsTruncated > 0
+	) {
+		details.push('some history could not be fully read')
+	}
+	return details.length ? ` Partial data: ${details.join('; ')}.` : ''
 }
 
 export default function ProfileOverview() {
 	const shellData = useOutletContext<ProfileShellData>()
-	const analyticsData = useLoaderData<typeof loader>()
-	const loaderData = { ...shellData, ...analyticsData }
+	const overviewData = useLoaderData<typeof loader>()
+	const loaderData = { ...shellData, ...overviewData }
 
-	const completionHistory = useMemo(
-		() => buildCompletionHistory(analyticsData.typedEntries),
-		[analyticsData.typedEntries],
-	)
+	const completionHistory = overviewData.completionHistory
+	const completionMonthsByYear = useMemo(() => {
+		const periods = new Map<string, Set<string>>()
+		for (const { day } of completionHistory.days) {
+			const year = day.slice(0, 4)
+			const month = day.slice(5, 7)
+			const months = periods.get(year) ?? new Set<string>()
+			months.add(month)
+			periods.set(year, months)
+		}
+		return Object.fromEntries(
+			[...periods].map(([year, months]) => [year, [...months].sort()]),
+		) as Record<string, string[]>
+	}, [completionHistory.days])
 	const completionYears = useMemo(
-		() => Object.keys(completionHistory.months),
-		[completionHistory],
+		() => Object.keys(completionMonthsByYear).sort(),
+		[completionMonthsByYear],
 	)
 
 	const latestYear = completionYears[completionYears.length - 1]
 	const latestMonths = latestYear
-		? Object.keys(completionHistory.months[latestYear])
+		? (completionMonthsByYear[latestYear] ?? [])
 		: []
 	const [selectedYear, setSelectedYear] = useState(latestYear ?? '')
 	const [selectedMonth, setSelectedMonth] = useState(
 		latestMonths[latestMonths.length - 1] ?? '',
 	)
 	const completionMonths = useMemo(
-		() =>
-			selectedYear
-				? Object.keys(completionHistory.months[selectedYear] ?? {})
-				: [],
-		[completionHistory, selectedYear],
+		() => (selectedYear ? (completionMonthsByYear[selectedYear] ?? []) : []),
+		[completionMonthsByYear, selectedYear],
 	)
 
 	useEffect(() => {
@@ -86,11 +109,11 @@ export default function ProfileOverview() {
 		}
 		if (!completionYears.includes(selectedYear)) {
 			const nextYear = completionYears[completionYears.length - 1]
-			const nextMonths = Object.keys(completionHistory.months[nextYear] ?? {})
+			const nextMonths = completionMonthsByYear[nextYear] ?? []
 			setSelectedYear(nextYear)
 			setSelectedMonth(nextMonths[nextMonths.length - 1] ?? '')
 		}
-	}, [completionHistory, completionYears, selectedYear])
+	}, [completionMonthsByYear, completionYears, selectedYear])
 
 	useEffect(() => {
 		if (completionMonths.includes(selectedMonth)) return
@@ -98,14 +121,22 @@ export default function ProfileOverview() {
 	}, [completionMonths, selectedMonth])
 
 	function selectYear(year: string) {
-		const months = Object.keys(completionHistory.months[year] ?? {})
+		const months = completionMonthsByYear[year] ?? []
 		setSelectedYear(year)
 		setSelectedMonth(months[months.length - 1] ?? '')
 	}
 
 	const selectedRange =
 		selectedYear && selectedMonth
-			? completionHistory.months[selectedYear]?.[selectedMonth]
+			? {
+					from: `${selectedYear}-${selectedMonth}-01`,
+					to: `${selectedYear}-${selectedMonth}-${new Date(
+						Date.UTC(Number(selectedYear), Number(selectedMonth), 0),
+					)
+						.getUTCDate()
+						.toString()
+						.padStart(2, '0')}`,
+				}
 			: null
 
 	return (
@@ -119,6 +150,7 @@ export default function ProfileOverview() {
 						<h2>Completion History</h2>
 						<p>
 							Finished titles and progress logged during the selected month.
+							{overviewDiagnosticText(overviewData.diagnostic)}
 						</p>
 					</header>
 					{selectedRange ? (

--- a/app/routes/users+/$username.stats.tsx
+++ b/app/routes/users+/$username.stats.tsx
@@ -7,7 +7,7 @@ import {
 import { ProfilePageHeader } from '#app/components/profile-ui.tsx'
 import { StatsOverview } from '#app/routes/users+/$username_/stats-overview.tsx'
 import { StatsData } from '#app/routes/users+/$username_/stats_/index.tsx'
-import { loadProfileAnalytics } from '#app/utils/profile-data.server.ts'
+import { loadProfileStats } from '#app/utils/profile-data.server.ts'
 import { profileHeaders } from '#app/utils/profile-headers.ts'
 import { type ProfileShellData } from '#app/utils/profile.ts'
 import { makeTimings } from '#app/utils/timing.server.ts'
@@ -16,12 +16,8 @@ export { ProfileTabErrorBoundary as ErrorBoundary } from '#app/components/profil
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
 	const timings = makeTimings('profile_stats', 'profile stats loader')
-	const analytics = await loadProfileAnalytics(
-		request,
-		params['username'],
-		timings,
-	)
-	return json(analytics, {
+	const stats = await loadProfileStats(request, params['username'], timings)
+	return json(stats, {
 		headers: { 'Server-Timing': timings.toString() },
 	})
 }

--- a/app/routes/users+/$username_/body.tsx
+++ b/app/routes/users+/$username_/body.tsx
@@ -53,6 +53,11 @@ export function RecentActivityData({
 			: allActivity.filter(item => item.typeId === selectedTypeId)
 
 	const visible = filtered.slice(0, visibleCount)
+	const activityMeta = loaderData.activityLimited
+		? selectedTypeId === 'all'
+			? `${filtered.length} recent ${filtered.length === 1 ? 'update' : 'updates'} shown · Partial`
+			: `${filtered.length} ${filtered.length === 1 ? 'match' : 'matches'} · Partial activity`
+		: `${filtered.length} ${filtered.length === 1 ? 'update' : 'updates'}`
 
 	return (
 		<div className="user-landing-recent-activity-container">
@@ -60,7 +65,7 @@ export function RecentActivityData({
 				eyebrow="Timeline"
 				title="Recent Activity"
 				description="A chronological view of ratings, progress, reviews, and diary entries."
-				meta={`${filtered.length} ${filtered.length === 1 ? 'update' : 'updates'}`}
+				meta={activityMeta}
 				action={
 					allActivity.length > 0 ? (
 						<ProfileSegmentedFilter
@@ -112,8 +117,16 @@ export function RecentActivityData({
 					) : (
 						<ProfileEmptyState
 							icon="activity-log"
-							title="No matching updates"
-							description="Choose another media type to see the rest of this member's activity."
+							title={
+								loaderData.activityLimited
+									? 'No matches in this recent window'
+									: 'No matching updates'
+							}
+							description={
+								loaderData.activityLimited
+									? 'Try another media type.'
+									: "Choose another media type to see the rest of this member's activity."
+							}
 						/>
 					)}
 					{visibleCount < filtered.length ? (
@@ -192,6 +205,11 @@ export function FavoritesData({
 				description="A personal shelf of standout titles, grouped by media type."
 				meta={`${favorites.length} ${favorites.length === 1 ? 'favorite' : 'favorites'}`}
 			/>
+			{loaderData.favoritesLimited ? (
+				<p className="user-landing-control-label" role="status">
+					Showing a limited selection of favorites.
+				</p>
+			) : null}
 			<div className="user-landing-favorites-controls">
 				<TypeSwitcher
 					variant="primary"

--- a/app/routes/users+/$username_/stats-overview.tsx
+++ b/app/routes/users+/$username_/stats-overview.tsx
@@ -1,77 +1,99 @@
 import {
-	type ProfileAnalyticsData,
+	compactProfileStatuses,
+	type ProfileOverviewData,
 	type ProfileShellData,
 } from '#app/utils/profile.ts'
 
 function progressLabel(unit: string) {
-  const plural = `${unit.charAt(0).toUpperCase()}${unit.slice(1)}s`
-  if (unit === 'chapter' || unit === 'volume') return `${plural} Read`
-  if (unit === 'episode') return 'Episodes Watched'
-  return `${plural} Tracked`
+	const plural = `${unit.charAt(0).toUpperCase()}${unit.slice(1)}s`
+	if (unit === 'chapter' || unit === 'volume') return `${plural} Read`
+	if (unit === 'episode') return 'Episodes Watched'
+	return `${plural} Tracked`
 }
 
 export function StatsOverview({
 	data,
 }: {
-	data: Pick<ProfileShellData, 'listTypes'> & ProfileAnalyticsData
+	data: Pick<ProfileShellData, 'listTypes'> &
+		Pick<ProfileOverviewData, 'trackingSummaries'>
 }) {
-  const { listTypes, trackingSummaries } = data
+	const { listTypes, trackingSummaries } = data
 
-  return (
-    <div className="user-landing-stats-overview">
-      {listTypes.map(type => {
-        const summary = trackingSummaries[type.id] ?? {
-          totalTitles: 0,
-          meanScore: null,
-          repeatCount: 0,
-          progress: [],
-          statuses: [],
-        }
+	return (
+		<div className="user-landing-stats-overview">
+			{listTypes.map(type => {
+				const summary = trackingSummaries[type.id] ?? {
+					totalTitles: 0,
+					meanScore: null,
+					repeatCount: 0,
+					progress: [],
+					statuses: [],
+				}
 
-        return (
-          <div className="user-landing-stats-overview-card" key={type.id}>
-            <h2 className="user-landing-stats-overview-title">{type.header}</h2>
-            <div className="user-landing-stats-overview-figures">
-              <div className="user-landing-stats-overview-figure">
-                <span className="user-landing-stats-overview-value">
-                  {summary.meanScore != null ? summary.meanScore.toFixed(2) : '—'}
-                </span>
-                <span className="user-landing-stats-overview-label">Mean Score</span>
-              </div>
-              <div className="user-landing-stats-overview-figure">
-                <span className="user-landing-stats-overview-value">{summary.totalTitles}</span>
-                <span className="user-landing-stats-overview-label">Total Titles</span>
-              </div>
-              {summary.progress.map(progress => (
-                <div className="user-landing-stats-overview-figure" key={progress.unit}>
-                  <span className="user-landing-stats-overview-value">{progress.current}</span>
-                  <span className="user-landing-stats-overview-label">
-                    {progressLabel(progress.unit)}
-                  </span>
-                </div>
-              ))}
-              {summary.repeatCount > 0 ? (
-                <div className="user-landing-stats-overview-figure">
-                  <span className="user-landing-stats-overview-value">{summary.repeatCount}</span>
-                  <span className="user-landing-stats-overview-label">Repeats</span>
-                </div>
-              ) : null}
-            </div>
-            <ul className="user-landing-stats-overview-statuses">
-              {summary.statuses.map(status => (
-                <li className="user-landing-stats-overview-status" key={status.key}>
-                  <span className="user-landing-stats-overview-status-label">
-                    {status.label}
-                  </span>
-                  <span className="user-landing-stats-overview-status-count">
-                    {status.count}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )
-      })}
-    </div>
-  )
+				return (
+					<div className="user-landing-stats-overview-card" key={type.id}>
+						<h2 className="user-landing-stats-overview-title">{type.header}</h2>
+						<div className="user-landing-stats-overview-figures">
+							<div className="user-landing-stats-overview-figure">
+								<span className="user-landing-stats-overview-value">
+									{summary.meanScore != null
+										? summary.meanScore.toFixed(2)
+										: '—'}
+								</span>
+								<span className="user-landing-stats-overview-label">
+									Mean Score
+								</span>
+							</div>
+							<div className="user-landing-stats-overview-figure">
+								<span className="user-landing-stats-overview-value">
+									{summary.totalTitles}
+								</span>
+								<span className="user-landing-stats-overview-label">
+									Total Titles
+								</span>
+							</div>
+							{summary.progress.map(progress => (
+								<div
+									className="user-landing-stats-overview-figure"
+									key={progress.unit}
+								>
+									<span className="user-landing-stats-overview-value">
+										{progress.current}
+									</span>
+									<span className="user-landing-stats-overview-label">
+										{progressLabel(progress.unit)}
+									</span>
+								</div>
+							))}
+							{summary.repeatCount > 0 ? (
+								<div className="user-landing-stats-overview-figure">
+									<span className="user-landing-stats-overview-value">
+										{summary.repeatCount}
+									</span>
+									<span className="user-landing-stats-overview-label">
+										Repeats
+									</span>
+								</div>
+							) : null}
+						</div>
+						<ul className="user-landing-stats-overview-statuses">
+							{compactProfileStatuses(summary.statuses).map(status => (
+								<li
+									className="user-landing-stats-overview-status"
+									key={status.key}
+								>
+									<span className="user-landing-stats-overview-status-label">
+										{status.label}
+									</span>
+									<span className="user-landing-stats-overview-status-count">
+										{status.count}
+									</span>
+								</li>
+							))}
+						</ul>
+					</div>
+				)
+			})}
+		</div>
+	)
 }

--- a/app/routes/users+/$username_/stats_/bar.tsx
+++ b/app/routes/users+/$username_/stats_/bar.tsx
@@ -1,168 +1,212 @@
 import { ResponsiveBar } from '@nivo/bar'
+import { ProfileChartDataTable } from '#app/routes/users+/$username_/stats_/visualization-boundary.tsx'
 import { veudChartColors, veudNivoTheme } from '#app/utils/nivo-theme.ts'
+import {
+	type ProfileAnalyticsResult,
+	PROFILE_COMPONENT_SCORE_FIELDS,
+	type ProfileProviderScoreField,
+	type ProfileScoreBuckets,
+	type ProfileScoreField,
+} from '#app/utils/profile-analytics.ts'
+import { type ListTypeMeta } from '#app/utils/profile.ts'
 
-function MyResponsiveBar(data: any, barKeys: any) {
-  return (
-    <div className="user-landing-stats-chart-container user-landing-stats-bar-chart">
-      <ResponsiveBar
-        colors={veudChartColors}
-        theme={veudNivoTheme}
-        data={data}
-        keys={barKeys}
-        indexBy="score"
-        margin={{ top: 50, right: 130, bottom: 50, left: 60 }}
-        padding={0.3}
-        //groupMode="grouped"
-        valueScale={{ type: 'linear' }}
-        indexScale={{ type: 'band', round: true }}
-        defs={[
-            {
-                id: 'dots',
-                type: 'patternDots',
-                background: 'inherit',
-                color: '#38bcb2',
-                size: 4,
-                padding: 1,
-                stagger: true
-            },
-            {
-                id: 'lines',
-                type: 'patternLines',
-                background: 'inherit',
-                color: '#eed312',
-                rotation: -45,
-                lineWidth: 6,
-                spacing: 10
-            }
-        ]}
-        // fill={fill}
-        tooltip={(point) => {
-          // console.log(point)
-          return (
-            <div
-              style={{
-                background: 'black',
-                color: point.color,
-                padding: '9px 12px',
-                border: '1px solid #ccc',
-              }}
-            >
-            <div>{`${point.indexValue}`}</div>
-            <div>{`${point.id.toString().charAt(0).toUpperCase() + point.id.toString().slice(1)}: ${point.value}`}</div>
-            </div>
-          )
-        }} 
-        borderColor={{
-            from: 'color',
-            modifiers: [
-                [
-                    'darker',
-                    1.6
-                ]
-            ]
-        }}
-        axisTop={null}
-        axisRight={null}
-        axisBottom={{
-            tickSize: 5,
-            tickPadding: 5,
-            tickRotation: 0,
-            legend: 'country',
-            legendPosition: 'middle',
-            legendOffset: 32,
-            truncateTickAt: 0
-        }}
-        axisLeft={{
-            tickSize: 5,
-            tickPadding: 5,
-            tickRotation: 0,
-            legend: 'food',
-            legendPosition: 'middle',
-            legendOffset: -40,
-            truncateTickAt: 0
-        }}
-        labelSkipWidth={12}
-        labelSkipHeight={12}
-        labelTextColor={{
-            from: 'color',
-            modifiers: [
-                [
-                    'darker',
-                    1.6
-                ]
-            ]
-        }}
-        legends={[
-          {
-            anchor: 'bottom-right',
-            direction: 'column',
-            justify: false,
-            translateX: 120,
-            translateY: 0,
-            itemsSpacing: 10,
-            itemWidth: 100,
-            itemHeight: 18,
-            itemTextColor: 'white',
-            itemDirection: 'left-to-right',
-            itemOpacity: 1,
-            symbolSize: 18,
-            symbolShape: 'square',
-            dataFrom: 'keys',
-            effects: [
-              {
-                on: 'hover',
-                style: {
-                  itemTextColor: '#66563d'
-                }
-              }
-            ]
-          }
-        ]}
-        role="application"
-        ariaLabel="Nivo bar chart demo"
-        barAriaLabel={e=>e.id+": "+e.formattedValue+" in country: "+e.indexValue}
-      />
-    </div>
-  )
+const SCORE_LABELS: Record<ProfileScoreField, string> = {
+	story: 'Story',
+	character: 'Character',
+	presentation: 'Presentation',
+	sound: 'Sound',
+	performance: 'Performance',
+	enjoyment: 'Enjoyment',
+	averaged: 'Average',
+	personal: 'Personal',
+	tmdbScore: 'TMDB Score',
+	malScore: 'MAL Score',
 }
 
-export function renderBarChart(loaderData: any, chartType: string, listType: any) {
-  if (chartType == "score") {
-    const typedEntry = loaderData.typedEntries[listType.id]
-    let scoredBars: any[] = [], barKeys: string[] = []
-    for (let i = 0; i < 10; i++) {
-      scoredBars[i] = {
-        score: (i + 1)
-      }
-    }
-
-    if (typedEntry && typedEntry.length > 0) {
-      typedEntry.forEach((typedEntry: any) => {
-        Object.entries(typedEntry).forEach(([columnKey, columnValue]: [string, any]) => {
-          if (!isNaN(columnValue) && !["date", "position", "volumes", "chapters", "episodes", "tmdb", "mal", "difference"].includes(columnKey.toLowerCase())) {
-            if (!columnValue || columnValue == "null" || columnValue == 0)
-              return
-  
-            if (columnValue >= 1 && columnValue <= 10) {
-              if (barKeys.indexOf(columnKey) === -1)
-                barKeys.push(columnKey)
-  
-              if (columnKey in scoredBars[Math.floor(columnValue - 1)]) {
-                scoredBars[Math.floor(columnValue - 1)][columnKey]++
-              }
-              else {
-                scoredBars[Math.floor(columnValue - 1)][columnKey] = 1
-              }
-            }
-          }
-        })
-      })
-    }
-
-    return MyResponsiveBar(scoredBars, barKeys)
-  }
+export function scoreSeriesLabel(field: ProfileScoreField) {
+	return SCORE_LABELS[field]
 }
 
-export function BarChart({ data, listType }: any) {
-  return renderBarChart(data, 'score', listType)
+type ScoreBarDatum = { score: number } & Record<string, number>
+
+function configuredProviderFields(listType: ListTypeMeta) {
+	try {
+		const columns = JSON.parse(listType.columns) as unknown
+		if (!columns || typeof columns !== 'object' || Array.isArray(columns)) {
+			return []
+		}
+		return (['tmdbScore', 'malScore'] as const).filter(
+			field => field in columns,
+		)
+	} catch {
+		if (listType.name === 'liveaction') return ['tmdbScore'] as const
+		if (listType.name === 'anime' || listType.name === 'manga') {
+			return ['malScore'] as const
+		}
+		return []
+	}
+}
+
+export function buildScoreBarSeries(
+	data: Pick<ProfileAnalyticsResult, 'scoreBuckets' | 'providerScoreBuckets'>,
+	listType: ListTypeMeta | undefined,
+) {
+	const componentBuckets = listType ? data.scoreBuckets[listType.id] : undefined
+	const providerBuckets = listType
+		? data.providerScoreBuckets[listType.id]
+		: undefined
+	const bucketsByField: Partial<
+		Record<ProfileScoreField, ProfileScoreBuckets>
+	> = {
+		...componentBuckets,
+		...providerBuckets,
+	}
+	const providerFields: readonly ProfileProviderScoreField[] = listType
+		? configuredProviderFields(listType)
+		: []
+	const barKeys: ProfileScoreField[] = [
+		...PROFILE_COMPONENT_SCORE_FIELDS,
+		...providerFields,
+	].filter(field => bucketsByField[field]?.some(count => count > 0))
+	const scoreBars: ScoreBarDatum[] = Array.from(
+		{ length: 10 },
+		(_, scoreIndex) => {
+			const datum: ScoreBarDatum = { score: scoreIndex + 1 }
+			for (const field of barKeys) {
+				datum[field] = bucketsByField[field]?.[scoreIndex] ?? 0
+			}
+			return datum
+		},
+	)
+	return { barKeys, scoreBars }
+}
+
+function MyResponsiveBar(data: ScoreBarDatum[], barKeys: ProfileScoreField[]) {
+	return (
+		<div className="user-landing-stats-chart-container user-landing-stats-bar-chart">
+			<ResponsiveBar
+				colors={veudChartColors}
+				theme={veudNivoTheme}
+				data={data}
+				keys={barKeys}
+				indexBy="score"
+				margin={{ top: 50, right: 130, bottom: 50, left: 60 }}
+				padding={0.3}
+				valueScale={{ type: 'linear' }}
+				indexScale={{ type: 'band', round: true }}
+				tooltip={point => (
+					<div
+						style={{
+							background: 'black',
+							color: point.color,
+							padding: '9px 12px',
+							border: '1px solid #ccc',
+						}}
+					>
+						<div>{`Score ${point.indexValue}`}</div>
+						<div>{`${scoreSeriesLabel(point.id as ProfileScoreField)}: ${point.value}`}</div>
+					</div>
+				)}
+				borderColor={{
+					from: 'color',
+					modifiers: [['darker', 1.6]],
+				}}
+				axisTop={null}
+				axisRight={null}
+				axisBottom={{
+					tickSize: 5,
+					tickPadding: 5,
+					tickRotation: 0,
+					legend: 'Score',
+					legendPosition: 'middle',
+					legendOffset: 32,
+					truncateTickAt: 0,
+				}}
+				axisLeft={{
+					tickSize: 5,
+					tickPadding: 5,
+					tickRotation: 0,
+					legend: 'Entries',
+					legendPosition: 'middle',
+					legendOffset: -40,
+					truncateTickAt: 0,
+				}}
+				labelSkipWidth={12}
+				labelSkipHeight={12}
+				labelTextColor={{
+					from: 'color',
+					modifiers: [['darker', 1.6]],
+				}}
+				legendLabel={datum => scoreSeriesLabel(datum.id as ProfileScoreField)}
+				legends={[
+					{
+						anchor: 'bottom-right',
+						direction: 'column',
+						justify: false,
+						translateX: 120,
+						translateY: 0,
+						itemsSpacing: 10,
+						itemWidth: 100,
+						itemHeight: 18,
+						itemTextColor: 'white',
+						itemDirection: 'left-to-right',
+						itemOpacity: 1,
+						symbolSize: 18,
+						symbolShape: 'square',
+						dataFrom: 'keys',
+						effects: [
+							{
+								on: 'hover',
+								style: { itemTextColor: '#66563d' },
+							},
+						],
+					},
+				]}
+				role="img"
+				ariaLabel="Score distribution"
+				barAriaLabel={bar =>
+					`${scoreSeriesLabel(bar.id as ProfileScoreField)}: ${bar.formattedValue} entries with score ${bar.indexValue}`
+				}
+			/>
+			<ProfileChartDataTable
+				label="Score distribution values"
+				columns={['Score', ...barKeys.map(scoreSeriesLabel)]}
+				rows={data
+					.filter(datum => barKeys.some(field => datum[field] > 0))
+					.map(datum => ({
+						key: String(datum.score),
+						cells: [datum.score, ...barKeys.map(field => datum[field] ?? 0)],
+					}))}
+			/>
+		</div>
+	)
+}
+
+export function renderBarChart(
+	data: Pick<ProfileAnalyticsResult, 'scoreBuckets' | 'providerScoreBuckets'>,
+	listType: ListTypeMeta | undefined,
+) {
+	const { barKeys, scoreBars } = buildScoreBarSeries(data, listType)
+	if (!barKeys.length) {
+		return (
+			<div
+				className="user-landing-stats-chart-container user-landing-stats-bar-chart"
+				role="status"
+			>
+				No scores yet.
+			</div>
+		)
+	}
+
+	return MyResponsiveBar(scoreBars, barKeys)
+}
+
+export function BarChart({
+	data,
+	listType,
+}: {
+	data: Pick<ProfileAnalyticsResult, 'scoreBuckets' | 'providerScoreBuckets'>
+	listType?: ListTypeMeta
+}) {
+	return renderBarChart(data, listType)
 }

--- a/app/routes/users+/$username_/stats_/box_plot.tsx
+++ b/app/routes/users+/$username_/stats_/box_plot.tsx
@@ -1,193 +1,256 @@
-import { ResponsiveBoxPlot } from '@nivo/boxplot'
-import { veudChartColors, veudNivoTheme } from '#app/utils/nivo-theme.ts'
+import { useId } from 'react'
+import { ProfileChartDataTable } from '#app/routes/users+/$username_/stats_/visualization-boundary.tsx'
+import { veudChartColors } from '#app/utils/nivo-theme.ts'
+import {
+	type ProfileAnalyticsResult,
+	type ProfileObjectiveScoreSummary,
+	type ProfileObjectiveScores,
+} from '#app/utils/profile-analytics.ts'
+import { type ListTypeMeta } from '#app/utils/profile.ts'
 
-function MyResponsiveBoxPlot(data: any) {
-  return (
-    <div className="user-landing-stats-chart-container user-landing-stats-box-plot-chart">
-      <ResponsiveBoxPlot
-        colors={veudChartColors}
-        theme={veudNivoTheme as any}
-          data={data}
-          margin={{ top: 60, right: 140, bottom: 60, left: 60 }}
-          minValue={0}
-          maxValue={10}
-          subGroupBy="group"
-          padding={0.12}
-          enableGridX={true}
-          axisTop={{
-              tickSize: 5,
-              tickPadding: 5,
-              tickRotation: 0,
-              legend: '',
-              legendOffset: 36,
-              truncateTickAt: 0
-          }}
-          axisRight={{
-              tickSize: 5,
-              tickPadding: 5,
-              tickRotation: 0,
-              legend: '',
-              legendOffset: 0,
-              truncateTickAt: 0
-          }}
-          axisBottom={{
-              tickSize: 5,
-              tickPadding: 5,
-              tickRotation: 0,
-              legend: 'group',
-              legendPosition: 'middle',
-              legendOffset: 32,
-              truncateTickAt: 0
-          }}
-          axisLeft={{
-              tickSize: 5,
-              tickPadding: 5,
-              tickRotation: 0,
-              legend: 'value',
-              legendPosition: 'middle',
-              legendOffset: -40,
-              truncateTickAt: 0
-          }}
-          colorBy="group"
-          borderRadius={2}
-          borderWidth={2}
-          borderColor={{
-              from: 'color',
-              modifiers: [
-                  [
-                      'darker',
-                      0.3
-                  ]
-              ]
-          }}
-          medianWidth={2}
-          medianColor={{
-              from: 'color',
-              modifiers: [
-                  [
-                      'darker',
-                      0.3
-                  ]
-              ]
-          }}
-          whiskerEndSize={0.6}
-          whiskerColor={{
-              from: 'color',
-              modifiers: [
-                  [
-                      'darker',
-                      0.3
-                  ]
-              ]
-          }}
-          motionConfig="stiff"
-          tooltip={(point: any) => {
-            //console.log(point)
-            return (
-              <div
-                style={{
-                  background: 'black',
-                  color: point.color,
-                  padding: '9px 12px',
-                  border: '1px solid #ccc',
-                }}
-              >
-                <div>{`${point.group} (${point.data.n})`}</div>
-                <div>{`Mean: ${Number(point.formatted.mean).toFixed(1)}`}</div>
-                <div>{`Min: ${point.data.extrema[0]}`}</div>
-                <div>{`Max: ${point.data.extrema[1]}`}</div>
-              </div>
-            )
-          }} 
-          legends={[
-          {
-            anchor: 'bottom-right',
-            direction: 'column',
-            justify: false,
-            translateX: 120,
-            translateY: 0,
-            itemsSpacing: 10,
-            itemWidth: 100,
-            itemHeight: 18,
-            itemTextColor: 'white',
-            itemDirection: 'left-to-right',
-            itemOpacity: 1,
-            symbolSize: 18,
-            symbolShape: 'square',
-            effects: [
-              {
-                on: 'hover',
-                style: {
-                  itemTextColor: '#66563d'
-                }
-              }
-            ]
-          }
-        ]}
-      />
-    </div>
-  )
+const WIDTH = 840
+const HEIGHT = 440
+const LEFT = 64
+const RIGHT = 816
+const TOP = 32
+const BOTTOM = 380
+
+function xPosition(score: number) {
+	return LEFT + ((score - 1) / 9) * (RIGHT - LEFT)
 }
 
-export function renderBoxPlotChart(loaderData: any, chartType: string, listType: any) {
-  if (chartType == "objective scores") {
-    const typedEntry = loaderData.typedEntries[listType.id]
-
-    let scoredBars: any[] = []
-    for (let i = 0; i < 10; i++) {
-      scoredBars[i] = {
-        value: (i + 1),
-        personal: []
-      }
-    }
-
-    let objectiveType: any
-    if (typedEntry && typedEntry.length >= 1 && typedEntry[0]) {
-      if ("tmdbScore" in typedEntry[0]) {
-        objectiveType = "tmdbScore"
-      }
-      else if ("malScore" in typedEntry[0]) {
-        objectiveType = "malScore"
-      }
-    }
-    else {
-      return
-    }
-
-    if (!objectiveType) {
-      throw new Error ("No objective score type found!")
-    }
-
-    typedEntry.forEach((typedEntry: any) => {
-      if ((!isNaN(typedEntry[objectiveType]) && !isNaN(typedEntry["personal"])) && ((typedEntry[objectiveType] >= 1 && typedEntry[objectiveType] <= 10)  && (typedEntry["personal"] >= 1 && typedEntry["personal"] <= 10))) {
-        scoredBars[Math.floor(typedEntry[objectiveType])]["personal"].push(typedEntry["personal"])
-      }
-    })
-
-    let scoresFormatted: any[] = []
-    for (const scoreBar of scoredBars) {
-      if (scoreBar.personal.length > 0) {
-        const dataLength = scoreBar.personal.length
-        const dataAverage = scoreBar.personal.reduce((a: any, b: any) => Number(a) + Number(b)) / dataLength
-        const stdDeviation = Math.sqrt(scoreBar.personal.map((x: any) => Math.pow(x - dataAverage, 2)).reduce((a: any, b: any) => Number(a) + Number(b)) / dataLength)
-
-        for (const personalScore of scoreBar.personal) {
-          scoresFormatted.push({
-            group: scoreBar.value,
-            subgroup: scoreBar.value,
-            value: personalScore,
-            mu: dataAverage,
-            sd: stdDeviation,
-            n: dataLength,
-          })
-        }
-      }
-    }
-    
-    return MyResponsiveBoxPlot(scoresFormatted)
-  }
+function yPosition(score: number) {
+	return BOTTOM - ((score - 1) / 9) * (BOTTOM - TOP)
 }
 
-export function BoxPlotChart({ data, listType }: any) {
-  return renderBoxPlotChart(data, 'objective scores', listType)
+function sourceLabel(source: ProfileObjectiveScores['source']) {
+	if (source === 'tmdbScore') return 'TMDB'
+	if (source === 'malScore') return 'MAL'
+	return 'Objective'
+}
+
+function summaryLabel(
+	summary: ProfileObjectiveScoreSummary,
+	source: ProfileObjectiveScores['source'],
+) {
+	return `${sourceLabel(source)} score ${summary.score}: ${summary.count} paired ${summary.count === 1 ? 'rating' : 'ratings'}, personal median ${summary.median.toFixed(1)}, mean ${summary.mean.toFixed(1)}, range ${summary.min.toFixed(1)} to ${summary.max.toFixed(1)}`
+}
+
+export function renderBoxPlotChart(
+	data: Pick<ProfileAnalyticsResult, 'objectiveScores'>,
+	listType: ListTypeMeta | undefined,
+	titleId = 'profile-objective-score-chart',
+) {
+	const scores = listType ? data.objectiveScores[listType.id] : undefined
+	if (!scores?.groups.length) {
+		return (
+			<div
+				className="user-landing-stats-chart-container user-landing-stats-box-plot-chart"
+				role="status"
+			>
+				No paired personal and public scores yet.
+			</div>
+		)
+	}
+
+	const provider = sourceLabel(scores.source)
+
+	return (
+		<div className="user-landing-stats-chart-container user-landing-stats-box-plot-chart">
+			<svg
+				viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+				width="100%"
+				height="100%"
+				role="img"
+				aria-labelledby={titleId}
+				preserveAspectRatio="xMidYMid meet"
+			>
+				<title id={titleId}>
+					{`Personal score distribution by ${provider} score`}
+				</title>
+
+				{Array.from({ length: 10 }, (_, index) => index + 1).map(score => {
+					const y = yPosition(score)
+					return (
+						<g key={`y-${score}`}>
+							<line
+								x1={LEFT}
+								x2={RIGHT}
+								y1={y}
+								y2={y}
+								stroke="rgba(255, 255, 255, 0.1)"
+							/>
+							<text
+								x={LEFT - 14}
+								y={y + 4}
+								textAnchor="end"
+								fill="#FFEFCC"
+								fontSize="12"
+							>
+								{score}
+							</text>
+						</g>
+					)
+				})}
+
+				<line x1={LEFT} x2={RIGHT} y1={BOTTOM} y2={BOTTOM} stroke="#6F6F6F" />
+				<line x1={LEFT} x2={LEFT} y1={TOP} y2={BOTTOM} stroke="#6F6F6F" />
+
+				{Array.from({ length: 10 }, (_, index) => index + 1).map(score => {
+					const x = xPosition(score)
+					return (
+						<g key={`x-${score}`}>
+							<line
+								x1={x}
+								x2={x}
+								y1={BOTTOM}
+								y2={BOTTOM + 5}
+								stroke="#6F6F6F"
+							/>
+							<text
+								x={x}
+								y={BOTTOM + 22}
+								textAnchor="middle"
+								fill="#FFEFCC"
+								fontSize="12"
+							>
+								{score}
+							</text>
+						</g>
+					)
+				})}
+
+				<text
+					x={(LEFT + RIGHT) / 2}
+					y={HEIGHT - 10}
+					textAnchor="middle"
+					fill="#dbffcc"
+					fontSize="13"
+				>
+					{`${provider} score`}
+				</text>
+				<text
+					x="14"
+					y={(TOP + BOTTOM) / 2}
+					textAnchor="middle"
+					fill="#dbffcc"
+					fontSize="13"
+					transform={`rotate(-90 14 ${(TOP + BOTTOM) / 2})`}
+				>
+					Personal score
+				</text>
+
+				{scores.groups.map((summary, index) => {
+					const x = xPosition(summary.score)
+					const minY = yPosition(summary.min)
+					const q1Y = yPosition(summary.q1)
+					const medianY = yPosition(summary.median)
+					const q3Y = yPosition(summary.q3)
+					const maxY = yPosition(summary.max)
+					const meanY = yPosition(summary.mean)
+					const color = veudChartColors[index % veudChartColors.length]
+					const boxWidth = 38
+
+					return (
+						<g
+							key={summary.score}
+							tabIndex={0}
+							role="img"
+							aria-label={summaryLabel(summary, scores.source)}
+						>
+							<title>{summaryLabel(summary, scores.source)}</title>
+							<line
+								x1={x}
+								x2={x}
+								y1={maxY}
+								y2={minY}
+								stroke={color}
+								strokeWidth="2"
+							/>
+							<line
+								x1={x - boxWidth / 3}
+								x2={x + boxWidth / 3}
+								y1={maxY}
+								y2={maxY}
+								stroke={color}
+								strokeWidth="2"
+							/>
+							<line
+								x1={x - boxWidth / 3}
+								x2={x + boxWidth / 3}
+								y1={minY}
+								y2={minY}
+								stroke={color}
+								strokeWidth="2"
+							/>
+							<rect
+								x={x - boxWidth / 2}
+								y={q3Y}
+								width={boxWidth}
+								height={Math.max(2, q1Y - q3Y)}
+								fill={color}
+								fillOpacity="0.72"
+								stroke={color}
+								strokeWidth="2"
+								rx="3"
+							/>
+							<line
+								x1={x - boxWidth / 2}
+								x2={x + boxWidth / 2}
+								y1={medianY}
+								y2={medianY}
+								stroke="#2e2f2b"
+								strokeWidth="3"
+							/>
+							<circle
+								cx={x}
+								cy={meanY}
+								r="4"
+								fill="#FFEFCC"
+								stroke="#2e2f2b"
+								strokeWidth="1.5"
+							/>
+						</g>
+					)
+				})}
+			</svg>
+			<ProfileChartDataTable
+				label={`Personal score distribution by ${provider} score values`}
+				columns={[
+					`${provider} score`,
+					'Ratings',
+					'Minimum',
+					'Lower quartile',
+					'Median',
+					'Upper quartile',
+					'Maximum',
+					'Mean',
+				]}
+				rows={scores.groups.map(summary => ({
+					key: String(summary.score),
+					cells: [
+						summary.score,
+						summary.count,
+						summary.min,
+						summary.q1,
+						summary.median,
+						summary.q3,
+						summary.max,
+						summary.mean,
+					],
+				}))}
+			/>
+		</div>
+	)
+}
+
+export function BoxPlotChart({
+	data,
+	listType,
+}: {
+	data: Pick<ProfileAnalyticsResult, 'objectiveScores'>
+	listType?: ListTypeMeta
+}) {
+	const titleId = useId()
+	return renderBoxPlotChart(data, listType, titleId)
 }

--- a/app/routes/users+/$username_/stats_/calendar.tsx
+++ b/app/routes/users+/$username_/stats_/calendar.tsx
@@ -1,6 +1,21 @@
 import { ResponsiveTimeRange } from '@nivo/calendar'
+import { ProfileChartDataTable } from '#app/routes/users+/$username_/stats_/visualization-boundary.tsx'
 import { veudChartColors, veudNivoTheme } from '#app/utils/nivo-theme.ts'
 import { type CompletionHistoryDay } from '#app/utils/profile-completion-history.ts'
+
+export function utcCalendarDayLabel(value: string | Date) {
+	if (typeof value === 'string') {
+		const canonicalDay = /^(\d{4}-\d{2}-\d{2})(?:$|T)/.exec(value)?.[1]
+		if (canonicalDay) return canonicalDay
+	}
+	const date = value instanceof Date ? value : new Date(value)
+	if (Number.isNaN(date.getTime())) return String(value)
+	return [
+		date.getUTCFullYear().toString().padStart(4, '0'),
+		(date.getUTCMonth() + 1).toString().padStart(2, '0'),
+		date.getUTCDate().toString().padStart(2, '0'),
+	].join('-')
+}
 
 export function CompletionHistoryChart({
 	data,
@@ -11,23 +26,27 @@ export function CompletionHistoryChart({
 	from: string
 	to: string
 }) {
+	const visibleDays = data.filter(day => day.day >= from && day.day <= to)
 	return (
 		<div className="user-landing-stats-calendar-chart">
-			<ResponsiveTimeRange
-				colors={veudChartColors}
-				theme={veudNivoTheme}
-				data={data}
-				from={from}
-				to={to}
-				emptyColor="rgba(255, 239, 204, 0.1)"
-				margin={{ top: 16, right: 16, bottom: 16, left: 16 }}
-				align="center"
-				direction="horizontal"
-				dayBorderWidth={1}
-				dayBorderColor="rgba(162, 255, 213, 0.2)"
-				tooltip={point => {
-					// console.log(point)
-					return (
+			<div
+				role="img"
+				aria-label="Completion history calendar"
+				style={{ width: '100%', height: '100%' }}
+			>
+				<ResponsiveTimeRange
+					colors={veudChartColors}
+					theme={veudNivoTheme}
+					data={data}
+					from={from}
+					to={to}
+					emptyColor="rgba(255, 239, 204, 0.1)"
+					margin={{ top: 16, right: 16, bottom: 16, left: 16 }}
+					align="center"
+					direction="horizontal"
+					dayBorderWidth={1}
+					dayBorderColor="rgba(162, 255, 213, 0.2)"
+					tooltip={point => (
 						<div
 							style={{
 								background: 'black',
@@ -36,10 +55,19 @@ export function CompletionHistoryChart({
 								border: '1px solid #ccc',
 							}}
 						>
-							<div>{`${new Date(point.day).toLocaleDateString()}: ${point.value}`}</div>
+							<div>{`${utcCalendarDayLabel(point.day)}: ${point.value}`}</div>
 						</div>
-					)
-				}}
+					)}
+				/>
+			</div>
+			<ProfileChartDataTable
+				label="Completion history values"
+				columns={['Date', 'Completions']}
+				rows={visibleDays.map(day => ({
+					key: day.day,
+					cells: [day.day, day.value],
+				}))}
+				emptyText={`No completions from ${from} through ${to}.`}
 			/>
 		</div>
 	)

--- a/app/routes/users+/$username_/stats_/chart-loader.tsx
+++ b/app/routes/users+/$username_/stats_/chart-loader.tsx
@@ -5,6 +5,11 @@ import {
 	type LazyExoticComponent,
 } from 'react'
 import {
+	type ListTypeMeta,
+	type ProfileShellData,
+	type ProfileStatsData,
+} from '#app/utils/profile.ts'
+import {
 	ProfileVisualizationBoundary,
 	ProfileVisualizationLoading,
 } from './visualization-boundary.tsx'
@@ -20,8 +25,8 @@ export type ProfileChartKey =
 	| 'type'
 
 type ChartModuleProps = {
-	data: any
-	listType?: any
+	data: Pick<ProfileShellData, 'listTypes'> & ProfileStatsData
+	listType?: ListTypeMeta
 	mode?: 'release' | 'watched'
 }
 
@@ -75,8 +80,8 @@ export function ProfileChart({
 }: {
 	chartKey: ProfileChartKey
 	label: string
-	data: any
-	listType?: any
+	data: Pick<ProfileShellData, 'listTypes'> & ProfileStatsData
+	listType?: ListTypeMeta
 }) {
 	const Chart = CHART_MODULES[chartKey]
 	const mode =

--- a/app/routes/users+/$username_/stats_/charts.test.tsx
+++ b/app/routes/users+/$username_/stats_/charts.test.tsx
@@ -1,0 +1,535 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { expect, test } from 'vitest'
+import { overviewDiagnosticText } from '#app/routes/users+/$username.index.tsx'
+import { RecentActivityData } from '#app/routes/users+/$username_/body.tsx'
+import {
+	buildScoreBarSeries,
+	renderBarChart,
+	scoreSeriesLabel,
+} from '#app/routes/users+/$username_/stats_/bar.tsx'
+import { renderBoxPlotChart } from '#app/routes/users+/$username_/stats_/box_plot.tsx'
+import {
+	CompletionHistoryChart,
+	utcCalendarDayLabel,
+} from '#app/routes/users+/$username_/stats_/calendar.tsx'
+import { renderChordChart } from '#app/routes/users+/$username_/stats_/chord.tsx'
+import {
+	firstPopulatedListTypeIndex,
+	StatsData,
+	statsDiagnosticText,
+} from '#app/routes/users+/$username_/stats_/index.tsx'
+import {
+	buildProfileLineSeries,
+	PROFILE_YEAR_LINE_SCALE,
+	renderLineChart,
+} from '#app/routes/users+/$username_/stats_/line.tsx'
+import { renderPieChart } from '#app/routes/users+/$username_/stats_/pie.tsx'
+import {
+	mediaTypeCategoryLabel,
+	renderRadialBar,
+} from '#app/routes/users+/$username_/stats_/radial_bar.tsx'
+import {
+	aggregateWatchlistStatuses,
+	watchlistOverview,
+} from '#app/routes/users+/$username_/stats_/watchlist.tsx'
+import {
+	PROFILE_COMPONENT_SCORE_FIELDS,
+	type ProfileAnalyticsDiagnostic,
+	type ProfileComponentScoreField,
+	type ProfileProviderScoreField,
+	type ProfileScoreBuckets,
+} from '#app/utils/profile-analytics.ts'
+import {
+	type ListTypeMeta,
+	type ProfileActivityData,
+	type ProfileShellData,
+	type ProfileStatsData,
+} from '#app/utils/profile.ts'
+
+const liveActionType: ListTypeMeta = {
+	id: 'live',
+	name: 'liveaction',
+	header: 'Live Action',
+	columns: '{"tmdbScore":"number"}',
+	mediaType: '["episode"]',
+	completionType: '{"past":"watched"}',
+}
+
+const animeType: ListTypeMeta = {
+	id: 'anime',
+	name: 'anime',
+	header: 'Anime',
+	columns: '{"malScore":"number"}',
+	mediaType: '["episode"]',
+	completionType: '{"past":"watched"}',
+}
+
+function emptyScoreBucket(): ProfileScoreBuckets {
+	return [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+}
+
+function componentBuckets() {
+	return Object.fromEntries(
+		PROFILE_COMPONENT_SCORE_FIELDS.map(field => [field, emptyScoreBucket()]),
+	) as Record<ProfileComponentScoreField, ProfileScoreBuckets>
+}
+
+function providerBuckets() {
+	return {
+		tmdbScore: emptyScoreBucket(),
+		malScore: emptyScoreBucket(),
+	} satisfies Record<ProfileProviderScoreField, ProfileScoreBuckets>
+}
+
+function diagnostic(
+	overrides: Partial<ProfileAnalyticsDiagnostic> = {},
+): ProfileAnalyticsDiagnostic {
+	return {
+		processed: 12,
+		truncated: false,
+		limit: 100_000,
+		completionDaysTruncated: false,
+		categoryCandidatesApproximate: false,
+		categoryCandidatesTruncated: false,
+		historyEntriesRejected: 0,
+		historyFinishEventsTruncated: 0,
+		watchlistsProcessed: 2,
+		watchlistsTruncated: false,
+		watchlistLimit: 100,
+		...overrides,
+	}
+}
+
+function profileStatsData({
+	userId,
+	listTypeCounts,
+}: {
+	userId: string
+	listTypeCounts: Record<string, number>
+}): Pick<ProfileShellData, 'listTypes' | 'user'> & ProfileStatsData {
+	return {
+		user: {
+			id: userId,
+			username: userId,
+			bio: null,
+			createdAt: '2025-01-01T00:00:00.000Z',
+			image: null,
+			banner: null,
+		},
+		listTypes: [liveActionType, animeType],
+		trackingSummaries: {},
+		listTypeCounts,
+		scoreBuckets: {},
+		providerScoreBuckets: {},
+		objectiveScores: {},
+		releaseYears: {},
+		completionYears: {},
+		genreMatrices: {},
+		mediaTypeCounts: {},
+		diagnostic: diagnostic(),
+	}
+}
+
+test('starts Stats on the first populated media type', () => {
+	expect(
+		firstPopulatedListTypeIndex([liveActionType, animeType], {
+			live: 0,
+			anime: 20,
+		}),
+	).toBe(1)
+	expect(
+		firstPopulatedListTypeIndex([liveActionType, animeType], {
+			live: 0,
+			anime: 0,
+		}),
+	).toBe(0)
+})
+
+test('Stats preserves an intentional selection within a profile and resets it during profile navigation', () => {
+	const view = render(
+		<StatsData
+			data={profileStatsData({
+				userId: 'profile-a',
+				listTypeCounts: { live: 0, anime: 20 },
+			})}
+		/>,
+	)
+
+	expect(screen.getByRole('button', { name: 'Anime' })).toHaveAttribute(
+		'aria-pressed',
+		'true',
+	)
+	fireEvent.click(screen.getByRole('button', { name: 'Live Action' }))
+	expect(screen.getByRole('button', { name: 'Live Action' })).toHaveAttribute(
+		'aria-pressed',
+		'true',
+	)
+
+	view.rerender(
+		<StatsData
+			data={profileStatsData({
+				userId: 'profile-a',
+				listTypeCounts: { live: 1, anime: 21 },
+			})}
+		/>,
+	)
+	expect(screen.getByRole('button', { name: 'Live Action' })).toHaveAttribute(
+		'aria-pressed',
+		'true',
+	)
+
+	view.rerender(
+		<StatsData
+			data={profileStatsData({
+				userId: 'profile-b',
+				listTypeCounts: { live: 0, anime: 4 },
+			})}
+		/>,
+	)
+	expect(screen.getByRole('button', { name: 'Anime' })).toHaveAttribute(
+		'aria-pressed',
+		'true',
+	)
+})
+
+test('reports only the relevant partial-profile diagnostics', () => {
+	expect(overviewDiagnosticText(diagnostic())).toBe('')
+	expect(
+		overviewDiagnosticText(
+			diagnostic({
+				truncated: true,
+				completionDaysTruncated: true,
+				historyEntriesRejected: 1,
+			}),
+		),
+	).toBe(
+		' Partial data: entry limit reached; completion timeline limited; some history could not be fully read.',
+	)
+
+	expect(statsDiagnosticText(diagnostic())).toBe('')
+	expect(
+		statsDiagnosticText(
+			diagnostic({
+				watchlistsTruncated: true,
+				historyFinishEventsTruncated: 1,
+				categoryCandidatesApproximate: true,
+				categoryCandidatesTruncated: true,
+			}),
+		),
+	).toBe(
+		' Partial data: watchlist limit reached; some history could not be fully read; category groups are approximate; category groups are limited.',
+	)
+})
+
+test('adds only the applicable provider score series with clear labels', () => {
+	const components = componentBuckets()
+	components.personal[7] = 2
+	const providers = providerBuckets()
+	providers.tmdbScore[8] = 7
+	providers.malScore[8] = 3
+
+	const result = buildScoreBarSeries(
+		{
+			scoreBuckets: { anime: components },
+			providerScoreBuckets: { anime: providers },
+		},
+		animeType,
+	)
+
+	expect(result.barKeys).toEqual(['personal', 'malScore'])
+	expect(result.scoreBars[7]).toMatchObject({ score: 8, personal: 2 })
+	expect(result.scoreBars[8]).toMatchObject({ score: 9, malScore: 3 })
+	expect(scoreSeriesLabel('tmdbScore')).toBe('TMDB Score')
+	expect(scoreSeriesLabel('malScore')).toBe('MAL Score')
+})
+
+test('charts return useful empty states when no media type is selected', () => {
+	render(
+		renderBarChart(
+			{
+				scoreBuckets: {},
+				providerScoreBuckets: {},
+			},
+			undefined,
+		),
+	)
+	expect(screen.getByRole('status')).toHaveTextContent('No scores yet.')
+})
+
+test('watchlist chart handles an undefined media type', () => {
+	render(watchlistOverview({ trackingSummaries: {} }, undefined))
+	expect(screen.getByRole('status')).toHaveTextContent('No watchlist data yet.')
+})
+
+test('media-type chart handles empty data and distinguishes its rollup', () => {
+	render(renderRadialBar({ listTypes: [], mediaTypeCounts: {} }))
+	expect(screen.getByRole('status')).toHaveTextContent(
+		'No media type data yet.',
+	)
+	expect(
+		mediaTypeCategoryLabel({
+			key: '__veud_category_rollup__',
+			label: 'Other',
+			isRollup: true,
+		}),
+	).toBe('All other types')
+	expect(
+		mediaTypeCategoryLabel({
+			key: '__veud_category_rollup__',
+			label: 'Other',
+		}),
+	).toBe('Other')
+	expect(mediaTypeCategoryLabel({ key: 'other', label: 'Other' })).toBe('Other')
+})
+
+test('line chart keeps every disjoint media series in chronological numeric order', () => {
+	const data = {
+		listTypes: [liveActionType, animeType],
+		releaseYears: {
+			live: [
+				{ year: 2030, count: 1 },
+				{ year: 1984, count: 2 },
+			],
+			anime: [
+				{ year: 2025, count: 3 },
+				{ year: 1997, count: 4 },
+			],
+		},
+		completionYears: {},
+	}
+	const series = buildProfileLineSeries(data, 'release')
+
+	expect(PROFILE_YEAR_LINE_SCALE.type).toBe('linear')
+	expect(series).toEqual([
+		{
+			id: 'Live Action',
+			data: [
+				{ x: 1984, y: 2 },
+				{ x: 2030, y: 1 },
+			],
+		},
+		{
+			id: 'Anime',
+			data: [
+				{ x: 1997, y: 4 },
+				{ x: 2025, y: 3 },
+			],
+		},
+	])
+
+	render(renderLineChart(data, 'release'))
+	const table = screen.getByRole('table', {
+		name: 'Release year distribution values',
+	})
+	expect(within(table).getByText('1984')).toBeInTheDocument()
+	expect(within(table).getByText('2030')).toBeInTheDocument()
+})
+
+test('profile charts expose their plotted values as accessible tables', () => {
+	const components = componentBuckets()
+	components.personal[7] = 2
+	const providers = providerBuckets()
+	providers.malScore[8] = 3
+	const view = render(
+		renderBarChart(
+			{
+				scoreBuckets: { anime: components },
+				providerScoreBuckets: { anime: providers },
+			},
+			animeType,
+		),
+	)
+	let table = screen.getByRole('table', {
+		name: 'Score distribution values',
+	})
+	expect(within(table).getByText('Personal')).toBeInTheDocument()
+	expect(within(table).getByText('MAL Score')).toBeInTheDocument()
+
+	view.rerender(
+		renderPieChart({
+			listTypes: [liveActionType, animeType],
+			listTypeCounts: { live: 3, anime: 5 },
+		}),
+	)
+	table = screen.getByRole('table', {
+		name: 'List type distribution values',
+	})
+	expect(within(table).getByText('Live Action')).toBeInTheDocument()
+	expect(within(table).getByText('5')).toBeInTheDocument()
+
+	view.rerender(
+		renderRadialBar({
+			listTypes: [animeType],
+			mediaTypeCounts: {
+				anime: [
+					{ key: 'other', label: 'Other', count: 4 },
+					{
+						key: '__veud_category_rollup__',
+						label: 'Other',
+						count: 2,
+						isRollup: true,
+					},
+				],
+			},
+		}),
+	)
+	table = screen.getByRole('table', {
+		name: 'Media type distribution values',
+	})
+	expect(within(table).getByText('Other')).toBeInTheDocument()
+	expect(within(table).getByText('All other types')).toBeInTheDocument()
+
+	view.rerender(
+		renderChordChart(
+			{
+				genreMatrices: {
+					anime: {
+						labels: ['Action', 'Drama'],
+						values: [
+							[3, 2],
+							[2, 4],
+						],
+					},
+				},
+			},
+			animeType,
+		),
+	)
+	table = screen.getByRole('table', { name: 'Genre overlap values' })
+	expect(
+		within(table).getByRole('row', { name: 'Action Drama 2' }),
+	).toBeInTheDocument()
+
+	view.rerender(
+		renderBoxPlotChart(
+			{
+				objectiveScores: {
+					anime: {
+						source: 'malScore',
+						groups: [
+							{
+								score: 8,
+								count: 3,
+								min: 6,
+								q1: 7,
+								median: 8,
+								q3: 8.5,
+								max: 9,
+								mean: 7.8,
+							},
+						],
+					},
+				},
+			},
+			animeType,
+		),
+	)
+	table = screen.getByRole('table', {
+		name: 'Personal score distribution by MAL score values',
+	})
+	expect(
+		within(table).getByRole('row', { name: '8 3 6 7 8 8.5 9 7.8' }),
+	).toBeInTheDocument()
+
+	view.rerender(
+		watchlistOverview(
+			{
+				trackingSummaries: {
+					anime: {
+						totalTitles: 5,
+						meanScore: 8,
+						repeatCount: 0,
+						progress: [],
+						statuses: [
+							{ key: 'watching', label: 'Watching', count: 2 },
+							{ key: 'completed', label: 'Completed', count: 3 },
+						],
+					},
+				},
+			},
+			animeType,
+		),
+	)
+	table = screen.getByRole('table', {
+		name: 'Watchlist status distribution values',
+	})
+	expect(
+		within(table).getByRole('row', { name: 'Completed 3 60.00%' }),
+	).toBeInTheDocument()
+
+	view.rerender(
+		<CompletionHistoryChart
+			data={[{ day: '2025-01-02', value: 3 }]}
+			from="2025-01-01"
+			to="2025-01-31"
+		/>,
+	)
+	table = screen.getByRole('table', { name: 'Completion history values' })
+	expect(
+		within(table).getByRole('row', { name: '2025-01-02 3' }),
+	).toBeInTheDocument()
+})
+
+test('watchlist statuses are capped to a fixed legend with a rollup', () => {
+	const statuses = Array.from({ length: 14 }, (_, index) => ({
+		key: `status-${index + 1}`,
+		label: `Status ${index + 1}`,
+		count: index + 1,
+	}))
+	const visible = aggregateWatchlistStatuses(statuses)
+
+	expect(visible).toHaveLength(12)
+	expect(visible[0]).toMatchObject({ label: 'Status 14', count: 14 })
+	expect(visible.at(-1)).toEqual({
+		key: '__other_statuses__',
+		label: 'Other statuses',
+		count: 6,
+	})
+	expect(visible.reduce((sum, status) => sum + status.count, 0)).toBe(105)
+})
+
+test('completion calendar uses an accessible wrapper and UTC day labels', () => {
+	render(<CompletionHistoryChart data={[]} from="2025-01-01" to="2025-01-31" />)
+	expect(
+		screen.getByRole('img', {
+			name: 'Completion history calendar',
+		}),
+	).toBeInTheDocument()
+	expect(utcCalendarDayLabel('2025-01-02')).toBe('2025-01-02')
+	expect(utcCalendarDayLabel(new Date('2025-01-02T23:00:00-08:00'))).toBe(
+		'2025-01-03',
+	)
+})
+
+test('partial activity filters explain that only a recent window was scanned', () => {
+	const data: ProfileActivityData = {
+		listTypes: [liveActionType, animeType],
+		activityLimited: true,
+		activityEvents: [
+			{
+				id: 'activity-1',
+				action: 'Completed',
+				time: '2025-01-02T00:00:00.000Z',
+				typeId: animeType.id,
+				media: {
+					id: 'media-1',
+					title: 'Example anime',
+					thumbnail: null,
+				},
+			},
+		],
+	}
+	render(
+		<MemoryRouter>
+			<RecentActivityData data={data} />
+		</MemoryRouter>,
+	)
+
+	fireEvent.click(screen.getByRole('button', { name: 'Live Action' }))
+	expect(
+		screen.getByText('No matches in this recent window', { exact: true }),
+	).toBeInTheDocument()
+})

--- a/app/routes/users+/$username_/stats_/chord.tsx
+++ b/app/routes/users+/$username_/stats_/chord.tsx
@@ -1,165 +1,145 @@
 import { ResponsiveChord } from '@nivo/chord'
+import { ProfileChartDataTable } from '#app/routes/users+/$username_/stats_/visualization-boundary.tsx'
 import { veudChartColors, veudNivoTheme } from '#app/utils/nivo-theme.ts'
+import {
+	type ProfileAnalyticsResult,
+	type ProfileCategoryMatrix,
+} from '#app/utils/profile-analytics.ts'
+import { type ListTypeMeta } from '#app/utils/profile.ts'
 
-function MyResponsiveChord(data: any, keys: any) {
-  return (
-    <div className="user-landing-stats-chart-container user-landing-stats-chord-chart">
-      <ResponsiveChord
-        colors={veudChartColors}
-        theme={veudNivoTheme}
-        data={data}
-        keys={keys}
-        margin={{ top: 60, right: 60, bottom: 90, left: 60 }}
-        valueFormat=".2f"
-        padAngle={0.02}
-        innerRadiusRatio={0.96}
-        innerRadiusOffset={0.02}
-        inactiveArcOpacity={0.25}
-        arcBorderColor={{
-            from: 'color',
-            modifiers: [
-                [
-                    'darker',
-                    0.6
-                ]
-            ]
-        }}
-        activeRibbonOpacity={0.75}
-        inactiveRibbonOpacity={0.25}
-        ribbonBorderColor={{
-            from: 'color',
-            modifiers: [
-                [
-                    'darker',
-                    0.6
-                ]
-            ]
-        }}
-        labelRotation={-90}
-        labelTextColor={{
-            from: 'color',
-            modifiers: [
-                [
-                    'darker',
-                    1
-                ]
-            ]
-        }}
-        motionConfig="stiff"
-        arcTooltip={(point) => {
-          // console.log(point.arc)
-          return (
-            <div
-              style={{
-                background: 'black',
-                color: point.arc.color,
-                padding: '9px 12px',
-                border: '1px solid #ccc',
-              }}
-            >
-              <div>{`${point.arc.label}: ${point.arc.value}`}</div>
-            </div>
-          )
-        }} 
-        ribbonTooltip={(point) => {
-          // console.log(point.ribbon)
-          return (
-            <div
-              style={{
-                background: 'black',
-                padding: '9px 12px',
-                border: '1px solid #ccc',
-              }}
-            >
-              <div style={{color: point.ribbon.source.color}}>{`${point.ribbon.source.label}: ${point.ribbon.source.value}`}</div>
-              <div style={{color: point.ribbon.target.color}}>{`${point.ribbon.target.label}: ${point.ribbon.target.value}`}</div>
-            </div>
-          )
-        }} 
-        legends={[
-          {
-            anchor: 'left',
-            direction: 'column',
-            justify: false,
-            translateX: 0,
-            translateY: 56,
-            itemsSpacing: 10,
-            itemWidth: 100,
-            itemHeight: 18,
-            itemTextColor: 'white',
-            itemDirection: 'left-to-right',
-            itemOpacity: 1,
-            symbolSize: 18,
-            symbolShape: 'square',
-            effects: [
-              {
-                on: 'hover',
-                style: {
-                  itemTextColor: '#66563d'
-                }
-              }
-            ]
-          }
-        ]}
-      />
-    </div>
-  )
+function MyResponsiveChord(matrix: ProfileCategoryMatrix) {
+	return (
+		<div className="user-landing-stats-chart-container user-landing-stats-chord-chart">
+			<ResponsiveChord
+				colors={veudChartColors}
+				theme={veudNivoTheme}
+				data={matrix.values}
+				keys={matrix.labels}
+				margin={{ top: 60, right: 60, bottom: 90, left: 60 }}
+				valueFormat=">-.0f"
+				padAngle={0.02}
+				innerRadiusRatio={0.96}
+				innerRadiusOffset={0.02}
+				inactiveArcOpacity={0.25}
+				arcBorderColor={{
+					from: 'color',
+					modifiers: [['darker', 0.6]],
+				}}
+				activeRibbonOpacity={0.75}
+				inactiveRibbonOpacity={0.25}
+				ribbonBorderColor={{
+					from: 'color',
+					modifiers: [['darker', 0.6]],
+				}}
+				labelRotation={-90}
+				labelTextColor={{
+					from: 'color',
+					modifiers: [['darker', 1]],
+				}}
+				motionConfig="stiff"
+				arcTooltip={point => (
+					<div
+						style={{
+							background: 'black',
+							color: point.arc.color,
+							padding: '9px 12px',
+							border: '1px solid #ccc',
+						}}
+					>
+						<div>{`${point.arc.label}: ${point.arc.value}`}</div>
+					</div>
+				)}
+				ribbonTooltip={point => (
+					<div
+						style={{
+							background: 'black',
+							padding: '9px 12px',
+							border: '1px solid #ccc',
+						}}
+					>
+						<div style={{ color: point.ribbon.source.color }}>
+							{`${point.ribbon.source.label}: ${point.ribbon.source.value}`}
+						</div>
+						<div style={{ color: point.ribbon.target.color }}>
+							{`${point.ribbon.target.label}: ${point.ribbon.target.value}`}
+						</div>
+					</div>
+				)}
+				legends={[
+					{
+						anchor: 'left',
+						direction: 'column',
+						justify: false,
+						translateX: 0,
+						translateY: 56,
+						itemsSpacing: 10,
+						itemWidth: 100,
+						itemHeight: 18,
+						itemTextColor: 'white',
+						itemDirection: 'left-to-right',
+						itemOpacity: 1,
+						symbolSize: 18,
+						symbolShape: 'square',
+						effects: [
+							{
+								on: 'hover',
+								style: { itemTextColor: '#66563d' },
+							},
+						],
+					},
+				]}
+				role="img"
+				ariaLabel="Genre overlap"
+			/>
+			<ProfileChartDataTable
+				label="Genre overlap values"
+				columns={['Genre', 'Related genre', 'Entries']}
+				rows={matrix.values.flatMap((row, rowIndex) =>
+					row.flatMap((value, columnIndex) => {
+						if (value <= 0 || columnIndex < rowIndex) return []
+						return [
+							{
+								key: `${rowIndex}:${columnIndex}`,
+								cells: [
+									matrix.labels[rowIndex] ?? `Genre ${rowIndex + 1}`,
+									matrix.labels[columnIndex] ?? `Genre ${columnIndex + 1}`,
+									value,
+								],
+							},
+						]
+					}),
+				)}
+			/>
+		</div>
+	)
 }
 
-export function renderChordChart(loaderData: any, listType: any) {
-  const typedEntry = loaderData.typedEntries[listType.id]
-  let chordMatrix: any[] = []
-  let chordIndices: string[] = []
+export function renderChordChart(
+	data: Pick<ProfileAnalyticsResult, 'genreMatrices'>,
+	listType: ListTypeMeta | undefined,
+) {
+	const matrix = listType ? data.genreMatrices[listType.id] : undefined
+	const hasOverlap = matrix?.values.some(row => row.some(value => value > 0))
+	if (!matrix || !hasOverlap) {
+		return (
+			<div
+				className="user-landing-stats-chart-container user-landing-stats-chord-chart"
+				role="status"
+			>
+				Not enough genre overlap yet.
+			</div>
+		)
+	}
 
-
-  if (typedEntry && typedEntry.length > 0) {
-    typedEntry.forEach((typedEntry: any) => {
-      let genreIndices: number[] = []
-
-      typedEntry.genres.split(", ").forEach((entryGenre: any) => {
-        let genreIndex = chordIndices.indexOf(entryGenre)
-
-        if (genreIndex == -1) {
-          genreIndex = chordIndices.push(entryGenre) - 1
-        }
-
-        genreIndices.push(genreIndex)
-      })
-
-      genreIndices.forEach(genreIndex => {
-        if (!chordMatrix[genreIndex]) {
-          chordMatrix[genreIndex] = []
-        }
-        
-        genreIndices.forEach(iteratedGenre => {
-          if (genreIndices.length > 1 && genreIndex == iteratedGenre) {
-            return
-          }
-
-          if (!chordMatrix[genreIndex][iteratedGenre] && chordMatrix[genreIndex][iteratedGenre] != 0) {
-            chordMatrix[genreIndex][iteratedGenre] = 0
-          }
-          else {
-            chordMatrix[genreIndex][iteratedGenre]++
-          }
-        })
-      })
-    })
-  }
-
-  if (chordMatrix && chordMatrix.length > 0) {
-    chordMatrix.forEach(matrixRow => {
-      for (let i = 0; i < chordMatrix.length; i++) {
-        if (!matrixRow[i]) {
-          matrixRow[i] = 0
-        }
-      }
-    })
-  }
-
-  return MyResponsiveChord(chordMatrix, chordIndices)
+	return MyResponsiveChord(matrix)
 }
 
-export function ChordChart({ data, listType }: any) {
-  return renderChordChart(data, listType)
+export function ChordChart({
+	data,
+	listType,
+}: {
+	data: Pick<ProfileAnalyticsResult, 'genreMatrices'>
+	listType?: ListTypeMeta
+}) {
+	return renderChordChart(data, listType)
 }

--- a/app/routes/users+/$username_/stats_/index.tsx
+++ b/app/routes/users+/$username_/stats_/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
 	ProfileEmptyState,
 	ProfileOptionNavigator,
@@ -8,9 +8,10 @@ import {
 	ProfileChart,
 	type ProfileChartKey,
 } from '#app/routes/users+/$username_/stats_/chart-loader.tsx'
+import { type ProfileAnalyticsDiagnostic } from '#app/utils/profile-analytics.ts'
 import {
-	type ProfileAnalyticsData,
 	type ProfileShellData,
+	type ProfileStatsData,
 } from '#app/utils/profile.ts'
 
 const PROFILE_CHARTS: Array<{
@@ -27,7 +28,7 @@ const PROFILE_CHARTS: Array<{
 	{ key: 'score', header: 'Score Distribution', typed: true },
 	{
 		key: 'objectiveScores',
-		header: 'Public Score Deviation',
+		header: 'Personal vs Public Scores',
 		typed: true,
 	},
 	{ key: 'release', header: 'Release Date Distribution', typed: false },
@@ -36,18 +37,82 @@ const PROFILE_CHARTS: Array<{
 	{ key: 'type', header: 'Media Type Distribution', typed: false },
 ]
 
+export function firstPopulatedListTypeIndex(
+	listTypes: ProfileShellData['listTypes'],
+	listTypeCounts: ProfileStatsData['listTypeCounts'],
+) {
+	const populatedIndex = listTypes.findIndex(
+		listType => (listTypeCounts[listType.id] ?? 0) > 0,
+	)
+	return populatedIndex >= 0 ? populatedIndex : 0
+}
+
+export function statsDiagnosticText(diagnostic: ProfileAnalyticsDiagnostic) {
+	const details: string[] = []
+	if (diagnostic.truncated) details.push('entry limit reached')
+	if (diagnostic.watchlistsTruncated) details.push('watchlist limit reached')
+	if (
+		diagnostic.historyEntriesRejected > 0 ||
+		diagnostic.historyFinishEventsTruncated > 0
+	) {
+		details.push('some history could not be fully read')
+	}
+	if (diagnostic.categoryCandidatesApproximate) {
+		details.push('category groups are approximate')
+	}
+	if (diagnostic.categoryCandidatesTruncated) {
+		details.push('category groups are limited')
+	}
+	return details.length ? ` Partial data: ${details.join('; ')}.` : ''
+}
+
 export function StatsData({
 	data: loaderData,
 }: {
-	data: ProfileShellData & ProfileAnalyticsData
+	data: Pick<ProfileShellData, 'listTypes' | 'user'> & ProfileStatsData
 }) {
 	const [chartIndex, setChartIndex] = useState(0)
-	const [typeIndex, setTypeIndex] = useState(0)
+	const defaultTypeId =
+		loaderData.listTypes[
+			firstPopulatedListTypeIndex(
+				loaderData.listTypes,
+				loaderData.listTypeCounts,
+			)
+		]?.id ?? ''
+	const [typeSelection, setTypeSelection] = useState(() => ({
+		profileId: loaderData.user.id,
+		typeId: defaultTypeId,
+	}))
+	const selectionIsCurrent =
+		typeSelection.profileId === loaderData.user.id &&
+		loaderData.listTypes.some(type => type.id === typeSelection.typeId)
+	const selectedTypeId = selectionIsCurrent
+		? typeSelection.typeId
+		: defaultTypeId
+
+	useEffect(() => {
+		if (
+			typeSelection.profileId === loaderData.user.id &&
+			typeSelection.typeId === selectedTypeId
+		) {
+			return
+		}
+		setTypeSelection({
+			profileId: loaderData.user.id,
+			typeId: selectedTypeId,
+		})
+	}, [
+		loaderData.user.id,
+		selectedTypeId,
+		typeSelection.profileId,
+		typeSelection.typeId,
+	])
 	const selectedType =
-		loaderData.listTypes[typeIndex] ?? loaderData.listTypes[0]
+		loaderData.listTypes.find(type => type.id === selectedTypeId) ??
+		loaderData.listTypes[0]
 	const selectedChart = PROFILE_CHARTS[chartIndex] ?? PROFILE_CHARTS[0]
-	const hasEntries = Object.values(loaderData.typedEntries ?? {}).some(
-		entries => entries.length > 0,
+	const hasEntries = Object.values(loaderData.listTypeCounts).some(
+		count => count > 0,
 	)
 
 	return (
@@ -55,7 +120,10 @@ export function StatsData({
 			<header className="user-landing-section-heading">
 				<span>Deep dive</span>
 				<h2>{selectedChart.header}</h2>
-				<p>Use the controls to explore a different view of this library.</p>
+				<p>
+					Use the controls to explore a different view of this library.
+					{statsDiagnosticText(loaderData.diagnostic)}
+				</p>
 			</header>
 			{hasEntries ? (
 				<>
@@ -88,12 +156,12 @@ export function StatsData({
 										label: listType.header,
 									}))}
 									value={selectedType?.id ?? ''}
-									onValueChange={value => {
-										const nextIndex = loaderData.listTypes.findIndex(
-											listType => listType.id === value,
-										)
-										if (nextIndex >= 0) setTypeIndex(nextIndex)
-									}}
+									onValueChange={typeId =>
+										setTypeSelection({
+											profileId: loaderData.user.id,
+											typeId,
+										})
+									}
 								/>
 							</div>
 						) : null}

--- a/app/routes/users+/$username_/stats_/line.tsx
+++ b/app/routes/users+/$username_/stats_/line.tsx
@@ -1,224 +1,173 @@
 import { ResponsiveLine } from '@nivo/line'
-import { getStartYear } from "#app/utils/lists/column-functions.tsx"
+import { ProfileChartDataTable } from '#app/routes/users+/$username_/stats_/visualization-boundary.tsx'
 import { veudChartColors, veudNivoTheme } from '#app/utils/nivo-theme.ts'
+import { type ProfileAnalyticsResult } from '#app/utils/profile-analytics.ts'
+import { type ProfileShellData } from '#app/utils/profile.ts'
 
-function MyResponsiveLine(data: any) {
-  return (
-    <div className="user-landing-stats-chart-container user-landing-stats-line-chart">
-      <ResponsiveLine
-        colors={veudChartColors}
-        theme={veudNivoTheme}
-        data={data}
-        margin={{ top: 50, right: 110, bottom: 50, left: 60 }}
-        xScale={{ type: 'point' }}
-        yScale={{
-            type: 'linear',
-            min: 'auto',
-            max: 'auto',
-            stacked: false,
-            reverse: false
-        }}
-        curve="monotoneX"
-        // axisTop={null}
-        // axisRight={null}
-        // axisBottom={{
-        //     tickSize: 5,
-        //     tickPadding: 5,
-        //     tickRotation: 0,
-        //     legend: 'transportation',
-        //     legendOffset: 36,
-        //     legendPosition: 'middle',
-        //     truncateTickAt: 0
-        // }}
-        // axisLeft={{
-        //     tickSize: 5,
-        //     tickPadding: 5,
-        //     tickRotation: 0,
-        //     legend: 'count',
-        //     legendOffset: -40,
-        //     legendPosition: 'middle',
-        //     truncateTickAt: 0
-        // }}
-        enableGridX={false}
-        enableGridY={false}
-        pointSize={10}
-        pointColor={{ theme: 'background' }}
-        pointBorderWidth={2}
-        pointBorderColor={{ from: 'serieColor' }}
-        enablePointLabel={true}
-        pointLabelYOffset={-12}
-        enableArea={true}
-        enableTouchCrosshair={true}
-        useMesh={true}
-        tooltip={(point) => {
-          // console.log(point.point)
-          return (
-            <div
-              style={{
-                background: 'black',
-                color: point.point.seriesColor,
-                padding: '9px 12px',
-                border: '1px solid #ccc',
-              }}
-            >
-              <div>{`${point.point.seriesId}`}</div>
-              <div>{`${point.point.data.x}: ${point.point.data.y}`}</div>
-            </div>
-          )
-        }} 
-        legends={[
-          {
-            anchor: 'left',
-            direction: 'column',
-            justify: false,
-            translateX: 0,
-            translateY: 56,
-            itemsSpacing: 10,
-            itemWidth: 100,
-            itemHeight: 18,
-            itemTextColor: 'white',
-            itemDirection: 'left-to-right',
-            itemOpacity: 1,
-            symbolSize: 18,
-            symbolShape: 'square',
-            effects: [
-              {
-                on: 'hover',
-                style: {
-                  itemTextColor: '#66563d'
-                }
-              }
-            ]
-          }
-        ]}
-      />
-    </div>
-  )
+type LineMode = 'release' | 'watched'
+
+export type ProfileLineSeries = {
+	id: string
+	data: Array<{ x: number; y: number }>
 }
 
-export function renderLineChart(loaderData: any, chartType: string) {
-  let typedLines: any[] = []
+export const PROFILE_YEAR_LINE_SCALE = {
+	type: 'linear',
+	min: 'auto',
+	max: 'auto',
+} as const
 
-  if (chartType == "release") {
-    let lineData: any = {}
+function MyResponsiveLine(data: ProfileLineSeries[], mode: LineMode) {
+	const label =
+		mode === 'release'
+			? 'Release year distribution'
+			: 'Completion year distribution'
+	return (
+		<div className="user-landing-stats-chart-container user-landing-stats-line-chart">
+			<ResponsiveLine
+				colors={veudChartColors}
+				theme={veudNivoTheme}
+				data={data}
+				margin={{ top: 50, right: 110, bottom: 50, left: 60 }}
+				xScale={PROFILE_YEAR_LINE_SCALE}
+				yScale={{
+					type: 'linear',
+					min: 'auto',
+					max: 'auto',
+					stacked: false,
+					reverse: false,
+				}}
+				curve="monotoneX"
+				axisBottom={{
+					tickSize: 5,
+					tickPadding: 5,
+					tickRotation: 0,
+					legend: 'Year',
+					legendOffset: 36,
+					legendPosition: 'middle',
+					truncateTickAt: 0,
+				}}
+				axisLeft={{
+					tickSize: 5,
+					tickPadding: 5,
+					tickRotation: 0,
+					legend: 'Entries',
+					legendOffset: -40,
+					legendPosition: 'middle',
+					truncateTickAt: 0,
+				}}
+				enableGridX={false}
+				enableGridY={false}
+				pointSize={10}
+				pointColor={{ theme: 'background' }}
+				pointBorderWidth={2}
+				pointBorderColor={{ from: 'serieColor' }}
+				enablePointLabel
+				pointLabelYOffset={-12}
+				enableArea
+				enableTouchCrosshair
+				useMesh
+				tooltip={point => (
+					<div
+						style={{
+							background: 'black',
+							color: point.point.seriesColor,
+							padding: '9px 12px',
+							border: '1px solid #ccc',
+						}}
+					>
+						<div>{point.point.seriesId}</div>
+						<div>{`${point.point.data.x}: ${point.point.data.y}`}</div>
+					</div>
+				)}
+				legends={[
+					{
+						anchor: 'left',
+						direction: 'column',
+						justify: false,
+						translateX: 0,
+						translateY: 56,
+						itemsSpacing: 10,
+						itemWidth: 100,
+						itemHeight: 18,
+						itemTextColor: 'white',
+						itemDirection: 'left-to-right',
+						itemOpacity: 1,
+						symbolSize: 18,
+						symbolShape: 'square',
+						effects: [
+							{
+								on: 'hover',
+								style: { itemTextColor: '#66563d' },
+							},
+						],
+					},
+				]}
+				role="img"
+				ariaLabel={label}
+			/>
+			<ProfileChartDataTable
+				label={`${label} values`}
+				columns={['Media type', 'Year', 'Entries']}
+				rows={data.flatMap(series =>
+					series.data.map(point => ({
+						key: `${series.id}:${point.x}`,
+						cells: [series.id, point.x, point.y],
+					})),
+				)}
+			/>
+		</div>
+	)
+}
 
+export function buildProfileLineSeries(
+	data: Pick<ProfileShellData, 'listTypes'> &
+		Pick<ProfileAnalyticsResult, 'releaseYears' | 'completionYears'>,
+	chartType: LineMode,
+) {
+	const countsByType =
+		chartType === 'release' ? data.releaseYears : data.completionYears
+	return data.listTypes
+		.map((listType): ProfileLineSeries => ({
+			id: listType.header,
+			data: (countsByType[listType.id] ?? [])
+				.slice()
+				.sort((left, right) => left.year - right.year)
+				.map(({ year, count }) => ({
+					x: year,
+					y: count,
+				})),
+		}))
+		.filter(line => line.data.length > 0)
+}
 
-    Object.entries(loaderData.typedEntries).forEach(([key, value]: [string, any]) => {
-      const foundListType = loaderData.listTypes.find((listType: any) => listType.id == key)
+export function renderLineChart(
+	data: Pick<ProfileShellData, 'listTypes'> &
+		Pick<ProfileAnalyticsResult, 'releaseYears' | 'completionYears'>,
+	chartType: LineMode,
+) {
+	const lines = buildProfileLineSeries(data, chartType)
+	if (!lines.length) {
+		return (
+			<div
+				className="user-landing-stats-chart-container user-landing-stats-line-chart"
+				role="status"
+			>
+				No {chartType === 'release' ? 'release' : 'completion'} dates yet.
+			</div>
+		)
+	}
 
-      lineData = {
-        id: foundListType.header,
-        data: []
-      }
-
-      let entryData: any[] = []
-
-      value.forEach((typedEntry: any) => {
-        const entryYear = getStartYear(typedEntry, foundListType, loaderData.listTypes)
-        if (!entryYear) {
-          return
-        }
-
-        let yearMatch = [...entryYear.matchAll(/\d{4}/g)]
-        let matchResult
-
-        try {
-          matchResult = yearMatch[0][0]
-        } catch {}
-        
-        if (matchResult) {
-          const foundIndex = entryData.findIndex((element) => element.x == matchResult)
-        
-          if (foundIndex != -1) {
-            entryData[foundIndex].y++
-          }
-          else {
-            entryData.push ({
-              x: Number(matchResult),
-              y: 1
-            })
-          }
-        }
-      })
-
-      lineData.data = entryData.sort(function(a, b) {
-        var keyA = new Date(a.x),
-        keyB = new Date(b.x);
-
-        if (keyA < keyB) return -1;
-        if (keyA > keyB) return 1;
-        return 0;
-      })
-
-      typedLines.push(lineData)
-    })
-  }
-  else if (chartType == "watched") {
-    let lineData: any = {}
-
-
-    Object.entries(loaderData.typedEntries).forEach(([key, value]: [string, any]) => {
-      const foundListType = loaderData.listTypes.find((listType: any) => listType.id == key)
-
-      lineData = {
-        id: foundListType.header,
-        data: []
-      }
-
-      let entryData: any[] = []
-
-      value.forEach((typedEntry: any) => {
-        let parsedYear
-
-        try {
-          if (typedEntry.history.finished == null || typedEntry.history.finished == 0)
-            throw new Error
-
-          parsedYear = new Date (typedEntry.history.finished).getFullYear()
-
-          if (isNaN(parsedYear)) {
-            throw new Error
-          }
-        }
-        catch {
-          return
-        }
-
-        const foundIndex = entryData.findIndex((element) => element.x == parsedYear)
-        
-        if (foundIndex != -1) {
-          entryData[foundIndex].y++
-        }
-        else {
-          entryData.push ({
-            x: Number(parsedYear),
-            y: 1
-          })
-        }
-      })
-
-      lineData.data = entryData.sort(function(a, b) {
-        var keyA = new Date(a.x),
-        keyB = new Date(b.x);
-
-        if (keyA < keyB) return -1;
-        if (keyA > keyB) return 1;
-        return 0;
-      })
-
-      typedLines.push(lineData)
-    })
-  }
-
-  return (MyResponsiveLine(typedLines))
+	return MyResponsiveLine(lines, chartType)
 }
 
 export function LineChart({
-  data,
-  mode = 'release',
+	data,
+	mode = 'release',
 }: {
-  data: any
-  mode?: 'release' | 'watched'
+	data: Pick<ProfileShellData, 'listTypes'> &
+		Pick<ProfileAnalyticsResult, 'releaseYears' | 'completionYears'>
+	mode?: LineMode
 }) {
-  return renderLineChart(data, mode)
+	return renderLineChart(data, mode)
 }

--- a/app/routes/users+/$username_/stats_/pie.tsx
+++ b/app/routes/users+/$username_/stats_/pie.tsx
@@ -1,129 +1,161 @@
 import { ResponsivePie } from '@nivo/pie'
+import { ProfileChartDataTable } from '#app/routes/users+/$username_/stats_/visualization-boundary.tsx'
 import { veudChartColors, veudNivoTheme } from '#app/utils/nivo-theme.ts'
+import { type ProfileAnalyticsResult } from '#app/utils/profile-analytics.ts'
+import { type ProfileShellData } from '#app/utils/profile.ts'
 
-function MyResponsivePie(data: any, fill: any) {
-  return (
-    <div className="user-landing-stats-chart-container user-landing-stats-pie-chart">
-      <ResponsivePie
-        colors={veudChartColors}
-        theme={veudNivoTheme}
-        data={data}
-        margin={{ top: 40, right: 80, bottom: 80, left: 80 }}
-        sortByValue={true}
-        innerRadius={0.5}
-        padAngle={0.7}
-        cornerRadius={3}
-        activeOuterRadiusOffset={8}
-        borderWidth={1}
-        borderColor={{
-        from: 'color',
-        modifiers: [
-          [
-            'darker',
-            0.2
-          ]
-        ]
-        }}
-        arcLinkLabelsSkipAngle={10}
-        arcLinkLabelsTextColor="white"
-        arcLinkLabelsThickness={2}
-        arcLinkLabelsColor="white"
-        arcLabelsSkipAngle={10}
-        arcLabelsTextColor="black"
-        tooltip={(point) => {
-          //console.log(point.datum)
-          return (
-            <div
-              style={{
-                background: 'black',
-                color: point.datum.color,
-                padding: '9px 12px',
-                border: '1px solid #ccc',
-              }}
-            >
-              <div>{`${point.datum.label}: ${point.datum.formattedValue}`}</div>
-            </div>
-          )
-        }} 
-        defs={[
-          {
-            id: 'dots',
-            type: 'patternDots',
-            background: 'inherit',
-            color: 'rgba(255, 255, 255, 0.3)',
-            size: 4,
-            padding: 1,
-            stagger: true
-          },
-          {
-            id: 'lines',
-            type: 'patternLines',
-            background: 'inherit',
-            color: 'rgba(255, 255, 255, 0.3)',
-            rotation: -45,
-            lineWidth: 6,
-            spacing: 10
-          }
-        ]}
-        fill={fill}
-        motionConfig="default"
-        legends={[
-          {
-            anchor: 'left',
-            direction: 'column',
-            justify: false,
-            translateX: 0,
-            translateY: 56,
-            itemsSpacing: 10,
-            itemWidth: 100,
-            itemHeight: 18,
-            itemTextColor: 'white',
-            itemDirection: 'left-to-right',
-            itemOpacity: 1,
-            symbolSize: 18,
-            symbolShape: 'square',
-            effects: [
-              {
-                on: 'hover',
-                style: {
-                  itemTextColor: '#66563d'
-                }
-              }
-            ]
-          }
-        ]}
-      />
-    </div>
-  )
+type ProfilePieDatum = {
+	id: string
+	label: string
+	value: number
 }
 
-export function renderPieChart(loaderData: any) {
-  let pieData: any[] = [], fill: any[] = []
-  const fillTypes = ["none", "lines", "dots"]
-  let fillIndex = 0
-
-  Object.entries(loaderData.typedEntries).forEach(([key, value]: [string, any]) => {
-    const foundListType = loaderData.listTypes.find((listType: any) => listType.id == key)
-
-    pieData.push({
-        id: foundListType.header,
-        label: foundListType.header,
-        value: Object.entries(value).length
-    })
-
-    fill.push({
-        match: {
-        id: foundListType.header
-        },
-        id: fillTypes[fillIndex]
-    })
-
-    fillIndex = (fillIndex + 1) % (fillTypes.length);
-  })
-
-  return (MyResponsivePie(pieData, fill))
+type ProfilePieFill = {
+	match: { id: string }
+	id: 'lines' | 'dots'
 }
 
-export function PieChart({ data }: any) {
-  return renderPieChart(data)
+function MyResponsivePie(data: ProfilePieDatum[], fill: ProfilePieFill[]) {
+	return (
+		<div className="user-landing-stats-chart-container user-landing-stats-pie-chart">
+			<div
+				role="img"
+				aria-label="List type distribution"
+				style={{ width: '100%', height: '100%' }}
+			>
+				<ResponsivePie
+					colors={veudChartColors}
+					theme={veudNivoTheme}
+					data={data}
+					margin={{ top: 40, right: 80, bottom: 80, left: 80 }}
+					sortByValue
+					innerRadius={0.5}
+					padAngle={0.7}
+					cornerRadius={3}
+					activeOuterRadiusOffset={8}
+					borderWidth={1}
+					borderColor={{
+						from: 'color',
+						modifiers: [['darker', 0.2]],
+					}}
+					arcLinkLabelsSkipAngle={10}
+					arcLinkLabelsTextColor="white"
+					arcLinkLabelsThickness={2}
+					arcLinkLabelsColor="white"
+					arcLabelsSkipAngle={10}
+					arcLabelsTextColor="black"
+					tooltip={point => (
+						<div
+							style={{
+								background: 'black',
+								color: point.datum.color,
+								padding: '9px 12px',
+								border: '1px solid #ccc',
+							}}
+						>
+							<div>{`${point.datum.label}: ${point.datum.formattedValue}`}</div>
+						</div>
+					)}
+					defs={[
+						{
+							id: 'dots',
+							type: 'patternDots',
+							background: 'inherit',
+							color: 'rgba(255, 255, 255, 0.3)',
+							size: 4,
+							padding: 1,
+							stagger: true,
+						},
+						{
+							id: 'lines',
+							type: 'patternLines',
+							background: 'inherit',
+							color: 'rgba(255, 255, 255, 0.3)',
+							rotation: -45,
+							lineWidth: 6,
+							spacing: 10,
+						},
+					]}
+					fill={fill}
+					motionConfig="default"
+					legends={[
+						{
+							anchor: 'left',
+							direction: 'column',
+							justify: false,
+							translateX: 0,
+							translateY: 56,
+							itemsSpacing: 10,
+							itemWidth: 100,
+							itemHeight: 18,
+							itemTextColor: 'white',
+							itemDirection: 'left-to-right',
+							itemOpacity: 1,
+							symbolSize: 18,
+							symbolShape: 'square',
+							effects: [
+								{
+									on: 'hover',
+									style: { itemTextColor: '#66563d' },
+								},
+							],
+						},
+					]}
+				/>
+			</div>
+			<ProfileChartDataTable
+				label="List type distribution values"
+				columns={['List type', 'Titles']}
+				rows={data.map(datum => ({
+					key: datum.id,
+					cells: [datum.label, datum.value],
+				}))}
+			/>
+		</div>
+	)
+}
+
+export function renderPieChart(
+	data: Pick<ProfileShellData, 'listTypes'> &
+		Pick<ProfileAnalyticsResult, 'listTypeCounts'>,
+) {
+	const pieData: ProfilePieDatum[] = data.listTypes
+		.map(listType => ({
+			id: listType.header,
+			label: listType.header,
+			value: data.listTypeCounts[listType.id] ?? 0,
+		}))
+		.filter(datum => datum.value > 0)
+	const patterns: ProfilePieFill['id'][] = ['lines', 'dots']
+	const fill = pieData.flatMap<ProfilePieFill>((datum, index) => {
+		if (index % 3 === 0) return []
+		return [
+			{
+				match: { id: datum.id },
+				id: patterns[(index - 1) % patterns.length] ?? 'lines',
+			},
+		]
+	})
+
+	if (!pieData.length) {
+		return (
+			<div
+				className="user-landing-stats-chart-container user-landing-stats-pie-chart"
+				role="status"
+			>
+				No titles yet.
+			</div>
+		)
+	}
+
+	return MyResponsivePie(pieData, fill)
+}
+
+export function PieChart({
+	data,
+}: {
+	data: Pick<ProfileShellData, 'listTypes'> &
+		Pick<ProfileAnalyticsResult, 'listTypeCounts'>
+}) {
+	return renderPieChart(data)
 }

--- a/app/routes/users+/$username_/stats_/radial_bar.tsx
+++ b/app/routes/users+/$username_/stats_/radial_bar.tsx
@@ -1,114 +1,133 @@
 import { ResponsiveRadialBar } from '@nivo/radial-bar'
+import { ProfileChartDataTable } from '#app/routes/users+/$username_/stats_/visualization-boundary.tsx'
 import { veudChartColors, veudNivoTheme } from '#app/utils/nivo-theme.ts'
+import { type ProfileAnalyticsResult } from '#app/utils/profile-analytics.ts'
+import { type ProfileShellData } from '#app/utils/profile.ts'
 
-function MyResponsiveRadialBar(data: any)  {
-  return (
-    <div className="user-landing-stats-chart-container user-landing-stats-radial-bar-chart">
-      <ResponsiveRadialBar
-        colors={veudChartColors}
-        theme={veudNivoTheme}
-        data={data}
-        padding={0.4}
-        cornerRadius={2}
-        margin={{ top: 40, right: 120, bottom: 40, left: 40 }}
-        radialAxisStart={{ tickSize: 5, tickPadding: 5, tickRotation: 0 }}
-        circularAxisOuter={{ tickSize: 5, tickPadding: 12, tickRotation: 0 }}
-        enableLabels={true}
-        tooltip={(point) => {
-          // console.log(point.bar)
-          return (
-            <div
-              style={{
-                background: 'black',
-                color: point.bar.color,
-                padding: '9px 12px',
-                border: '1px solid #ccc',
-              }}
-            >
-              <div>{`${point.bar.groupId}`}</div>
-              <div>{`${point.bar.category}: ${point.bar.value}`}</div>
-            </div>
-          )
-        }} 
-        legends={[
-          {
-            anchor: 'left',
-            direction: 'column',
-            justify: false,
-            translateX: 0,
-            translateY: 56,
-            itemsSpacing: 10,
-            itemWidth: 100,
-            itemHeight: 18,
-            itemTextColor: 'white',
-            itemDirection: 'left-to-right',
-            itemOpacity: 1,
-            symbolSize: 18,
-            symbolShape: 'square',
-            effects: [
-              {
-                on: 'hover',
-                style: {
-                  itemTextColor: '#66563d'
-                }
-              }
-            ]
-          }
-        ]}
-      />
-    </div>
-  )
+type ProfileRadialSeries = {
+	id: string
+	data: Array<{ x: string; y: number }>
 }
 
-export function renderRadialBar(loaderData: any, chartType: string) {
-  let typedBars: any[] = []
-
-  if (chartType == "type") {
-    let barData: any = {}
-
-    Object.entries(loaderData.typedEntries).forEach(([key, value]: [string, any]) => {
-      const foundListType = loaderData.listTypes.find((listType: any) => listType.id == key)
-
-      barData = {
-        id: foundListType.header,
-        data: []
-      }
-
-      let entryData: any[] = []
-
-      value.forEach((typedEntry: any) => {
-        if (!typedEntry.type || typedEntry.type == "null")
-          return
-
-        const foundIndex = entryData.findIndex((element) => element.x == typedEntry.type)
-        
-        if (foundIndex != -1) {
-          entryData[foundIndex].y++
-        }
-        else {
-          entryData.push ({
-            x: typedEntry.type,
-            y: 1
-          })
-        }
-      })
-
-      barData.data = entryData.sort(function(a, b) {
-        var keyA = new Date(a.x),
-        keyB = new Date(b.x);
-
-        if (keyA < keyB) return -1;
-        if (keyA > keyB) return 1;
-        return 0;
-      })
-
-      typedBars.push(barData)
-    })
-  }
-
-  return (MyResponsiveRadialBar(typedBars))
+export function mediaTypeCategoryLabel(category: {
+	key: string
+	label: string
+	isRollup?: true
+}) {
+	return category.isRollup ? 'All other types' : category.label
 }
 
-export function RadialBarChart({ data }: any) {
-  return renderRadialBar(data, 'type')
+function MyResponsiveRadialBar(data: ProfileRadialSeries[]) {
+	return (
+		<div className="user-landing-stats-chart-container user-landing-stats-radial-bar-chart">
+			<ResponsiveRadialBar
+				colors={veudChartColors}
+				theme={veudNivoTheme}
+				data={data}
+				padding={0.4}
+				cornerRadius={2}
+				margin={{ top: 40, right: 120, bottom: 40, left: 40 }}
+				radialAxisStart={{ tickSize: 5, tickPadding: 5, tickRotation: 0 }}
+				circularAxisOuter={{
+					tickSize: 5,
+					tickPadding: 12,
+					tickRotation: 0,
+				}}
+				enableLabels
+				tooltip={point => (
+					<div
+						style={{
+							background: 'black',
+							color: point.bar.color,
+							padding: '9px 12px',
+							border: '1px solid #ccc',
+						}}
+					>
+						<div>{point.bar.groupId}</div>
+						<div>{`${point.bar.category}: ${point.bar.value}`}</div>
+					</div>
+				)}
+				legends={[
+					{
+						anchor: 'left',
+						direction: 'column',
+						justify: false,
+						translateX: 0,
+						translateY: 56,
+						itemsSpacing: 10,
+						itemWidth: 100,
+						itemHeight: 18,
+						itemTextColor: 'white',
+						itemDirection: 'left-to-right',
+						itemOpacity: 1,
+						symbolSize: 18,
+						symbolShape: 'square',
+						effects: [
+							{
+								on: 'hover',
+								style: { itemTextColor: '#66563d' },
+							},
+						],
+					},
+				]}
+				role="img"
+				ariaLabel="Media type distribution"
+			/>
+			<ProfileChartDataTable
+				label="Media type distribution values"
+				columns={['List type', 'Media type', 'Titles']}
+				rows={data.flatMap(series =>
+					series.data.map((datum, index) => ({
+						key: `${series.id}:${datum.x}:${index}`,
+						cells: [series.id, datum.x, datum.y],
+					})),
+				)}
+			/>
+		</div>
+	)
+}
+
+export function renderRadialBar(
+	data: Pick<ProfileShellData, 'listTypes'> &
+		Pick<ProfileAnalyticsResult, 'mediaTypeCounts'>,
+) {
+	const bars = data.listTypes
+		.map((listType): ProfileRadialSeries => ({
+			id: listType.header,
+			data: (data.mediaTypeCounts[listType.id] ?? []).map(category => ({
+				x: mediaTypeCategoryLabel(category),
+				y: category.count,
+			})),
+		}))
+		.filter(series => series.data.length > 0)
+
+	if (!bars.length) {
+		return (
+			<div
+				className="user-landing-stats-chart-container user-landing-stats-radial-bar-chart"
+				role="status"
+			>
+				No media type data yet.
+			</div>
+		)
+	}
+
+	return MyResponsiveRadialBar(bars)
+}
+
+export function renderRadialBarChart(
+	data: Pick<ProfileShellData, 'listTypes'> &
+		Pick<ProfileAnalyticsResult, 'mediaTypeCounts'>,
+	_chartType: 'type' = 'type',
+) {
+	return renderRadialBar(data)
+}
+
+export function RadialBarChart({
+	data,
+}: {
+	data: Pick<ProfileShellData, 'listTypes'> &
+		Pick<ProfileAnalyticsResult, 'mediaTypeCounts'>
+}) {
+	return renderRadialBarChart(data)
 }

--- a/app/routes/users+/$username_/stats_/visualization-boundary.tsx
+++ b/app/routes/users+/$username_/stats_/visualization-boundary.tsx
@@ -1,5 +1,52 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 
+export type ProfileChartDataRow = {
+	key: string
+	cells: readonly ReactNode[]
+}
+
+export function ProfileChartDataTable({
+	label,
+	columns,
+	rows,
+	emptyText = 'No values.',
+}: {
+	label: string
+	columns: readonly string[]
+	rows: readonly ProfileChartDataRow[]
+	emptyText?: string
+}) {
+	return (
+		<table className="sr-only">
+			<caption>{label}</caption>
+			<thead>
+				<tr>
+					{columns.map(column => (
+						<th key={column} scope="col">
+							{column}
+						</th>
+					))}
+				</tr>
+			</thead>
+			<tbody>
+				{rows.length ? (
+					rows.map(row => (
+						<tr key={row.key}>
+							{row.cells.map((cell, index) => (
+								<td key={`${row.key}:${columns[index] ?? index}`}>{cell}</td>
+							))}
+						</tr>
+					))
+				) : (
+					<tr>
+						<td colSpan={Math.max(1, columns.length)}>{emptyText}</td>
+					</tr>
+				)}
+			</tbody>
+		</table>
+	)
+}
+
 export class ProfileVisualizationBoundary extends Component<
 	{ children: ReactNode },
 	{ failed: boolean }

--- a/app/routes/users+/$username_/stats_/watchlist.tsx
+++ b/app/routes/users+/$username_/stats_/watchlist.tsx
@@ -1,35 +1,57 @@
 import { ResponsiveWaffle } from '@nivo/waffle'
+import { ProfileChartDataTable } from '#app/routes/users+/$username_/stats_/visualization-boundary.tsx'
 import { veudChartColors, veudNivoTheme } from '#app/utils/nivo-theme.ts'
+import {
+	compactProfileStatuses,
+	type ListTypeMeta,
+	type ProfileStatsData,
+} from '#app/utils/profile.ts'
 
-function MyResponsiveWaffle(data: any, waffleDimensions: any) {
+type WaffleDatum = {
+	id: string
+	label: string
+	value: number
+	total: number
+}
+
+type WatchlistStatus = {
+	key: string
+	label: string
+	count: number
+}
+
+export function aggregateWatchlistStatuses(
+	statuses: readonly WatchlistStatus[],
+) {
+	return compactProfileStatuses(statuses)
+}
+
+function MyResponsiveWaffle(data: WaffleDatum[], waffleSide: number) {
 	return (
 		<div className="user-landing-stats-waffle-chart">
-			<ResponsiveWaffle
+			<ResponsiveWaffle<WaffleDatum>
 				colors={veudChartColors}
 				theme={veudNivoTheme}
 				data={data}
 				total={100}
-				rows={waffleDimensions.x}
-				columns={waffleDimensions.y}
+				rows={waffleSide}
+				columns={waffleSide}
 				padding={1}
 				valueFormat=".2f"
 				margin={{ top: 10, right: 10, bottom: 10, left: 120 }}
-				tooltip={(point: any) => {
-					// console.log(point)
-					return (
-						<div
-							style={{
-								background: 'black',
-								color: point.data.color,
-								padding: '9px 12px',
-								border: '1px solid #ccc',
-							}}
-						>
-							<div>{`${point.data.label}: ${point.data.data.total}`}</div>
-							<center>{`(${point.data.formattedValue}%)`}</center>
-						</div>
-					)
-				}}
+				tooltip={point => (
+					<div
+						style={{
+							background: 'black',
+							color: point.data.color,
+							padding: '9px 12px',
+							border: '1px solid #ccc',
+						}}
+					>
+						<div>{`${point.data.label}: ${point.data.data.total}`}</div>
+						<div>{`${point.data.formattedValue}%`}</div>
+					</div>
+				)}
 				borderRadius={3}
 				borderColor={{
 					from: 'color',
@@ -61,6 +83,16 @@ function MyResponsiveWaffle(data: any, waffleDimensions: any) {
 						],
 					},
 				]}
+				role="img"
+				ariaLabel="Watchlist status distribution"
+			/>
+			<ProfileChartDataTable
+				label="Watchlist status distribution values"
+				columns={['Status', 'Titles', 'Percent']}
+				rows={data.map(status => ({
+					key: status.id,
+					cells: [status.label, status.total, `${status.value.toFixed(2)}%`],
+				}))}
 			/>
 		</div>
 	)
@@ -92,27 +124,31 @@ function progressUnitLabel(unit: string) {
 	return /s$/i.test(normalized) ? normalized : `${normalized}s`
 }
 
-export function watchlistOverview(loaderData: any, listType: any) {
-	const summary = loaderData.trackingSummaries?.[listType.id] ?? {
+export function watchlistOverview(
+	loaderData: Pick<ProfileStatsData, 'trackingSummaries'>,
+	listType: ListTypeMeta | undefined,
+) {
+	if (!listType) {
+		return (
+			<div
+				className="user-landing-stats-chart-container user-landing-stats-waffle-chart-container"
+				role="status"
+			>
+				No watchlist data yet.
+			</div>
+		)
+	}
+
+	const summary = loaderData.trackingSummaries[listType.id] ?? {
 		totalTitles: 0,
 		meanScore: null,
+		repeatCount: 0,
 		progress: [],
 		statuses: [],
 	}
-	const totalTitles = Number.isFinite(summary.totalTitles)
-		? Math.max(0, summary.totalTitles)
-		: 0
-	const statuses = Array.isArray(summary.statuses)
-		? summary.statuses.filter(
-				(status: any) =>
-					status &&
-					typeof status.key === 'string' &&
-					typeof status.label === 'string' &&
-					Number.isFinite(status.count) &&
-					status.count > 0,
-			)
-		: []
-	const waffleData = statuses.map((status: any) => ({
+	const totalTitles = Math.max(0, summary.totalTitles)
+	const statuses = aggregateWatchlistStatuses(summary.statuses)
+	const waffleData: WaffleDatum[] = statuses.map(status => ({
 		id: status.key,
 		label: status.label,
 		value: totalTitles ? (status.count / totalTitles) * 100 : 0,
@@ -120,26 +156,15 @@ export function watchlistOverview(loaderData: any, listType: any) {
 	}))
 	const smallestPercentage = Math.min(
 		100,
-		...waffleData.map((status: any) => status.value),
+		...waffleData.map(status => status.value),
 	)
 	const waffleSide = Math.min(
 		20,
 		Math.max(10, Math.ceil(Math.sqrt(100 / smallestPercentage))),
 	)
-	const meanScore =
-		typeof summary.meanScore === 'number' && Number.isFinite(summary.meanScore)
-			? summary.meanScore.toFixed(2)
-			: 'N/A'
+	const meanScore = summary.meanScore?.toFixed(2) ?? 'N/A'
 	const completed = completionLabel(listType.completionType)
-	const progress = Array.isArray(summary.progress)
-		? summary.progress.filter(
-				(item: any) =>
-					item &&
-					typeof item.unit === 'string' &&
-					Number.isFinite(item.current) &&
-					item.current > 0,
-			)
-		: []
+	const progress = summary.progress.filter(item => item.current > 0)
 
 	return (
 		<div className="user-landing-stats-chart-container user-landing-stats-waffle-chart-container">
@@ -150,7 +175,7 @@ export function watchlistOverview(loaderData: any, listType: any) {
 				<div className="user-landing-stats-waffle-chart-text-right">
 					{`Mean Score: ${meanScore}`}
 					<div>
-						{progress.map((item: any) => (
+						{progress.map(item => (
 							<div key={item.unit}>
 								<span>
 									{`${item.current} ${progressUnitLabel(item.unit)} ${completed}`}
@@ -160,14 +185,23 @@ export function watchlistOverview(loaderData: any, listType: any) {
 					</div>
 				</div>
 			</div>
-			{MyResponsiveWaffle(waffleData, {
-				x: waffleSide,
-				y: waffleSide,
-			})}
+			{waffleData.length ? (
+				MyResponsiveWaffle(waffleData, waffleSide)
+			) : (
+				<div className="user-landing-stats-waffle-chart" role="status">
+					No status data yet.
+				</div>
+			)}
 		</div>
 	)
 }
 
-export function WatchlistChart({ data, listType }: any) {
+export function WatchlistChart({
+	data,
+	listType,
+}: {
+	data: Pick<ProfileStatsData, 'trackingSummaries'>
+	listType?: ListTypeMeta
+}) {
 	return watchlistOverview(data, listType)
 }

--- a/app/routes/users+/profile-performance.route.test.ts
+++ b/app/routes/users+/profile-performance.route.test.ts
@@ -1,12 +1,76 @@
 import { faker } from '@faker-js/faker'
 import { expect, test } from 'vitest'
+import { loader as activityLoader } from '#app/routes/users+/$username.activity.tsx'
+import { loader as favoritesLoader } from '#app/routes/users+/$username.favorites.tsx'
 import { loader as overviewLoader } from '#app/routes/users+/$username.index.tsx'
+import { loader as statsLoader } from '#app/routes/users+/$username.stats.tsx'
 import {
 	loader as profileLoader,
 	shouldRevalidate,
 } from '#app/routes/users+/$username.tsx'
+import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import { BASE_URL } from '#tests/utils.ts'
+import {
+	PROFILE_ACTIVITY_ACTION_LENGTH_LIMIT,
+	PROFILE_ACTIVITY_RESPONSE_BYTE_LIMIT,
+	PROFILE_ACTIVITY_TITLE_LENGTH_LIMIT,
+} from '#app/utils/profile-activity.ts'
+import { PROFILE_ANALYTICS_ENTRY_LIMIT } from '#app/utils/profile-analytics.ts'
+import {
+	PROFILE_CATEGORY_CANDIDATE_CODE_UNIT_LIMIT,
+	PROFILE_CATEGORY_CANDIDATE_RAW_CODE_UNIT_LIMIT,
+	PROFILE_CATEGORY_EXACT_CODE_UNIT_LIMIT,
+	PROFILE_CATEGORY_EXACT_RAW_CODE_UNIT_LIMIT,
+	PROFILE_CATEGORY_GENRES_CODE_UNIT_LIMIT,
+	PROFILE_CATEGORY_RAW_REQUEST_CODE_UNIT_LIMIT,
+	PROFILE_CATEGORY_REQUEST_CODE_UNIT_LIMIT,
+	PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT,
+} from '#app/utils/profile-data.server.ts'
+import { BASE_URL, getSessionCookieHeader } from '#tests/utils.ts'
+
+test('profile category projections share one fixed and fair request budget', () => {
+	const semanticCodeUnitsPerPass =
+		(PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT +
+			PROFILE_CATEGORY_GENRES_CODE_UNIT_LIMIT) *
+		PROFILE_ANALYTICS_ENTRY_LIMIT
+	const rawCodeUnitsPerPass =
+		2 *
+		(PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT +
+			1 +
+			PROFILE_CATEGORY_GENRES_CODE_UNIT_LIMIT +
+			1) *
+		PROFILE_ANALYTICS_ENTRY_LIMIT
+
+	expect(PROFILE_CATEGORY_REQUEST_CODE_UNIT_LIMIT).toBe(48 * 1024 * 1024)
+	expect(PROFILE_CATEGORY_CANDIDATE_CODE_UNIT_LIMIT).toBe(
+		PROFILE_CATEGORY_EXACT_CODE_UNIT_LIMIT,
+	)
+	expect(
+		PROFILE_CATEGORY_CANDIDATE_CODE_UNIT_LIMIT +
+			PROFILE_CATEGORY_EXACT_CODE_UNIT_LIMIT,
+	).toBe(PROFILE_CATEGORY_REQUEST_CODE_UNIT_LIMIT)
+	expect(PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT).toBe(64)
+	expect(PROFILE_CATEGORY_GENRES_CODE_UNIT_LIMIT).toBe(
+		Math.floor(
+			PROFILE_CATEGORY_CANDIDATE_CODE_UNIT_LIMIT /
+				PROFILE_ANALYTICS_ENTRY_LIMIT,
+		) - PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT,
+	)
+	expect(PROFILE_CATEGORY_GENRES_CODE_UNIT_LIMIT).toBe(187)
+	expect(semanticCodeUnitsPerPass).toBeLessThanOrEqual(
+		PROFILE_CATEGORY_CANDIDATE_CODE_UNIT_LIMIT,
+	)
+	expect(semanticCodeUnitsPerPass * 2).toBeLessThanOrEqual(
+		PROFILE_CATEGORY_REQUEST_CODE_UNIT_LIMIT,
+	)
+	expect(PROFILE_CATEGORY_CANDIDATE_RAW_CODE_UNIT_LIMIT).toBe(
+		rawCodeUnitsPerPass,
+	)
+	expect(PROFILE_CATEGORY_EXACT_RAW_CODE_UNIT_LIMIT).toBe(rawCodeUnitsPerPass)
+	expect(PROFILE_CATEGORY_RAW_REQUEST_CODE_UNIT_LIMIT).toBe(
+		rawCodeUnitsPerPass * 2,
+	)
+})
 
 test('profile tab navigation keeps the stable shell without blocking explicit refreshes', () => {
 	const base = {
@@ -32,7 +96,7 @@ test('profile tab navigation keeps the stable shell without blocking explicit re
 	).toBe(true)
 })
 
-test('profile shell and analytics stay within representative payload budgets', async () => {
+test('profile shell and analytics stay compact as a library grows', async () => {
 	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
 	const user = await prisma.user.create({
 		data: {
@@ -64,50 +128,622 @@ test('profile shell and analytics stay within representative payload budgets', a
 		},
 	})
 	const omittedSentinel = `OMITTED_${suffix}`
-	const entries = Array.from({ length: 500 }, (_, index) => ({
-		watchlistId: watchlist.id,
-		position: index + 1,
-		title: `Representative title ${index + 1}`,
-		type: 'TV',
-		length: `${(index % 24) + 1} / 24 eps`,
-		personal: (index % 10) + 1,
-		history: JSON.stringify({
-			added: Date.UTC(2025, 0, 1) + index,
-			lastUpdated: Date.UTC(2025, 0, 1) + index,
-		}),
-		description: `${omittedSentinel}:${'description '.repeat(180)}`,
-		notes: `${omittedSentinel}:${'private note '.repeat(120)}`,
-	}))
-	for (let index = 0; index < entries.length; index += 100) {
-		await prisma.entry.createMany({ data: entries.slice(index, index + 100) })
+	const entries = Array.from({ length: 5_000 }, (_, index) => {
+		// Seed the newest 1,000 completion days first, then older history. This
+		// proves the bounded payload is stable while still exercising eviction.
+		const completionDay = index < 1_000 ? index + 4_000 : index - 1_000
+		return {
+			watchlistId: watchlist.id,
+			position: index + 1,
+			title: `Representative title ${index + 1}`,
+			type: 'TV',
+			length: `${(index % 24) + 1} / 24 eps`,
+			personal: (index % 10) + 1,
+			history: JSON.stringify({
+				added: Date.UTC(2025, 0, 1) + index,
+				lastUpdated: Date.UTC(2025, 0, 1) + index,
+				finished: Date.UTC(2012, 9, 1) + completionDay * 86_400_000,
+			}),
+			description: `${omittedSentinel}:${'description '.repeat(180)}`,
+			notes: `${omittedSentinel}:${'private note '.repeat(120)}`,
+		}
+	})
+	async function insertEntries(from: number, to: number) {
+		for (let index = from; index < to; index += 100) {
+			await prisma.entry.createMany({
+				data: entries.slice(index, Math.min(index + 100, to)),
+			})
+		}
 	}
 
 	const args = {
 		request: new Request(`${BASE_URL}/users/${user.username}`),
 		params: { username: user.username },
 	} as any
-	const [shellResult, overviewResult] = await Promise.all([
+	await insertEntries(0, 1_000)
+	const [shellResult, smallOverviewResult] = await Promise.all([
 		profileLoader(args),
 		overviewLoader(args),
 	])
+	await insertEntries(1_000, entries.length)
+	const [overviewResult, statsResult] = await Promise.all([
+		overviewLoader(args),
+		statsLoader(args),
+	])
 	const shellPayload = JSON.stringify(shellResult.data)
-	const analyticsPayload = JSON.stringify(overviewResult.data)
-	const analyticsRoundTrip = JSON.parse(analyticsPayload) as {
-		typedEntries: Record<string, Array<{ personal: unknown }>>
+	const smallOverviewPayload = JSON.stringify(smallOverviewResult.data)
+	const overviewPayload = JSON.stringify(overviewResult.data)
+	const statsPayload = JSON.stringify(statsResult.data)
+	const overviewRoundTrip = JSON.parse(overviewPayload) as {
+		trackingSummaries: Record<string, { totalTitles: number }>
+		diagnostic: { processed: number; truncated: boolean }
 	}
-	const firstAnalyticsEntry = Object.values(analyticsRoundTrip.typedEntries)
-		.flat()
-		.at(0)
+	const statsRoundTrip = JSON.parse(statsPayload) as {
+		scoreBuckets: Record<string, { personal: number[] }>
+		diagnostic: { processed: number; truncated: boolean }
+	}
 
 	expect(Buffer.byteLength(shellPayload)).toBeLessThan(32 * 1024)
-	expect(Buffer.byteLength(analyticsPayload)).toBeLessThan(512 * 1024)
+	expect(Buffer.byteLength(overviewPayload)).toBeLessThan(64 * 1024)
+	expect(Buffer.byteLength(statsPayload)).toBeLessThan(128 * 1024)
+	expect(
+		Math.abs(
+			Buffer.byteLength(overviewPayload) -
+				Buffer.byteLength(smallOverviewPayload),
+		),
+	).toBeLessThan(2 * 1024)
 	expect(shellPayload).not.toContain('typedEntries')
-	expect(analyticsPayload).not.toContain(omittedSentinel)
-	expect(typeof firstAnalyticsEntry?.personal).toBe('number')
+	expect(overviewPayload).not.toContain('typedEntries')
+	expect(statsPayload).not.toContain('typedEntries')
+	expect(overviewPayload).not.toContain(omittedSentinel)
+	expect(statsPayload).not.toContain(omittedSentinel)
+	expect(overviewPayload).not.toContain('Representative title')
+	expect(statsPayload).not.toContain('Representative title')
+	expect(overviewRoundTrip.trackingSummaries[listType.id]?.totalTitles).toBe(
+		5_000,
+	)
+	expect(overviewRoundTrip.diagnostic).toMatchObject({
+		processed: 5_000,
+		truncated: false,
+		limit: 100_000,
+		completionDaysTruncated: true,
+	})
+	expect(statsRoundTrip.diagnostic).toMatchObject({
+		processed: 5_000,
+		truncated: false,
+		limit: 100_000,
+	})
+	expect(statsRoundTrip.scoreBuckets[listType.id]?.personal).toEqual(
+		Array.from({ length: 10 }, () => 500),
+	)
 	expect(new Headers(shellResult.init?.headers).get('Server-Timing')).toContain(
 		'profile_shell',
 	)
 	expect(
 		new Headers(overviewResult.init?.headers).get('Server-Timing'),
 	).toContain('profile_overview')
+})
+
+test('profile text projection and activity stay byte-bounded for hostile legacy rows', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const user = await prisma.user.create({
+		data: {
+			email: `profile-bytes-${suffix}@example.com`,
+			username: `profile_bytes_${suffix}`,
+		},
+	})
+	const listType = await prisma.listType.create({
+		data: {
+			name: `profile-bytes-${suffix}`,
+			header: 'Profile byte bounds',
+			columns: '{"title":"string"}',
+			mediaType: '["episode"]',
+			completionType: '{"past":"watched"}',
+		},
+	})
+	const watchlist = await prisma.watchlist.create({
+		data: {
+			ownerId: user.id,
+			typeId: listType.id,
+			name: 'watching',
+			header: 'Watching',
+			position: 1,
+			isPublic: true,
+		},
+	})
+	await prisma.entry.createMany({
+		data: [
+			{
+				watchlistId: watchlist.id,
+				position: 1,
+				title: 'T'.repeat(300_000),
+				thumbnail: `https://example.com/${'x'.repeat(4_000)}`,
+				type: 'Y'.repeat(1_000),
+				genres: 'Genre,'.repeat(10_000),
+				history: JSON.stringify({
+					['A'.repeat(20_000)]: Date.UTC(2026, 0, 1),
+				}),
+			},
+			{
+				watchlistId: watchlist.id,
+				position: 2,
+				title: 'Oversized history',
+				history: JSON.stringify({ note: 'z'.repeat(200_000) }),
+			},
+		],
+	})
+	const session = await prisma.session.create({
+		data: { userId: user.id, expirationDate: getSessionExpirationDate() },
+	})
+	const args = {
+		request: new Request(`${BASE_URL}/users/${user.username}`, {
+			headers: { cookie: await getSessionCookieHeader(session) },
+		}),
+		params: { username: user.username },
+	} as any
+
+	const [overviewResult, statsResult, activityResult] = await Promise.all([
+		overviewLoader(args),
+		statsLoader(args),
+		activityLoader(args),
+	])
+	const overviewPayload = JSON.stringify(overviewResult.data)
+	const statsPayload = JSON.stringify(statsResult.data)
+	const activityPayload = JSON.stringify(activityResult.data)
+
+	expect(Buffer.byteLength(overviewPayload)).toBeLessThan(64 * 1024)
+	expect(Buffer.byteLength(statsPayload)).toBeLessThan(128 * 1024)
+	expect(Buffer.byteLength(activityPayload)).toBeLessThan(64 * 1024)
+	expect(overviewResult.data.diagnostic.historyEntriesRejected).toBeGreaterThan(
+		0,
+	)
+	expect(statsResult.data.diagnostic.categoryCandidatesTruncated).toBe(true)
+	expect(activityResult.data.activityLimited).toBe(true)
+	expect(activityResult.data.activityEvents[0]?.action.length).toBeLessThan(512)
+	expect(
+		activityResult.data.activityEvents[0]?.media.title.length,
+	).toBeLessThan(512)
+	expect(activityResult.data.activityEvents[0]?.media.thumbnail).toBeNull()
+})
+
+test('emoji-heavy profile text stays within UTF-16 projection ceilings', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const user = await prisma.user.create({
+		data: {
+			email: `profile-emoji-${suffix}@example.com`,
+			username: `profile_emoji_${suffix}`,
+		},
+	})
+	const listType = await prisma.listType.create({
+		data: {
+			name: `profile-emoji-${suffix}`,
+			header: 'Emoji profile bounds',
+			columns: '{"title":"string"}',
+			mediaType: '["episode"]',
+			completionType: '{"past":"watched"}',
+		},
+	})
+	const watchlist = await prisma.watchlist.create({
+		data: {
+			ownerId: user.id,
+			typeId: listType.id,
+			name: 'watching',
+			header: 'Watching',
+			position: 1,
+		},
+	})
+	const omittedSentinel = `EMOJI_OMITTED_${suffix}`
+	const media = await prisma.media.create({
+		data: {
+			kind: 'anime',
+			title: `${'😀'.repeat(200)}${omittedSentinel}`,
+		},
+	})
+	const state = await prisma.trackingState.create({
+		data: {
+			ownerId: user.id,
+			mediaId: media.id,
+			status: `${'😀'.repeat(200_000)}${omittedSentinel}`,
+			statusWatchlistId: watchlist.id,
+		},
+	})
+	await Promise.all([
+		prisma.entry.create({
+			data: {
+				watchlistId: watchlist.id,
+				mediaId: media.id,
+				trackingStateId: state.id,
+				position: 1,
+				title: media.title!,
+				type: '😀'.repeat(200),
+				genres: '😀'.repeat(5_000),
+				history: JSON.stringify({
+					finished: Date.UTC(2026, 0, 1),
+					note: `${'😀'.repeat(70_000)}${omittedSentinel}`,
+				}),
+			},
+		}),
+		prisma.activityEvent.create({
+			data: {
+				type: 'status',
+				status: '😀'.repeat(100),
+				actorId: user.id,
+				mediaId: media.id,
+				publicEligible: true,
+			},
+		}),
+	])
+	const args = {
+		request: new Request(`${BASE_URL}/users/${user.username}`),
+		params: { username: user.username },
+	} as any
+
+	const [overviewResult, statsResult, activityResult] = await Promise.all([
+		overviewLoader(args),
+		statsLoader(args),
+		activityLoader(args),
+	])
+	const payload = JSON.stringify({
+		overview: overviewResult.data,
+		stats: statsResult.data,
+		activity: activityResult.data,
+	})
+	const activityTitle = activityResult.data.activityEvents[0]?.media.title ?? ''
+
+	expect(overviewResult.data.diagnostic.historyEntriesRejected).toBe(1)
+	expect(statsResult.data.diagnostic.categoryCandidatesTruncated).toBe(true)
+	expect(activityResult.data.activityLimited).toBe(true)
+	expect(activityTitle.length).toBeLessThanOrEqual(241)
+	expect(activityTitle).not.toContain('\uFFFD')
+	expect(payload).not.toContain(omittedSentinel)
+	expect(Buffer.byteLength(payload)).toBeLessThan(256 * 1024)
+})
+
+test('hostile early category values do not starve a later page', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const user = await prisma.user.create({
+		data: {
+			email: `profile-category-fairness-${suffix}@example.com`,
+			username: `profile_category_fairness_${suffix}`,
+		},
+	})
+	const listType = await prisma.listType.create({
+		data: {
+			name: `profile-category-fairness-${suffix}`,
+			header: 'Category projection fairness',
+			columns: '{"title":"string"}',
+			mediaType: '["episode"]',
+			completionType: '{"past":"watched"}',
+		},
+	})
+	const watchlist = await prisma.watchlist.create({
+		data: {
+			ownerId: user.id,
+			typeId: listType.id,
+			name: 'watching',
+			header: 'Watching',
+			position: 1,
+		},
+	})
+	const hostileEntries = Array.from({ length: 500 }, (_, index) => ({
+		id: `category-fair-${suffix}-${String(index).padStart(4, '0')}`,
+		watchlistId: watchlist.id,
+		position: index + 1,
+		title: `Hostile category ${index + 1}`,
+		type: '😀'.repeat(100),
+		genres: 'Hostile Genre,'.repeat(100),
+	}))
+	for (let index = 0; index < hostileEntries.length; index += 100) {
+		await prisma.entry.createMany({
+			data: hostileEntries.slice(index, index + 100),
+		})
+	}
+	await prisma.entry.create({
+		data: {
+			id: `category-fair-${suffix}-9999-tail`,
+			watchlistId: watchlist.id,
+			position: hostileEntries.length + 1,
+			title: 'Tail category',
+			type: 'Tail Type',
+			genres: 'Tail Fairness',
+		},
+	})
+
+	const result = await statsLoader({
+		request: new Request(`${BASE_URL}/users/${user.username}`),
+		params: { username: user.username },
+	} as any)
+
+	expect(result.data.diagnostic).toMatchObject({
+		processed: 501,
+		truncated: false,
+		categoryCandidatesTruncated: true,
+	})
+	expect(result.data.mediaTypeCounts[listType.id]).toContainEqual({
+		key: 'tail type',
+		label: 'Tail Type',
+		count: 1,
+	})
+	expect(result.data.genreMatrices[listType.id]?.labels).toContain(
+		'Tail Fairness',
+	)
+})
+
+test('BMP profile titles retain half, half-plus-one, and full-limit values', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const user = await prisma.user.create({
+		data: {
+			email: `profile-bmp-${suffix}@example.com`,
+			username: `profile_bmp_${suffix}`,
+		},
+	})
+	const titles = ['A'.repeat(120), 'B'.repeat(121), 'C'.repeat(240)]
+	const media = await Promise.all(
+		titles.map(title =>
+			prisma.media.create({ data: { kind: 'movie', title } }),
+		),
+	)
+	await prisma.activityEvent.createMany({
+		data: media.map((item, index) => ({
+			type: 'status',
+			status: 'planned',
+			actorId: user.id,
+			mediaId: item.id,
+			publicEligible: true,
+			createdAt: new Date(Date.UTC(2026, 6, 28, 0, index)),
+		})),
+	})
+
+	const result = await activityLoader({
+		request: new Request(`${BASE_URL}/users/${user.username}`),
+		params: { username: user.username },
+	} as any)
+
+	expect(
+		[...result.data.activityEvents]
+			.map(event => event.media.title)
+			.sort((left, right) => left.length - right.length),
+	).toEqual(titles)
+	expect(result.data.activityLimited).toBe(false)
+})
+
+test('normalized activity, review, diary, and media text stay bounded before serialization', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const user = await prisma.user.create({
+		data: {
+			email: `profile-normalized-${suffix}@example.com`,
+			username: `profile_normalized_${suffix}`,
+		},
+	})
+	const listType = await prisma.listType.create({
+		data: {
+			name: `profile-normalized-${suffix}`,
+			header: 'Normalized profile text',
+			columns: '{"title":"string"}',
+			mediaType: '["movie"]',
+			completionType: '{"past":"watched"}',
+		},
+	})
+	const watchlist = await prisma.watchlist.create({
+		data: {
+			ownerId: user.id,
+			typeId: listType.id,
+			name: 'watching',
+			header: 'Watching',
+			position: 1,
+			isPublic: true,
+		},
+	})
+	const omittedSentinel = `NORMALIZED_OMITTED_${suffix}`
+	const hostileText = (prefix: string) =>
+		`${prefix}${'x'.repeat(5_000)}${omittedSentinel}`
+	const [trackingMedia, reviewMedia, diaryMedia] = await Promise.all(
+		['tracking', 'review', 'diary'].map(source =>
+			prisma.media.create({
+				data: {
+					kind: 'movie',
+					title: hostileText(`${source} title `),
+					thumbnail: hostileText(`https://example.com/${source}/`),
+				},
+			}),
+		),
+	)
+	const [unknownEvent, statusEvent, progressEvent, review, diary] =
+		await Promise.all([
+			prisma.activityEvent.create({
+				data: {
+					type: hostileText('unknown event '),
+					actorId: user.id,
+					mediaId: trackingMedia!.id,
+					publicEligible: true,
+					createdAt: new Date('2026-07-28T12:05:00.000Z'),
+				},
+			}),
+			prisma.activityEvent.create({
+				data: {
+					type: 'status',
+					status: hostileText('watching '),
+					statusLabel: hostileText('Watching '),
+					previousStatus: hostileText('planned '),
+					previousStatusLabel: hostileText('Planned '),
+					statusWatchlistId: watchlist.id,
+					previousStatusWatchlistId: watchlist.id,
+					actorId: user.id,
+					mediaId: trackingMedia!.id,
+					publicEligible: true,
+					createdAt: new Date('2026-07-28T12:04:00.000Z'),
+				},
+			}),
+			prisma.activityEvent.create({
+				data: {
+					type: 'progress',
+					progressUnit: hostileText('episode '),
+					progressCurrent: 2,
+					progressPrevious: 1,
+					progressTotal: 12,
+					actorId: user.id,
+					mediaId: trackingMedia!.id,
+					publicEligible: true,
+					createdAt: new Date('2026-07-28T12:03:00.000Z'),
+				},
+			}),
+			prisma.review.create({
+				data: {
+					authorId: user.id,
+					mediaId: reviewMedia!.id,
+					body: hostileText('review body '),
+					createdAt: new Date('2026-07-28T12:02:00.000Z'),
+				},
+			}),
+			prisma.diaryEntry.create({
+				data: {
+					ownerId: user.id,
+					mediaId: diaryMedia!.id,
+					loggedOn: new Date('2026-07-27T00:00:00.000Z'),
+					createdAt: new Date('2026-07-28T12:01:00.000Z'),
+				},
+			}),
+		])
+
+	const result = await activityLoader({
+		request: new Request(`${BASE_URL}/users/${user.username}`),
+		params: { username: user.username },
+	} as any)
+	const payload = JSON.stringify(result.data)
+	const eventIds = result.data.activityEvents.map(event => event.id)
+
+	expect(Buffer.byteLength(payload)).toBeLessThan(
+		PROFILE_ACTIVITY_RESPONSE_BYTE_LIMIT,
+	)
+	expect(result.data.activityLimited).toBe(true)
+	expect(eventIds).toEqual(
+		expect.arrayContaining([
+			`tracking:${unknownEvent.id}`,
+			`tracking:${statusEvent.id}`,
+			`tracking:${progressEvent.id}`,
+			`review:${review.id}`,
+			`diary:${diary.id}`,
+		]),
+	)
+	expect(payload).not.toContain(omittedSentinel)
+	for (const event of result.data.activityEvents) {
+		expect(event.action.length).toBeLessThanOrEqual(
+			PROFILE_ACTIVITY_ACTION_LENGTH_LIMIT,
+		)
+		expect(event.media.title.length).toBeLessThanOrEqual(
+			PROFILE_ACTIVITY_TITLE_LENGTH_LIMIT,
+		)
+		expect(event.media.thumbnail).toBeNull()
+	}
+})
+
+test('profile favorites enforce a fixed row cap and bound hostile display text', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const user = await prisma.user.create({
+		data: {
+			email: `profile-favorites-${suffix}@example.com`,
+			username: `profile_favorites_${suffix}`,
+		},
+	})
+	const listType = await prisma.listType.create({
+		data: {
+			name: `profile-favorites-${suffix}`,
+			header: 'Favorite profile fixtures',
+			columns: '{"title":"string"}',
+			mediaType: '["movie"]',
+			completionType: '{"past":"watched"}',
+		},
+	})
+	const omittedSentinel = `FAVORITE_OMITTED_${suffix}`
+	const hostileTail = `${'f'.repeat(5_000)}${omittedSentinel}`
+	await prisma.userFavorite.createMany({
+		data: Array.from({ length: 301 }, (_, index) => ({
+			ownerId: user.id,
+			typeId: listType.id,
+			position: index + 1,
+			title:
+				index === 0 ? `Hostile favorite ${hostileTail}` : `Favorite ${index}`,
+			thumbnail: index === 0 ? `https://example.com/${hostileTail}` : null,
+			mediaType: index === 0 ? `Movie ${hostileTail}` : 'Movie',
+			startYear: index === 0 ? `2026 ${hostileTail}` : '2026',
+		})),
+	})
+
+	const result = await favoritesLoader({
+		request: new Request(`${BASE_URL}/users/${user.username}/favorites`),
+		params: { username: user.username },
+	} as any)
+	const payload = JSON.stringify(result.data)
+	const hostileFavorite = result.data.favorites.find(
+		favorite => favorite.position === 1,
+	)
+
+	expect(result.data.favorites).toHaveLength(300)
+	expect(result.data.favoritesLimited).toBe(true)
+	expect(Buffer.byteLength(payload)).toBeLessThan(64 * 1024)
+	expect(payload).not.toContain(omittedSentinel)
+	expect(hostileFavorite).toMatchObject({ thumbnail: null })
+	expect(hostileFavorite?.title.length).toBeLessThanOrEqual(241)
+	expect(hostileFavorite?.mediaType.length).toBeLessThanOrEqual(120)
+	expect(hostileFavorite?.startYear.length).toBeLessThanOrEqual(64)
+})
+
+test('profile history projection enforces an aggregate transfer budget', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const user = await prisma.user.create({
+		data: {
+			email: `profile-history-budget-${suffix}@example.com`,
+			username: `profile_history_budget_${suffix}`,
+		},
+	})
+	const listType = await prisma.listType.create({
+		data: {
+			name: `profile-history-budget-${suffix}`,
+			header: 'History projection budget',
+			columns: '{"title":"string"}',
+			mediaType: '["movie"]',
+			completionType: '{"past":"watched"}',
+		},
+	})
+	const watchlist = await prisma.watchlist.create({
+		data: {
+			ownerId: user.id,
+			typeId: listType.id,
+			name: 'watching',
+			header: 'Watching',
+			position: 1,
+		},
+	})
+	const omittedSentinel = `HISTORY_BUDGET_OMITTED_${suffix}`
+	// Every row is below the per-entry parser ceiling, while their combined
+	// 24 MiB source would exceed the request-level 16 MiB projection budget.
+	const history = JSON.stringify({
+		finished: Date.UTC(2026, 0, 1),
+		note: `${'h'.repeat(40_000)}${omittedSentinel}`,
+	})
+	const entries = Array.from({ length: 600 }, (_, index) => ({
+		watchlistId: watchlist.id,
+		position: index + 1,
+		title: `Budgeted history ${index + 1}`,
+		history,
+	}))
+	for (let index = 0; index < entries.length; index += 50) {
+		await prisma.entry.createMany({ data: entries.slice(index, index + 50) })
+	}
+
+	const result = await overviewLoader({
+		request: new Request(`${BASE_URL}/users/${user.username}`),
+		params: { username: user.username },
+	} as any)
+	const payload = JSON.stringify(result.data)
+
+	expect(result.data.diagnostic).toMatchObject({
+		processed: 600,
+		truncated: false,
+		historyEntriesRejected: 600,
+	})
+	expect(result.data.trackingSummaries[listType.id]?.totalTitles).toBe(600)
+	expect(result.data.completionHistory.days).toEqual([])
+	expect(Buffer.byteLength(payload)).toBeLessThan(64 * 1024)
+	expect(payload).not.toContain(omittedSentinel)
 })

--- a/app/routes/users+/profile-tracking.route.test.ts
+++ b/app/routes/users+/profile-tracking.route.test.ts
@@ -4,6 +4,7 @@ import { loader as activityLoader } from '#app/routes/users+/$username.activity.
 import { loader as diaryLoader } from '#app/routes/users+/$username.diary.tsx'
 import { loader as overviewLoader } from '#app/routes/users+/$username.index.tsx'
 import { loader as reviewsLoader } from '#app/routes/users+/$username.reviews.tsx'
+import { loader as statsLoader } from '#app/routes/users+/$username.stats.tsx'
 import { loader as profileLoader } from '#app/routes/users+/$username.tsx'
 import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
@@ -55,6 +56,7 @@ test('profile loader returns canonical tracking summaries without duplicate rows
 			kind: 'anime',
 			title: 'Canonical Activity Title',
 			thumbnail: 'https://example.com/poster.jpg|https://example.com/title',
+			malScore: 9.1,
 		},
 		select: { id: true },
 	})
@@ -79,6 +81,8 @@ test('profile loader returns canonical tracking summaries without duplicate rows
 				title: 'Duplicate source row',
 				mediaId: media.id,
 				trackingStateId: state.id,
+				personal: 6,
+				malScore: 5,
 			},
 			{
 				watchlistId: completed.id,
@@ -86,6 +90,8 @@ test('profile loader returns canonical tracking summaries without duplicate rows
 				title: 'Canonical destination row',
 				mediaId: media.id,
 				trackingStateId: state.id,
+				personal: 6,
+				malScore: 5,
 			},
 		],
 	})
@@ -96,6 +102,7 @@ test('profile loader returns canonical tracking summaries without duplicate rows
 			mediaId: media.id,
 			trackingStateId: state.id,
 			score: 8.5,
+			publicEligible: true,
 		},
 	})
 	const [review, diaryEntry] = await Promise.all([
@@ -123,14 +130,21 @@ test('profile loader returns canonical tracking summaries without duplicate rows
 		request: new Request(`${BASE_URL}/users/${user.username}`),
 		params: { username: user.username },
 	} as any
-	const [result, overviewResult, activityResult, reviewsResult, diaryResult] =
-		await Promise.all([
-			profileLoader(loaderArgs),
-			overviewLoader(loaderArgs),
-			activityLoader(loaderArgs),
-			reviewsLoader(loaderArgs),
-			diaryLoader(loaderArgs),
-		])
+	const [
+		result,
+		overviewResult,
+		statsResult,
+		activityResult,
+		reviewsResult,
+		diaryResult,
+	] = await Promise.all([
+		profileLoader(loaderArgs),
+		overviewLoader(loaderArgs),
+		statsLoader(loaderArgs),
+		activityLoader(loaderArgs),
+		reviewsLoader(loaderArgs),
+		diaryLoader(loaderArgs),
+	])
 
 	expect(result.data).not.toHaveProperty('typedEntries')
 	expect(result.data).not.toHaveProperty('activityEvents')
@@ -187,6 +201,190 @@ test('profile loader returns canonical tracking summaries without duplicate rows
 			media: expect.objectContaining({ id: media.id }),
 		}),
 	])
+	expect(activityResult.data.activityLimited).toBe(false)
+	expect(statsResult.data.scoreBuckets[listType.id].personal[7]).toBe(2)
+	expect(statsResult.data.providerScoreBuckets[listType.id].malScore[8]).toBe(2)
+})
+
+test('profile activity returns a bounded recent window with an explicit partial marker', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const user = await prisma.user.create({
+		data: {
+			email: `activity-bound-${suffix}@example.com`,
+			username: `activity_bound_${suffix}`,
+		},
+	})
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Bounded activity fixture' },
+	})
+	await prisma.activityEvent.createMany({
+		data: Array.from({ length: 101 }, (_, index) => ({
+			type: 'status',
+			actorId: user.id,
+			mediaId: media.id,
+			status: 'watching',
+			publicEligible: true,
+			createdAt: new Date(Date.UTC(2026, 0, 1, 0, index)),
+		})),
+	})
+
+	const result = await activityLoader({
+		request: new Request(`${BASE_URL}/users/${user.username}/activity`),
+		params: { username: user.username },
+	} as any)
+
+	expect(result.data.activityEvents).toHaveLength(100)
+	expect(result.data.activityLimited).toBe(true)
+	expect(result.data.activityEvents[0]?.time).toEqual(
+		new Date(Date.UTC(2026, 0, 1, 1, 40)),
+	)
+})
+
+test('visitor activity keeps media-type mappings when the only list is private', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const user = await prisma.user.create({
+		data: {
+			email: `private-type-${suffix}@example.com`,
+			username: `private_type_${suffix}`,
+		},
+	})
+	const listType = await prisma.listType.upsert({
+		where: { name: 'anime' },
+		update: {},
+		create: {
+			name: 'anime',
+			header: 'Anime',
+			columns: '{"length":"string"}',
+			mediaType: '["episode"]',
+			completionType: '{"past":"watched"}',
+		},
+	})
+	await prisma.watchlist.create({
+		data: {
+			ownerId: user.id,
+			typeId: listType.id,
+			name: 'private-only',
+			header: 'Private only',
+			position: 1,
+			isPublic: false,
+		},
+	})
+	const media = await prisma.media.create({
+		data: { kind: 'anime', title: 'Private-only type mapping fixture' },
+	})
+	const [review, diary] = await Promise.all([
+		prisma.review.create({
+			data: {
+				authorId: user.id,
+				mediaId: media.id,
+				body: 'Public review without a public list.',
+			},
+		}),
+		prisma.diaryEntry.create({
+			data: {
+				ownerId: user.id,
+				mediaId: media.id,
+				loggedOn: new Date('2026-07-28T00:00:00.000Z'),
+			},
+		}),
+	])
+
+	const result = await activityLoader({
+		request: new Request(`${BASE_URL}/users/${user.username}/activity`),
+		params: { username: user.username },
+	} as any)
+
+	expect(result.data.activityEvents).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				id: `review:${review.id}`,
+				typeId: listType.id,
+			}),
+			expect.objectContaining({ id: `diary:${diary.id}`, typeId: listType.id }),
+		]),
+	)
+})
+
+test('profile activity keeps newer legacy events for owners but not visitors', async () => {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	const user = await prisma.user.create({
+		data: {
+			email: `activity-parity-${suffix}@example.com`,
+			username: `activity_parity_${suffix}`,
+		},
+	})
+	const listType = await prisma.listType.create({
+		data: {
+			name: `activity-parity-${suffix}`,
+			header: 'Activity parity',
+			columns: '{"title":"string"}',
+			mediaType: '["episode"]',
+			completionType: '{"past":"watched"}',
+		},
+	})
+	const watchlist = await prisma.watchlist.create({
+		data: {
+			ownerId: user.id,
+			typeId: listType.id,
+			name: 'watching',
+			header: 'Watching',
+			position: 1,
+			isPublic: true,
+		},
+	})
+	const media = await prisma.media.create({
+		data: { kind: 'anime', title: 'Legacy parity fixture' },
+	})
+	const normalizedAt = new Date('2026-07-28T12:00:00.000Z')
+	const legacyFinishedAt = new Date('2026-07-28T12:02:00.000Z')
+	await Promise.all([
+		prisma.entry.create({
+			data: {
+				watchlistId: watchlist.id,
+				mediaId: media.id,
+				position: 1,
+				title: 'Legacy parity fixture',
+				history: JSON.stringify({
+					finished: legacyFinishedAt.getTime(),
+				}),
+			},
+		}),
+		prisma.activityEvent.create({
+			data: {
+				type: 'score',
+				actorId: user.id,
+				mediaId: media.id,
+				score: 8,
+				publicEligible: true,
+				createdAt: normalizedAt,
+			},
+		}),
+	])
+
+	const visitorResult = await activityLoader({
+		request: new Request(`${BASE_URL}/users/${user.username}/activity`),
+		params: { username: user.username },
+	} as any)
+
+	expect(visitorResult.data.activityEvents).toEqual([
+		expect.objectContaining({ action: 'Rated 8/10', time: normalizedAt }),
+	])
+
+	const session = await prisma.session.create({
+		data: { userId: user.id, expirationDate: getSessionExpirationDate() },
+	})
+	const ownerResult = await activityLoader({
+		request: new Request(`${BASE_URL}/users/${user.username}/activity`, {
+			headers: { cookie: await getSessionCookieHeader(session) },
+		}),
+		params: { username: user.username },
+	} as any)
+	expect(ownerResult.data.activityEvents).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({ action: 'Rated 8/10', time: normalizedAt }),
+			expect.objectContaining({ action: 'Finished', time: legacyFinishedAt }),
+		]),
+	)
 })
 
 test('profile loader hides private lists and their tracking activity from visitors', async () => {
@@ -236,6 +434,23 @@ test('profile loader hides private lists and their tracking activity from visito
 			data: { kind: 'anime', title: 'Private profile title' },
 		}),
 	])
+	const unrelatedOwner = await prisma.user.create({
+		data: {
+			email: `unrelated_${suffix}@example.com`,
+			username: `unrelated_${suffix}`,
+		},
+	})
+	const unrelatedMedia = await prisma.media.create({
+		data: { kind: 'anime', title: 'Cross-owner state fixture' },
+	})
+	const [mismatchedStateMedia, mismatchedEntryMedia] = await Promise.all([
+		prisma.media.create({
+			data: { kind: 'anime', title: 'Mismatched state media' },
+		}),
+		prisma.media.create({
+			data: { kind: 'anime', title: 'Mismatched entry media' },
+		}),
+	])
 	const [publicState, privateState] = await Promise.all([
 		prisma.trackingState.create({
 			data: {
@@ -251,9 +466,38 @@ test('profile loader hides private lists and their tracking activity from visito
 				mediaId: privateMedia.id,
 				status: 'watching',
 				statusWatchlistId: privateList.id,
+				score: 9,
+				repeatCount: 4,
+				progress: {
+					create: { unit: 'episode', current: 12, total: 12 },
+				},
 			},
 		}),
 	])
+	const unrelatedState = await prisma.trackingState.create({
+		data: {
+			ownerId: unrelatedOwner.id,
+			mediaId: unrelatedMedia.id,
+			status: 'watching',
+			score: 10,
+			repeatCount: 7,
+			progress: {
+				create: { unit: 'episode', current: 99, total: 99 },
+			},
+		},
+	})
+	const mismatchedState = await prisma.trackingState.create({
+		data: {
+			ownerId: user.id,
+			mediaId: mismatchedStateMedia.id,
+			status: 'watching',
+			score: 7,
+			repeatCount: 3,
+			progress: {
+				create: { unit: 'episode', current: 24, total: 24 },
+			},
+		},
+	})
 	await Promise.all([
 		prisma.entry.create({
 			data: {
@@ -269,8 +513,49 @@ test('profile loader hides private lists and their tracking activity from visito
 				watchlistId: privateList.id,
 				position: 1,
 				title: 'Private profile title',
+				type: 'Private sentinel type',
+				genres: 'Private Sentinel Genre',
 				mediaId: privateMedia.id,
 				trackingStateId: privateState.id,
+			},
+		}),
+		prisma.entry.create({
+			data: {
+				watchlistId: publicList.id,
+				position: 2,
+				title: 'Public duplicate with a private canonical state',
+				mediaId: privateMedia.id,
+				trackingStateId: privateState.id,
+				personal: 9,
+				length: '12 / 12 eps',
+				history: JSON.stringify({
+					started: Date.UTC(2026, 0, 1),
+					finished: Date.UTC(2026, 0, 2),
+					repeatCount: 4,
+					progress: {
+						episode: {
+							12: { finishDate: [Date.UTC(2026, 0, 2)] },
+						},
+					},
+				}),
+			},
+		}),
+		prisma.entry.create({
+			data: {
+				watchlistId: publicList.id,
+				position: 3,
+				title: 'Entry with an unrelated tracking state',
+				mediaId: unrelatedMedia.id,
+				trackingStateId: unrelatedState.id,
+			},
+		}),
+		prisma.entry.create({
+			data: {
+				watchlistId: publicList.id,
+				position: 4,
+				title: 'Entry with a mismatched media state',
+				mediaId: mismatchedEntryMedia.id,
+				trackingStateId: mismatchedState.id,
 			},
 		}),
 		prisma.activityEvent.create({
@@ -283,6 +568,7 @@ test('profile loader hides private lists and their tracking activity from visito
 				statusLabel: publicList.header,
 				statusWatchlistId: publicList.id,
 				isPublic: true,
+				publicEligible: true,
 			},
 		}),
 		prisma.activityEvent.create({
@@ -295,6 +581,7 @@ test('profile loader hides private lists and their tracking activity from visito
 				statusLabel: privateList.header,
 				statusWatchlistId: privateList.id,
 				isPublic: false,
+				publicEligible: true,
 			},
 		}),
 	])
@@ -303,21 +590,38 @@ test('profile loader hides private lists and their tracking activity from visito
 		request: new Request(`${BASE_URL}/users/${user.username}`),
 		params: { username: user.username },
 	} as any
-	const [visitorResult, visitorActivityResult, visitorOverviewResult] =
-		await Promise.all([
-			profileLoader(visitorArgs),
-			activityLoader(visitorArgs),
-			overviewLoader(visitorArgs),
-		])
-	expect(visitorResult.data.watchLists.map(list => list.id)).toEqual([
-		publicList.id,
+	const [
+		visitorResult,
+		visitorActivityResult,
+		visitorOverviewResult,
+		visitorStatsResult,
+	] = await Promise.all([
+		profileLoader(visitorArgs),
+		activityLoader(visitorArgs),
+		overviewLoader(visitorArgs),
+		statsLoader(visitorArgs),
 	])
+	expect(visitorResult.data).not.toHaveProperty('watchLists')
 	expect(
 		visitorActivityResult.data.activityEvents.map(event => event.media.title),
 	).toEqual(['Public profile title'])
 	expect(
-		visitorOverviewResult.data.trackingSummaries[listType.id].totalTitles,
-	).toBe(1)
+		visitorOverviewResult.data.trackingSummaries[listType.id],
+	).toMatchObject({
+		totalTitles: 4,
+		meanScore: null,
+		repeatCount: 0,
+		progress: [],
+	})
+	expect(visitorOverviewResult.data.completionHistory.days).toEqual([])
+	expect(visitorStatsResult.data.scoreBuckets[listType.id].personal).toEqual(
+		Array.from({ length: 10 }, () => 0),
+	)
+	expect(visitorStatsResult.data.completionYears[listType.id]).toEqual([])
+	expect(
+		visitorStatsResult.data.genreMatrices[listType.id].labels,
+	).not.toContain('Private Sentinel Genre')
+	expect(visitorStatsResult.data.listTypeCounts[listType.id]).toBe(4)
 
 	const session = await prisma.session.create({
 		data: { userId: user.id, expirationDate: getSessionExpirationDate() },
@@ -330,17 +634,43 @@ test('profile loader hides private lists and their tracking activity from visito
 		}),
 		params: { username: user.username },
 	} as any
-	const [ownerResult, ownerActivityResult, ownerOverviewResult] =
-		await Promise.all([
-			profileLoader(ownerArgs),
-			activityLoader(ownerArgs),
-			overviewLoader(ownerArgs),
-		])
-	expect(ownerResult.data.watchLists.map(list => list.id).sort()).toEqual(
-		[publicList.id, privateList.id].sort(),
+	const [
+		ownerResult,
+		ownerActivityResult,
+		ownerOverviewResult,
+		ownerStatsResult,
+	] = await Promise.all([
+		profileLoader(ownerArgs),
+		activityLoader(ownerArgs),
+		overviewLoader(ownerArgs),
+		statsLoader(ownerArgs),
+	])
+	expect(ownerResult.data).not.toHaveProperty('watchLists')
+	expect(ownerActivityResult.data.activityEvents).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({ id: expect.stringMatching(/^tracking:/) }),
+			expect.objectContaining({ action: 'Finished' }),
+		]),
 	)
-	expect(ownerActivityResult.data.activityEvents).toHaveLength(2)
-	expect(
-		ownerOverviewResult.data.trackingSummaries[listType.id].totalTitles,
-	).toBe(2)
+	expect(ownerOverviewResult.data.trackingSummaries[listType.id]).toMatchObject(
+		{
+			totalTitles: 4,
+			meanScore: 9,
+			repeatCount: 4,
+			progress: [{ unit: 'episode', current: 12 }],
+		},
+	)
+	expect(ownerOverviewResult.data.completionHistory.days).toContainEqual({
+		day: '2026-01-02',
+		value: 1,
+	})
+	expect(ownerStatsResult.data.scoreBuckets[listType.id].personal[8]).toBe(2)
+	expect(ownerStatsResult.data.completionYears[listType.id]).toContainEqual({
+		year: 2026,
+		count: 1,
+	})
+	expect(ownerStatsResult.data.genreMatrices[listType.id].labels).toContain(
+		'Private Sentinel Genre',
+	)
+	expect(ownerStatsResult.data.listTypeCounts[listType.id]).toBe(5)
 })

--- a/app/utils/activity-feed.server.test.ts
+++ b/app/utils/activity-feed.server.test.ts
@@ -22,7 +22,14 @@ test('following activity merges supported events in time order and scopes actors
 	const media = await prisma.media.create({
 		data: { kind: 'anime', title: 'Feed Fixture' },
 	})
-	const [tracking, privateTracking, review, diary, collection] = await Promise.all([
+	const [
+		tracking,
+		privateTracking,
+		unresolvedTracking,
+		review,
+		diary,
+		collection,
+	] = await Promise.all([
 		prisma.activityEvent.create({
 			data: {
 				type: 'progress',
@@ -32,6 +39,7 @@ test('following activity merges supported events in time order and scopes actors
 				progressPrevious: 2,
 				progressCurrent: 4,
 				progressTotal: 12,
+				publicEligible: true,
 				createdAt: new Date('2026-07-17T12:00:00.000Z'),
 			},
 		}),
@@ -44,6 +52,17 @@ test('following activity merges supported events in time order and scopes actors
 				statusLabel: 'Private queue',
 				isPublic: false,
 				createdAt: new Date('2026-07-20T18:00:00.000Z'),
+			},
+		}),
+		prisma.activityEvent.create({
+			data: {
+				type: 'score',
+				actorId: followed.id,
+				mediaId: media.id,
+				statusLabel: 'Unresolved private queue',
+				score: 10,
+				isPublic: true,
+				createdAt: new Date('2026-07-20T19:00:00.000Z'),
 			},
 		}),
 		prisma.review.create({
@@ -104,6 +123,9 @@ test('following activity merges supported events in time order and scopes actors
 	])
 	expect(feed.map(item => item.id)).not.toContain(
 		`tracking:${privateTracking.id}`,
+	)
+	expect(feed.map(item => item.id)).not.toContain(
+		`tracking:${unresolvedTracking.id}`,
 	)
 	expect(feed.every(item => item.actor.id === followed.id)).toBe(true)
 	expect(feed).toEqual(

--- a/app/utils/activity-feed.server.ts
+++ b/app/utils/activity-feed.server.ts
@@ -1,5 +1,6 @@
 import { activityEventLabel, diaryActivityLabel } from './activity.ts'
 import { prisma } from './db.server.ts'
+import { publicActivityEventWhere } from './lists/visibility.ts'
 
 export type FollowingActivityFeedItem = {
 	id: string
@@ -74,7 +75,10 @@ export async function getFollowingActivityFeed(
 	const [trackingRows, reviewRows, diaryRows, collectionRows] =
 		await Promise.all([
 			prisma.activityEvent.findMany({
-				where: { actorId: { in: uniqueActorIds }, isPublic: true },
+				where: {
+					actorId: { in: uniqueActorIds },
+					AND: [publicActivityEventWhere],
+				},
 				orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
 				take,
 				select: {

--- a/app/utils/activity.server.test.ts
+++ b/app/utils/activity.server.test.ts
@@ -1,0 +1,346 @@
+import { faker } from '@faker-js/faker'
+import { expect, test } from 'vitest'
+import {
+	getTrackingActivityState,
+	recordTrackingActivityDiff,
+} from './activity.server.ts'
+import { prisma } from './db.server.ts'
+import { publicActivityEventWhere } from './lists/visibility.ts'
+
+async function user(prefix: string) {
+	const suffix = faker.string.alphanumeric({ length: 12 }).toLowerCase()
+	return prisma.user.create({
+		data: {
+			email: `${prefix}-${suffix}@example.com`,
+			username: `${prefix}_${suffix}`,
+		},
+	})
+}
+
+test('tracking activity rejects cross-owner watchlist provenance', async () => {
+	const [actor, other] = await Promise.all([user('actor'), user('other')])
+	const listType = await prisma.listType.create({
+		data: {
+			name: `activity-${faker.string.uuid()}`,
+			header: 'Activity',
+			columns: '[]',
+			mediaType: 'liveAction',
+			completionType: 'watched',
+		},
+	})
+	const foreignList = await prisma.watchlist.create({
+		data: {
+			ownerId: other.id,
+			typeId: listType.id,
+			name: 'foreign',
+			header: 'Foreign list',
+			position: 1,
+			isPublic: true,
+		},
+	})
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Cross-owner provenance fixture' },
+	})
+	const state = await prisma.trackingState.create({
+		data: {
+			ownerId: actor.id,
+			mediaId: media.id,
+			status: 'watching',
+			statusWatchlistId: foreignList.id,
+		},
+	})
+
+	await prisma.$transaction(async tx => {
+		const after = await getTrackingActivityState(tx, actor.id, media.id)
+		if (!after) throw new Error('test setup: tracking state was not created')
+		await recordTrackingActivityDiff(tx, {
+			actorId: actor.id,
+			mediaId: media.id,
+			before: null,
+			after,
+		})
+	})
+
+	expect(
+		await prisma.activityEvent.findFirstOrThrow({
+			where: { actorId: actor.id, trackingStateId: state.id },
+			select: {
+				statusLabel: true,
+				statusWatchlistId: true,
+				isPublic: true,
+				publicEligible: true,
+			},
+		}),
+	).toEqual({
+		statusLabel: null,
+		statusWatchlistId: foreignList.id,
+		isPublic: false,
+		publicEligible: false,
+	})
+})
+
+test('tracking activity rejects cross-owner previous-list provenance', async () => {
+	const [actor, other] = await Promise.all([
+		user('move_actor'),
+		user('move_other'),
+	])
+	const listType = await prisma.listType.create({
+		data: {
+			name: `move-activity-${faker.string.uuid()}`,
+			header: 'Move activity',
+			columns: '[]',
+			mediaType: 'liveAction',
+			completionType: 'watched',
+		},
+	})
+	const [ownedList, foreignList] = await Promise.all([
+		prisma.watchlist.create({
+			data: {
+				ownerId: actor.id,
+				typeId: listType.id,
+				name: 'owned',
+				header: 'Owned list',
+				position: 1,
+			},
+		}),
+		prisma.watchlist.create({
+			data: {
+				ownerId: other.id,
+				typeId: listType.id,
+				name: 'foreign',
+				header: 'Foreign previous list',
+				position: 1,
+			},
+		}),
+	])
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Cross-owner previous fixture' },
+	})
+	await prisma.trackingState.create({
+		data: {
+			ownerId: actor.id,
+			mediaId: media.id,
+			status: 'watching',
+			statusWatchlistId: ownedList.id,
+		},
+	})
+
+	await prisma.$transaction(async tx => {
+		const after = await getTrackingActivityState(tx, actor.id, media.id)
+		if (!after) throw new Error('test setup: tracking state was not created')
+		await recordTrackingActivityDiff(tx, {
+			actorId: actor.id,
+			mediaId: media.id,
+			before: {
+				...after,
+				status: 'planned',
+				statusWatchlistId: foreignList.id,
+			},
+			after,
+		})
+	})
+
+	expect(
+		await prisma.activityEvent.findFirstOrThrow({
+			where: { actorId: actor.id, mediaId: media.id },
+			select: {
+				statusLabel: true,
+				previousStatusLabel: true,
+				previousStatusWatchlistId: true,
+				isPublic: true,
+				publicEligible: true,
+			},
+		}),
+	).toEqual({
+		statusLabel: ownedList.header,
+		previousStatusLabel: null,
+		previousStatusWatchlistId: foreignList.id,
+		isPublic: false,
+		publicEligible: false,
+	})
+})
+
+test('genuinely listless tracking activity is public-eligible', async () => {
+	const actor = await user('listless_actor')
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Listless provenance fixture' },
+	})
+	await prisma.trackingState.create({
+		data: {
+			ownerId: actor.id,
+			mediaId: media.id,
+			status: 'planned',
+		},
+	})
+
+	await prisma.$transaction(async tx => {
+		const after = await getTrackingActivityState(tx, actor.id, media.id)
+		if (!after) throw new Error('test setup: tracking state was not created')
+		await recordTrackingActivityDiff(tx, {
+			actorId: actor.id,
+			mediaId: media.id,
+			before: null,
+			after,
+		})
+	})
+
+	expect(
+		await prisma.activityEvent.findFirstOrThrow({
+			where: { actorId: actor.id, AND: [publicActivityEventWhere] },
+			select: {
+				statusLabel: true,
+				statusWatchlistId: true,
+				isPublic: true,
+				publicEligible: true,
+			},
+		}),
+	).toEqual({
+		statusLabel: null,
+		statusWatchlistId: null,
+		isPublic: true,
+		publicEligible: true,
+	})
+})
+
+test('tracking activity created on a private list is never public-eligible', async () => {
+	const actor = await user('private_actor')
+	const listType = await prisma.listType.create({
+		data: {
+			name: `private-activity-${faker.string.uuid()}`,
+			header: 'Private activity',
+			columns: '[]',
+			mediaType: 'liveAction',
+			completionType: 'watched',
+		},
+	})
+	const privateList = await prisma.watchlist.create({
+		data: {
+			ownerId: actor.id,
+			typeId: listType.id,
+			name: 'private',
+			header: 'Private history label',
+			position: 1,
+			isPublic: false,
+		},
+	})
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Private provenance fixture' },
+	})
+	await prisma.trackingState.create({
+		data: {
+			ownerId: actor.id,
+			mediaId: media.id,
+			status: 'watching',
+			statusWatchlistId: privateList.id,
+		},
+	})
+
+	await prisma.$transaction(async tx => {
+		const after = await getTrackingActivityState(tx, actor.id, media.id)
+		if (!after) throw new Error('test setup: tracking state was not created')
+		await recordTrackingActivityDiff(tx, {
+			actorId: actor.id,
+			mediaId: media.id,
+			before: null,
+			after,
+		})
+	})
+
+	expect(
+		await prisma.activityEvent.findFirstOrThrow({
+			where: { actorId: actor.id, mediaId: media.id },
+			select: { statusLabel: true, isPublic: true, publicEligible: true },
+		}),
+	).toEqual({
+		statusLabel: privateList.header,
+		isPublic: false,
+		publicEligible: false,
+	})
+})
+
+test('score and progress labels fail closed across a direct watchlist deletion', async () => {
+	const actor = await user('delete_actor')
+	const listType = await prisma.listType.create({
+		data: {
+			name: `delete-activity-${faker.string.uuid()}`,
+			header: 'Delete activity',
+			columns: '[]',
+			mediaType: 'liveAction',
+			completionType: 'watched',
+		},
+	})
+	const publicList = await prisma.watchlist.create({
+		data: {
+			ownerId: actor.id,
+			typeId: listType.id,
+			name: 'watching',
+			header: 'Public history label',
+			position: 1,
+			isPublic: true,
+		},
+	})
+	const media = await prisma.media.create({
+		data: { kind: 'movie', title: 'Deletion race fixture' },
+	})
+	await prisma.trackingState.create({
+		data: {
+			ownerId: actor.id,
+			mediaId: media.id,
+			status: 'watching',
+			statusWatchlistId: publicList.id,
+			score: 8,
+			progress: { create: { unit: 'episode', current: 2, total: 12 } },
+		},
+	})
+
+	await prisma.$transaction(async tx => {
+		const after = await getTrackingActivityState(tx, actor.id, media.id)
+		if (!after) throw new Error('test setup: tracking state was not created')
+		await recordTrackingActivityDiff(tx, {
+			actorId: actor.id,
+			mediaId: media.id,
+			before: {
+				...after,
+				score: null,
+				progress: [{ unit: 'episode', current: 0, total: 12 }],
+			},
+			after,
+		})
+	})
+
+	await prisma.watchlist.delete({ where: { id: publicList.id } })
+
+	expect(
+		await prisma.activityEvent.findMany({
+			where: { actorId: actor.id, type: { in: ['score', 'progress'] } },
+			orderBy: { type: 'asc' },
+			select: {
+				type: true,
+				statusLabel: true,
+				statusWatchlistId: true,
+				isPublic: true,
+				publicEligible: true,
+			},
+		}),
+	).toEqual([
+		{
+			type: 'progress',
+			statusLabel: publicList.header,
+			statusWatchlistId: null,
+			isPublic: true,
+			publicEligible: true,
+		},
+		{
+			type: 'score',
+			statusLabel: publicList.header,
+			statusWatchlistId: null,
+			isPublic: true,
+			publicEligible: true,
+		},
+	])
+	expect(
+		await prisma.activityEvent.findMany({
+			where: { actorId: actor.id, AND: [publicActivityEventWhere] },
+		}),
+	).toEqual([])
+})

--- a/app/utils/activity.server.ts
+++ b/app/utils/activity.server.ts
@@ -1,4 +1,5 @@
 import { type Prisma } from '@prisma/client'
+import { serializeUserLibraryMutation } from './watchlist-limits.ts'
 
 export const trackingActivityStateSelect = {
 	id: true,
@@ -40,15 +41,19 @@ export async function recordTrackingActivityDiff(
 		after: TrackingActivityState
 	},
 ) {
+	await serializeUserLibraryMutation(tx, input.actorId)
 	const events: Prisma.ActivityEventUncheckedCreateInput[] = []
 	const watchlistIds = [
 		input.before?.statusWatchlistId,
 		input.after.statusWatchlistId,
-	].filter((id): id is string => Boolean(id))
+	]
+		.filter((id): id is string => Boolean(id))
+		.filter((id, index, ids) => ids.indexOf(id) === index)
+		.sort()
 	const watchlists = watchlistIds.length
 		? await tx.watchlist.findMany({
 				where: { id: { in: watchlistIds } },
-				select: { id: true, header: true, isPublic: true },
+				select: { id: true, ownerId: true, header: true, isPublic: true },
 			})
 		: []
 	const watchlistById = new Map(
@@ -60,7 +65,22 @@ export async function recordTrackingActivityDiff(
 	const previousWatchlist = input.before?.statusWatchlistId
 		? watchlistById.get(input.before.statusWatchlistId)
 		: null
-	const currentIsPublic = currentWatchlist?.isPublic ?? true
+	const currentVisibility = input.after.statusWatchlistId
+		? {
+				verified: currentWatchlist?.ownerId === input.actorId,
+				isPublic:
+					currentWatchlist?.ownerId === input.actorId &&
+					currentWatchlist.isPublic,
+			}
+		: { verified: true, isPublic: true }
+	const previousVisibility = input.before?.statusWatchlistId
+		? {
+				verified: previousWatchlist?.ownerId === input.actorId,
+				isPublic:
+					previousWatchlist?.ownerId === input.actorId &&
+					previousWatchlist.isPublic,
+			}
+		: { verified: true, isPublic: true }
 	const statusChanged =
 		!input.before ||
 		input.before.status !== input.after.status ||
@@ -74,16 +94,20 @@ export async function recordTrackingActivityDiff(
 			trackingStateId: input.after.id,
 			status: input.after.status,
 			statusLabel: input.after.statusWatchlistId
-				? currentWatchlist?.header
+				? currentVisibility.verified
+					? currentWatchlist?.header
+					: null
 				: null,
 			statusWatchlistId: input.after.statusWatchlistId,
 			previousStatus: input.before?.status ?? null,
 			previousStatusLabel: input.before?.statusWatchlistId
-				? previousWatchlist?.header
+				? previousVisibility.verified
+					? previousWatchlist?.header
+					: null
 				: null,
-			previousStatusWatchlistId:
-				input.before?.statusWatchlistId ?? null,
-			isPublic: currentIsPublic && (previousWatchlist?.isPublic ?? true),
+			previousStatusWatchlistId: input.before?.statusWatchlistId ?? null,
+			isPublic: currentVisibility.isPublic && previousVisibility.isPublic,
+			publicEligible: currentVisibility.isPublic && previousVisibility.isPublic,
 		})
 	}
 
@@ -97,8 +121,14 @@ export async function recordTrackingActivityDiff(
 			trackingStateId: input.after.id,
 			score: afterScore,
 			previousScore: beforeScore,
+			statusLabel: input.after.statusWatchlistId
+				? currentVisibility.verified
+					? currentWatchlist?.header
+					: null
+				: null,
 			statusWatchlistId: input.after.statusWatchlistId,
-			isPublic: currentIsPublic,
+			isPublic: currentVisibility.isPublic,
+			publicEligible: currentVisibility.isPublic,
 		})
 	}
 
@@ -124,8 +154,14 @@ export async function recordTrackingActivityDiff(
 			progressCurrent: current,
 			progressPrevious: previous,
 			progressTotal: after?.total ?? before?.total ?? null,
+			statusLabel: input.after.statusWatchlistId
+				? currentVisibility.verified
+					? currentWatchlist?.header
+					: null
+				: null,
 			statusWatchlistId: input.after.statusWatchlistId,
-			isPublic: currentIsPublic,
+			isPublic: currentVisibility.isPublic,
+			publicEligible: currentVisibility.isPublic,
 		})
 	}
 

--- a/app/utils/anonymous-home.server.ts
+++ b/app/utils/anonymous-home.server.ts
@@ -1,5 +1,6 @@
 import { activityEventLabel } from './activity.ts'
 import { prisma } from './db.server.ts'
+import { publicActivityEventWhere } from './lists/visibility.ts'
 
 export type AnonymousHomeActivity = {
 	id: string
@@ -54,8 +55,8 @@ export async function getAnonymousHomeProof(): Promise<AnonymousHomeProof> {
 		}),
 		prisma.activityEvent.findMany({
 			where: {
-				isPublic: true,
 				actor: { is: { accountStatus: 'active' } },
+				AND: [publicActivityEventWhere],
 			},
 			orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
 			take: 8,

--- a/app/utils/catalog-media-merge.server.test.ts
+++ b/app/utils/catalog-media-merge.server.test.ts
@@ -278,6 +278,7 @@ async function seedSafeRelationInventory() {
 				actorId: base.owner.id,
 				mediaId: 'merge-source',
 				trackingStateId: tracking.id,
+				publicEligible: true,
 			},
 		}),
 		prisma.consumptionEvent.create({
@@ -583,6 +584,12 @@ test('applies and reverses a complete safe relation inventory without data loss'
 	expect(await prisma.mediaTitle.count()).toBe(2)
 	expect(await prisma.catalogFeedItem.count()).toBe(2)
 	expect(await prisma.mediaRelation.count()).toBe(1)
+	expect(
+		await prisma.activityEvent.findUniqueOrThrow({
+			where: { id: 'merge-activity' },
+			select: { mediaId: true, publicEligible: true },
+		}),
+	).toEqual({ mediaId: 'merge-target', publicEligible: true })
 
 	const reverted = await revertCatalogMediaMerge(prisma, {
 		mergeId: prepared.merge.id,
@@ -591,6 +598,12 @@ test('applies and reverses a complete safe relation inventory without data loss'
 		now: new Date(now.getTime() + 2_000),
 	})
 	expect(reverted.status).toBe('reverted')
+	expect(
+		await prisma.activityEvent.findUniqueOrThrow({
+			where: { id: 'merge-activity' },
+			select: { mediaId: true, publicEligible: true },
+		}),
+	).toEqual({ mediaId: 'merge-source', publicEligible: true })
 	expect(
 		await prisma.media.findUniqueOrThrow({
 			where: { id: 'merge-source' },

--- a/app/utils/consumption.server.ts
+++ b/app/utils/consumption.server.ts
@@ -9,6 +9,7 @@ import {
 	progressUnitsForMediaKind,
 	type SupportedProgressUnit,
 } from './media-detail.ts'
+import { serializeUserLibraryMutation } from './watchlist-limits.ts'
 
 function catalogTotal(
 	media: {
@@ -36,6 +37,7 @@ export async function recordInstallmentConsumption(
 		source?: string
 	},
 ) {
+	await serializeUserLibraryMutation(tx, input.ownerId)
 	const before = await getTrackingActivityState(
 		tx,
 		input.ownerId,

--- a/app/utils/library-import-commit.server.test.ts
+++ b/app/utils/library-import-commit.server.test.ts
@@ -1,3 +1,6 @@
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { faker } from '@faker-js/faker'
 import { expect, test } from 'vitest'
 import { prisma } from './db.server.ts'
@@ -7,7 +10,7 @@ import {
 	rollbackLibraryImportBatch,
 } from './library-import-commit.server.ts'
 import { type LibraryImportItem } from './library-import.ts'
-import { syncWatchlistActivityVisibility } from './lists/visibility.server.ts'
+import { syncWatchlistActivityVisibility } from './lists/activity-visibility.server.ts'
 import {
 	MAX_WATCHLISTS_PER_TYPE,
 	MAX_WATCHLISTS_PER_USER,
@@ -16,6 +19,31 @@ import {
 function suffix() {
 	return faker.string.alphanumeric({ length: 10 }).toLowerCase()
 }
+
+test('imports the library writer without request-session credentials', () => {
+	const environment = { ...process.env }
+	Reflect.deleteProperty(environment, 'SESSION_SECRET')
+	const moduleUrl = pathToFileURL(
+		path.join(process.cwd(), 'app/utils/library-import-commit.server.ts'),
+	).href
+	const result = spawnSync(
+		process.execPath,
+		[
+			'--import',
+			'tsx',
+			'--input-type=module',
+			'--eval',
+			`await import(${JSON.stringify(moduleUrl)})`,
+		],
+		{
+			cwd: process.cwd(),
+			encoding: 'utf8',
+			env: environment,
+		},
+	)
+
+	expect(result.status, result.stderr).toBe(0)
+})
 
 async function owner() {
 	const id = suffix()

--- a/app/utils/library-import-commit.server.test.ts
+++ b/app/utils/library-import-commit.server.test.ts
@@ -7,6 +7,11 @@ import {
 	rollbackLibraryImportBatch,
 } from './library-import-commit.server.ts'
 import { type LibraryImportItem } from './library-import.ts'
+import { syncWatchlistActivityVisibility } from './lists/visibility.server.ts'
+import {
+	MAX_WATCHLISTS_PER_TYPE,
+	MAX_WATCHLISTS_PER_USER,
+} from './watchlist-limits.ts'
 
 function suffix() {
 	return faker.string.alphanumeric({ length: 10 }).toLowerCase()
@@ -36,6 +41,40 @@ async function animeListType() {
 			completionType:
 				'{"present":"watch","past":"watched","continuous":"watching"}',
 		},
+	})
+}
+
+async function auxiliaryListType(name: string) {
+	return prisma.listType.create({
+		data: {
+			name,
+			header: name,
+			columns: '{}',
+			mediaType: '[]',
+			completionType: '{}',
+		},
+	})
+}
+
+async function seedWatchlists({
+	ownerId,
+	typeId,
+	count,
+	prefix,
+}: {
+	ownerId: string
+	typeId: string
+	count: number
+	prefix: string
+}) {
+	await prisma.watchlist.createMany({
+		data: Array.from({ length: count }, (_, index) => ({
+			ownerId,
+			typeId,
+			position: index + 1,
+			name: `${prefix}-${index + 1}`,
+			header: `${prefix} ${index + 1}`,
+		})),
 	})
 }
 
@@ -140,9 +179,31 @@ test('atomically applies a new import and rolls it back exactly', async () => {
 	expect(
 		await prisma.activityEvent.findMany({
 			where: { actorId: member.id, mediaId: work.id },
-			select: { type: true, isPublic: true },
+			select: { type: true, isPublic: true, publicEligible: true },
 		}),
-	).toEqual([{ type: 'library_import', isPublic: false }])
+	).toEqual([
+		{ type: 'library_import', isPublic: false, publicEligible: false },
+	])
+	if (!applied.statusWatchlistId) {
+		throw new Error('test setup: import destination list was not created')
+	}
+	await prisma.$transaction(async tx => {
+		const published = await tx.watchlist.update({
+			where: { id: applied.statusWatchlistId! },
+			data: { isPublic: true },
+		})
+		await syncWatchlistActivityVisibility(tx, published)
+	})
+	expect(
+		await prisma.activityEvent.findFirstOrThrow({
+			where: {
+				actorId: member.id,
+				mediaId: work.id,
+				type: 'library_import',
+			},
+			select: { isPublic: true, publicEligible: true },
+		}),
+	).toEqual({ isPublic: false, publicEligible: false })
 	await expect(
 		prisma.$transaction(tx =>
 			applyLibraryImportBatch(tx, {
@@ -172,6 +233,18 @@ test('atomically applies a new import and rolls it back exactly', async () => {
 		where: { id: storedItem.id },
 		data: { journal: JSON.stringify(legacyJournal) },
 	})
+	const linkedActivity = await prisma.activityEvent.create({
+		data: {
+			type: 'score',
+			actorId: member.id,
+			mediaId: work.id,
+			trackingStateId: applied.id,
+			statusWatchlistId: applied.statusWatchlistId,
+			score: 9,
+			isPublic: true,
+			publicEligible: true,
+		},
+	})
 
 	await prisma.$transaction(tx =>
 		rollbackLibraryImportBatch(tx, {
@@ -198,6 +271,175 @@ test('atomically applies a new import and rolls it back exactly', async () => {
 			},
 		}),
 	).toBe(1)
+	expect(
+		await prisma.activityEvent.findUniqueOrThrow({
+			where: { id: linkedActivity.id },
+			select: {
+				statusWatchlistId: true,
+				isPublic: true,
+				publicEligible: true,
+			},
+		}),
+	).toEqual({
+		statusWatchlistId: null,
+		isPublic: false,
+		publicEligible: true,
+	})
+})
+
+test('rejects an import-created list at the per-type limit', async () => {
+	const type = await animeListType()
+	const [member, work] = await Promise.all([
+		owner(),
+		media(`Type-limited import ${suffix()}`),
+	])
+	await seedWatchlists({
+		ownerId: member.id,
+		typeId: type.id,
+		count: MAX_WATCHLISTS_PER_TYPE,
+		prefix: 'type-limit',
+	})
+	const importBatch = await batch(member.id, [
+		{
+			sourceKey: 'mal:anime:type-limit',
+			mediaId: work.id,
+			resolution: 'add',
+			payload: payload('mal:anime:type-limit', work.title!),
+		},
+	])
+
+	await expect(
+		prisma.$transaction(tx =>
+			applyLibraryImportBatch(tx, {
+				ownerId: member.id,
+				batchId: importBatch.id,
+			}),
+		),
+	).rejects.toEqual(
+		expect.objectContaining<Partial<LibraryImportError>>({
+			status: 409,
+			message: expect.stringContaining(
+				`${MAX_WATCHLISTS_PER_TYPE} watchlists for each media type`,
+			),
+		}),
+	)
+	expect(
+		await prisma.libraryImportBatch.findUniqueOrThrow({
+			where: { id: importBatch.id },
+			select: { status: true },
+		}),
+	).toEqual({ status: 'previewed' })
+	expect(
+		await prisma.trackingState.count({ where: { ownerId: member.id } }),
+	).toBe(0)
+})
+
+test('reuses an existing import list at the per-type limit', async () => {
+	const type = await animeListType()
+	const [member, work] = await Promise.all([
+		owner(),
+		media(`Existing-list import ${suffix()}`),
+	])
+	const completed = await prisma.watchlist.create({
+		data: {
+			ownerId: member.id,
+			typeId: type.id,
+			position: 1,
+			name: 'completed',
+			header: 'Completed',
+			isPublic: false,
+		},
+	})
+	await seedWatchlists({
+		ownerId: member.id,
+		typeId: type.id,
+		count: MAX_WATCHLISTS_PER_TYPE - 1,
+		prefix: 'existing-limit',
+	})
+	const importBatch = await batch(member.id, [
+		{
+			sourceKey: 'mal:anime:existing-limit',
+			mediaId: work.id,
+			resolution: 'add',
+			payload: payload('mal:anime:existing-limit', work.title!),
+		},
+	])
+
+	await prisma.$transaction(tx =>
+		applyLibraryImportBatch(tx, {
+			ownerId: member.id,
+			batchId: importBatch.id,
+		}),
+	)
+
+	expect(
+		await prisma.watchlist.count({
+			where: { ownerId: member.id, typeId: type.id },
+		}),
+	).toBe(MAX_WATCHLISTS_PER_TYPE)
+	expect(
+		await prisma.trackingState.findUniqueOrThrow({
+			where: { ownerId_mediaId: { ownerId: member.id, mediaId: work.id } },
+			select: { statusWatchlistId: true },
+		}),
+	).toEqual({ statusWatchlistId: completed.id })
+})
+
+test('rejects an import-created list at the total limit', async () => {
+	const type = await animeListType()
+	const id = suffix()
+	const [member, work, secondType, thirdType] = await Promise.all([
+		owner(),
+		media(`Total-limited import ${id}`),
+		auxiliaryListType(`import-total-b-${id}`),
+		auxiliaryListType(`import-total-c-${id}`),
+	])
+	await seedWatchlists({
+		ownerId: member.id,
+		typeId: type.id,
+		count: MAX_WATCHLISTS_PER_TYPE - 1,
+		prefix: 'total-limit-a',
+	})
+	await seedWatchlists({
+		ownerId: member.id,
+		typeId: secondType.id,
+		count: MAX_WATCHLISTS_PER_TYPE,
+		prefix: 'total-limit-b',
+	})
+	await seedWatchlists({
+		ownerId: member.id,
+		typeId: thirdType.id,
+		count:
+			MAX_WATCHLISTS_PER_USER -
+			(MAX_WATCHLISTS_PER_TYPE - 1) -
+			MAX_WATCHLISTS_PER_TYPE,
+		prefix: 'total-limit-c',
+	})
+	const importBatch = await batch(member.id, [
+		{
+			sourceKey: 'mal:anime:total-limit',
+			mediaId: work.id,
+			resolution: 'add',
+			payload: payload('mal:anime:total-limit', work.title!),
+		},
+	])
+
+	await expect(
+		prisma.$transaction(tx =>
+			applyLibraryImportBatch(tx, {
+				ownerId: member.id,
+				batchId: importBatch.id,
+			}),
+		),
+	).rejects.toEqual(
+		expect.objectContaining<Partial<LibraryImportError>>({
+			status: 409,
+			message: expect.stringContaining(`${MAX_WATCHLISTS_PER_USER} watchlists`),
+		}),
+	)
+	expect(await prisma.watchlist.count({ where: { ownerId: member.id } })).toBe(
+		MAX_WATCHLISTS_PER_USER,
+	)
 })
 
 test('merge preserves stronger progress and rollback restores prior state', async () => {

--- a/app/utils/library-import-commit.server.ts
+++ b/app/utils/library-import-commit.server.ts
@@ -3,8 +3,15 @@ import {
 	type LibraryImportItem as NormalizedImportItem,
 	libraryImportProviders,
 } from './library-import.ts'
+import { syncWatchlistActivityVisibility } from './lists/visibility.server.ts'
 import { listTypeNameForMediaKind } from './media-kind.ts'
 import { setMediaTrackingStatus } from './tracking-status.server.ts'
+import {
+	assertWatchlistCreationAllowed,
+	serializeUserLibraryMutation,
+	serializeWatchlistCreation,
+	WatchlistLimitError,
+} from './watchlist-limits.ts'
 
 export const libraryImportResolutions = [
 	'add',
@@ -236,6 +243,7 @@ async function ensureStatusWatchlist(
 			409,
 		)
 	}
+	await serializeWatchlistCreation(tx, input.ownerId)
 	const existing = await tx.watchlist.findFirst({
 		where: {
 			ownerId: input.ownerId,
@@ -246,6 +254,17 @@ async function ensureStatusWatchlist(
 		select: { id: true },
 	})
 	if (existing) return { id: existing.id, created: false }
+	try {
+		await assertWatchlistCreationAllowed(tx, {
+			ownerId: input.ownerId,
+			typeId: listType.id,
+		})
+	} catch (error) {
+		if (error instanceof WatchlistLimitError) {
+			throw new LibraryImportError(error.message, error.status)
+		}
+		throw error
+	}
 	const aggregate = await tx.watchlist.aggregate({
 		where: { ownerId: input.ownerId, typeId: listType.id },
 		_max: { position: true },
@@ -413,6 +432,7 @@ export async function applyLibraryImportBatch(
 	tx: Prisma.TransactionClient,
 	input: { ownerId: string; batchId: string },
 ) {
+	await serializeUserLibraryMutation(tx, input.ownerId)
 	const claim = await tx.libraryImportBatch.updateMany({
 		where: {
 			id: input.batchId,
@@ -509,6 +529,7 @@ export async function applyLibraryImportBatch(
 				progressCurrent: imported.progress[0]?.current,
 				progressTotal: imported.progress[0]?.total,
 				isPublic: false,
+				publicEligible: false,
 			},
 		})
 		const after = await memberMediaSnapshot(tx, input.ownerId, stored.mediaId)
@@ -604,6 +625,7 @@ async function restoreSnapshot(
 				actorId: input.ownerId,
 				mediaId: input.mediaId,
 				isPublic: false,
+				publicEligible: false,
 			},
 		})
 	} else {
@@ -669,6 +691,7 @@ async function restoreSnapshot(
 				status: tracking.status,
 				statusWatchlistId: tracking.statusWatchlistId,
 				isPublic: false,
+				publicEligible: false,
 			},
 		})
 	}
@@ -680,6 +703,7 @@ export async function rollbackLibraryImportBatch(
 	tx: Prisma.TransactionClient,
 	input: { ownerId: string; batchId: string },
 ) {
+	await serializeUserLibraryMutation(tx, input.ownerId)
 	const claim = await tx.libraryImportBatch.updateMany({
 		where: {
 			id: input.batchId,
@@ -735,9 +759,16 @@ export async function rollbackLibraryImportBatch(
 		})
 	}
 	for (const id of createdWatchlistIds) {
-		await tx.watchlist.deleteMany({
+		const createdWatchlist = await tx.watchlist.findFirst({
 			where: { id, ownerId: input.ownerId, entries: { none: {} } },
+			select: { id: true, ownerId: true, header: true },
 		})
+		if (!createdWatchlist) continue
+		await syncWatchlistActivityVisibility(tx, {
+			...createdWatchlist,
+			isPublic: false,
+		})
+		await tx.watchlist.delete({ where: { id: createdWatchlist.id } })
 	}
 	const rolledBackAt = new Date()
 	await tx.libraryImportBatch.update({

--- a/app/utils/library-import-commit.server.ts
+++ b/app/utils/library-import-commit.server.ts
@@ -3,7 +3,7 @@ import {
 	type LibraryImportItem as NormalizedImportItem,
 	libraryImportProviders,
 } from './library-import.ts'
-import { syncWatchlistActivityVisibility } from './lists/visibility.server.ts'
+import { syncWatchlistActivityVisibility } from './lists/activity-visibility.server.ts'
 import { listTypeNameForMediaKind } from './media-kind.ts'
 import { setMediaTrackingStatus } from './tracking-status.server.ts'
 import {

--- a/app/utils/lists/activity-visibility.server.ts
+++ b/app/utils/lists/activity-visibility.server.ts
@@ -1,0 +1,82 @@
+import { type Prisma } from '@prisma/client'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
+
+/**
+ * Keep verified tracking activity aligned with a list's visibility. This
+ * module deliberately has no request/session dependencies so imports,
+ * background jobs, and database smoke checks can use it without application
+ * credentials.
+ */
+export async function syncWatchlistActivityVisibility(
+	tx: Prisma.TransactionClient,
+	watchlist: { id: string; ownerId: string; header: string; isPublic: boolean },
+	previousHeader?: string,
+) {
+	await serializeUserLibraryMutation(tx, watchlist.ownerId)
+	const labels = [...new Set([watchlist.header, previousHeader])].filter(
+		(label): label is string => Boolean(label),
+	)
+	const linkedToWatchlist = {
+		OR: [
+			{ statusWatchlistId: watchlist.id },
+			{ previousStatusWatchlistId: watchlist.id },
+		],
+	} satisfies Prisma.ActivityEventWhereInput
+
+	if (labels.length) {
+		await tx.activityEvent.updateMany({
+			where: {
+				actorId: watchlist.ownerId,
+				publicEligible: false,
+				OR: labels.flatMap(label => [
+					{ statusWatchlistId: null, statusLabel: label },
+					{
+						previousStatusWatchlistId: null,
+						previousStatusLabel: label,
+					},
+				]),
+			},
+			data: { isPublic: false },
+		})
+	}
+
+	if (!watchlist.isPublic) {
+		await tx.activityEvent.updateMany({
+			where: linkedToWatchlist,
+			data: { isPublic: false },
+		})
+		return
+	}
+
+	// Recompute all linked rows fail-closed in two statements. Historical and
+	// private-created rows remain private; eligible rows are public only when
+	// both immutable list relations are currently public or genuinely absent.
+	await tx.activityEvent.updateMany({
+		where: linkedToWatchlist,
+		data: { isPublic: false },
+	})
+	await tx.activityEvent.updateMany({
+		where: {
+			...linkedToWatchlist,
+			publicEligible: true,
+			AND: [
+				{
+					OR: [
+						{ statusWatchlistId: null, statusLabel: null },
+						{ statusWatchlist: { isPublic: true } },
+					],
+				},
+				{
+					OR: [
+						{
+							previousStatusWatchlistId: null,
+							previousStatusLabel: null,
+						},
+						{ previousStatusWatchlist: { isPublic: true } },
+					],
+				},
+			],
+		},
+		data: { isPublic: true },
+	})
+}

--- a/app/utils/lists/bulk-list-commands.server.ts
+++ b/app/utils/lists/bulk-list-commands.server.ts
@@ -3,6 +3,7 @@ import {
 	deleteTrackingStateIfOrphan,
 	reconcileTrackingStateBeforeEntryDeletion,
 } from '#app/utils/tracking-state.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 import {
 	moveEntryToWatchlist,
 	normalizeEntryPositions,
@@ -23,6 +24,7 @@ export async function bulkDeleteEntriesCommand(
 ) {
 	const ids = uniqueIds(entryIds)
 	return prisma.$transaction(async tx => {
+		await serializeUserLibraryMutation(tx, ownerId)
 		const entries = await tx.entry.findMany({
 			where: { id: { in: ids }, watchlist: { ownerId } },
 			include: {
@@ -71,6 +73,7 @@ export async function bulkMoveEntriesCommand(
 ) {
 	const ids = uniqueIds(entryIds)
 	return prisma.$transaction(async tx => {
+		await serializeUserLibraryMutation(tx, ownerId)
 		const ownedCount = await tx.entry.count({
 			where: { id: { in: ids }, watchlist: { ownerId } },
 		})

--- a/app/utils/lists/entry-order.server.ts
+++ b/app/utils/lists/entry-order.server.ts
@@ -2,6 +2,7 @@ import { type Prisma } from '@prisma/client'
 import { mediaIdentityFromThumbnail } from '#app/utils/media-identity.ts'
 import { mediaKindMatchesListType } from '#app/utils/media-kind.ts'
 import { syncTrackingStateForEntry } from '#app/utils/tracking-state.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 import { claimWatchlistRevisions } from './watchlist-revision.server.ts'
 
 export class EntryOrderError extends Error {
@@ -60,6 +61,7 @@ export async function setWatchlistEntryOrder(
 		entryIds: string[]
 	},
 ) {
+	await serializeUserLibraryMutation(tx, input.ownerId)
 	const watchlist = await tx.watchlist.findFirst({
 		where: { id: input.watchlistId, ownerId: input.ownerId },
 		select: { id: true, mutationVersion: true },
@@ -98,6 +100,7 @@ export async function moveEntryToWatchlist(
 		position: number | null
 	},
 ) {
+	await serializeUserLibraryMutation(tx, input.ownerId)
 	const entry = await tx.entry.findUnique({
 		where: { id: input.entryId },
 		include: {

--- a/app/utils/lists/public-watchlist.server.ts
+++ b/app/utils/lists/public-watchlist.server.ts
@@ -1,3 +1,7 @@
+import { profileHistoryTimestamp } from '#app/utils/profile-history-bounds.ts'
+
+const PUBLIC_HISTORY_CODE_UNIT_LIMIT = 64 * 1024
+
 const publicEntryBaseFields = new Set([
 	'id',
 	'watchlistId',
@@ -5,12 +9,7 @@ const publicEntryBaseFields = new Set([
 	'position',
 	'thumbnail',
 	'title',
-	'type',
-	'personal',
-	'tmdbScore',
-	'malScore',
 	'media',
-	'trackingState',
 ])
 
 const publicEntryFields = new Set([
@@ -48,6 +47,117 @@ const publicEntryFields = new Set([
 	'type',
 	'volumes',
 ])
+
+const publicHistoryFields = [
+	'started',
+	'finished',
+	'added',
+	'lastUpdated',
+] as const
+
+const privateMirroredTrackingFields = [
+	'personal',
+	'differencePersonal',
+	'differenceObjective',
+	'history',
+	'length',
+	'chapters',
+	'volumes',
+] as const
+
+type TrackingStateVisibilityProbe = Record<string, unknown> & {
+	ownerId: string
+	mediaId: string
+	statusWatchlistId: string | null
+	statusWatchlist: { ownerId: string; isPublic: boolean } | null
+}
+
+type WatchlistEntryVisibilityProbe = Record<string, unknown> & {
+	mediaId: string | null
+	trackingState: TrackingStateVisibilityProbe | null
+	personal: unknown
+	differencePersonal: unknown
+	differenceObjective: unknown
+	history: unknown
+	length: unknown
+	chapters: unknown
+	volumes: unknown
+}
+
+type PublicTrackingState<TEntry extends WatchlistEntryVisibilityProbe> = Omit<
+	NonNullable<TEntry['trackingState']>,
+	| 'ownerId'
+	| 'mediaId'
+	| 'owner'
+	| 'media'
+	| 'statusWatchlistId'
+	| 'statusWatchlist'
+> & {
+	statusWatchlistId?: NonNullable<TEntry['trackingState']>['statusWatchlistId']
+}
+
+type PreparedWatchlistEntry<TEntry extends WatchlistEntryVisibilityProbe> =
+	Omit<TEntry, 'trackingState'> & {
+		trackingState: PublicTrackingState<TEntry> | null
+	}
+
+function withoutVisibilityProbe<TEntry extends WatchlistEntryVisibilityProbe>(
+	trackingState: NonNullable<TEntry['trackingState']>,
+	keepStatusWatchlistId: boolean,
+): PublicTrackingState<TEntry> {
+	const publicState: Record<string, unknown> = { ...trackingState }
+	delete publicState.ownerId
+	delete publicState.mediaId
+	delete publicState.owner
+	delete publicState.media
+	delete publicState.statusWatchlist
+	if (!keepStatusWatchlistId) delete publicState.statusWatchlistId
+	return publicState as PublicTrackingState<TEntry>
+}
+
+/**
+ * Remove the relation fields fetched only to enforce public-list privacy.
+ *
+ * A public duplicate can still point at the owner's canonical TrackingState
+ * whose current status lives on a private list. In that case the Entry's
+ * mirrored score/history/progress fields are private too and must not become
+ * normalization fallbacks.
+ */
+export function prepareWatchlistEntryForViewer<
+	TEntry extends WatchlistEntryVisibilityProbe,
+>(
+	entry: TEntry,
+	watchlistOwnerId: string,
+	isOwner: boolean,
+): PreparedWatchlistEntry<TEntry> {
+	const trackingState = entry.trackingState
+	const validIdentity =
+		trackingState &&
+		trackingState.ownerId === watchlistOwnerId &&
+		entry.mediaId !== null &&
+		trackingState.mediaId === entry.mediaId
+	const trackingStateVisible =
+		validIdentity &&
+		(isOwner ||
+			trackingState.statusWatchlistId === null ||
+			(trackingState.statusWatchlist?.ownerId === watchlistOwnerId &&
+				trackingState.statusWatchlist.isPublic))
+
+	const prepared = {
+		...entry,
+		trackingState: trackingState
+			? withoutVisibilityProbe<TEntry>(trackingState, isOwner)
+			: null,
+	} as PreparedWatchlistEntry<TEntry>
+
+	if (!trackingState || trackingStateVisible) return prepared
+
+	prepared.trackingState = null
+	for (const field of privateMirroredTrackingFields) {
+		;(prepared as Record<string, unknown>)[field] = null
+	}
+	return prepared
+}
 
 export const publicListOwnerSelect = {
 	id: true,
@@ -89,17 +199,55 @@ export function publicEntryPayload<
 	const visibleFields = new Set(
 		configuredFields.filter(field => publicEntryFields.has(field)),
 	)
-	if (
-		['started', 'finished', 'added', 'lastUpdated'].some(field =>
-			configuredFields.includes(field),
-		)
-	) {
-		visibleFields.add('history')
-	}
-
-	return Object.fromEntries(
+	const payload = Object.fromEntries(
 		Object.entries(entry).filter(
 			([key]) => publicEntryBaseFields.has(key) || visibleFields.has(key),
 		),
 	) as Pick<TEntry, 'watchlistId' | 'position'> & Record<string, unknown>
+
+	const visibleHistoryFields = publicHistoryFields.filter(field =>
+		configuredFields.includes(field),
+	)
+	if (visibleHistoryFields.length) {
+		let legacyHistory: Record<string, unknown> = {}
+		if (
+			typeof entry.history === 'string' &&
+			entry.history.length <= PUBLIC_HISTORY_CODE_UNIT_LIMIT
+		) {
+			try {
+				const parsed = JSON.parse(entry.history) as unknown
+				if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+					legacyHistory = parsed as Record<string, unknown>
+				}
+			} catch {
+				// Invalid legacy history is represented by null values below.
+			}
+		}
+		const trackingState =
+			entry.trackingState &&
+			typeof entry.trackingState === 'object' &&
+			!Array.isArray(entry.trackingState)
+				? (entry.trackingState as Record<string, unknown>)
+				: null
+		const history = Object.fromEntries(
+			visibleHistoryFields.map(field => {
+				const canonical =
+					field === 'started'
+						? trackingState?.startedAt
+						: field === 'finished'
+							? trackingState?.completedAt
+							: null
+				const timestamp = profileHistoryTimestamp(
+					canonical ?? legacyHistory[field],
+				)
+				return [
+					field,
+					timestamp === null ? null : new Date(timestamp).toISOString(),
+				]
+			}),
+		)
+		payload.history = JSON.stringify(history)
+	}
+
+	return payload
 }

--- a/app/utils/lists/visibility.server.ts
+++ b/app/utils/lists/visibility.server.ts
@@ -1,7 +1,5 @@
-import { type Prisma } from '@prisma/client'
 import { getUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
-import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 import { visibleWatchlistWhere } from './visibility.ts'
 
 export {
@@ -29,84 +27,4 @@ export async function requireVisibleWatchlist(
 		: null
 	if (!watchlist) throw new Response('Not found', { status: 404 })
 	return { viewerId, watchlist }
-}
-
-/**
- * Keep verified tracking activity aligned with a list's visibility. Legacy
- * label-only rows are quarantined rather than attached by mutable label. Both
- * branches use a fixed number of server-side updates, independent of history
- * size.
- */
-export async function syncWatchlistActivityVisibility(
-	tx: Prisma.TransactionClient,
-	watchlist: { id: string; ownerId: string; header: string; isPublic: boolean },
-	previousHeader?: string,
-) {
-	await serializeUserLibraryMutation(tx, watchlist.ownerId)
-	const labels = [...new Set([watchlist.header, previousHeader])].filter(
-		(label): label is string => Boolean(label),
-	)
-	const linkedToWatchlist = {
-		OR: [
-			{ statusWatchlistId: watchlist.id },
-			{ previousStatusWatchlistId: watchlist.id },
-		],
-	} satisfies Prisma.ActivityEventWhereInput
-
-	if (labels.length) {
-		await tx.activityEvent.updateMany({
-			where: {
-				actorId: watchlist.ownerId,
-				publicEligible: false,
-				OR: labels.flatMap(label => [
-					{ statusWatchlistId: null, statusLabel: label },
-					{
-						previousStatusWatchlistId: null,
-						previousStatusLabel: label,
-					},
-				]),
-			},
-			data: { isPublic: false },
-		})
-	}
-
-	if (!watchlist.isPublic) {
-		await tx.activityEvent.updateMany({
-			where: linkedToWatchlist,
-			data: { isPublic: false },
-		})
-		return
-	}
-
-	// Recompute all linked rows fail-closed in two statements. Historical and
-	// private-created rows remain private; eligible rows are public only when
-	// both immutable list relations are currently public or genuinely absent.
-	await tx.activityEvent.updateMany({
-		where: linkedToWatchlist,
-		data: { isPublic: false },
-	})
-	await tx.activityEvent.updateMany({
-		where: {
-			...linkedToWatchlist,
-			publicEligible: true,
-			AND: [
-				{
-					OR: [
-						{ statusWatchlistId: null, statusLabel: null },
-						{ statusWatchlist: { isPublic: true } },
-					],
-				},
-				{
-					OR: [
-						{
-							previousStatusWatchlistId: null,
-							previousStatusLabel: null,
-						},
-						{ previousStatusWatchlist: { isPublic: true } },
-					],
-				},
-			],
-		},
-		data: { isPublic: true },
-	})
 }

--- a/app/utils/lists/visibility.server.ts
+++ b/app/utils/lists/visibility.server.ts
@@ -1,9 +1,11 @@
 import { type Prisma } from '@prisma/client'
 import { getUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import { serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 import { visibleWatchlistWhere } from './visibility.ts'
 
 export {
+	publicActivityEventWhere,
 	publicTrackingStateWhere,
 	publicWatchlistWhere,
 	visibleActivityEventWhere,
@@ -30,51 +32,81 @@ export async function requireVisibleWatchlist(
 }
 
 /**
- * Keep historical tracking activity aligned with a list's visibility. Events
- * created after LIST-013 carry exact list ids. The label fallback safely hides
- * older rows created before those provenance columns existed.
+ * Keep verified tracking activity aligned with a list's visibility. Legacy
+ * label-only rows are quarantined rather than attached by mutable label. Both
+ * branches use a fixed number of server-side updates, independent of history
+ * size.
  */
 export async function syncWatchlistActivityVisibility(
 	tx: Prisma.TransactionClient,
 	watchlist: { id: string; ownerId: string; header: string; isPublic: boolean },
+	previousHeader?: string,
 ) {
-	if (!watchlist.isPublic) {
+	await serializeUserLibraryMutation(tx, watchlist.ownerId)
+	const labels = [...new Set([watchlist.header, previousHeader])].filter(
+		(label): label is string => Boolean(label),
+	)
+	const linkedToWatchlist = {
+		OR: [
+			{ statusWatchlistId: watchlist.id },
+			{ previousStatusWatchlistId: watchlist.id },
+		],
+	} satisfies Prisma.ActivityEventWhereInput
+
+	if (labels.length) {
 		await tx.activityEvent.updateMany({
 			where: {
 				actorId: watchlist.ownerId,
-				OR: [
-					{ statusWatchlistId: watchlist.id },
-					{ previousStatusWatchlistId: watchlist.id },
-					{ statusLabel: watchlist.header },
-					{ previousStatusLabel: watchlist.header },
-				],
+				publicEligible: false,
+				OR: labels.flatMap(label => [
+					{ statusWatchlistId: null, statusLabel: label },
+					{
+						previousStatusWatchlistId: null,
+						previousStatusLabel: label,
+					},
+				]),
 			},
+			data: { isPublic: false },
+		})
+	}
+
+	if (!watchlist.isPublic) {
+		await tx.activityEvent.updateMany({
+			where: linkedToWatchlist,
 			data: { isPublic: false },
 		})
 		return
 	}
 
-	const events = await tx.activityEvent.findMany({
+	// Recompute all linked rows fail-closed in two statements. Historical and
+	// private-created rows remain private; eligible rows are public only when
+	// both immutable list relations are currently public or genuinely absent.
+	await tx.activityEvent.updateMany({
+		where: linkedToWatchlist,
+		data: { isPublic: false },
+	})
+	await tx.activityEvent.updateMany({
 		where: {
-			actorId: watchlist.ownerId,
-			OR: [
-				{ statusWatchlistId: watchlist.id },
-				{ previousStatusWatchlistId: watchlist.id },
+			...linkedToWatchlist,
+			publicEligible: true,
+			AND: [
+				{
+					OR: [
+						{ statusWatchlistId: null, statusLabel: null },
+						{ statusWatchlist: { isPublic: true } },
+					],
+				},
+				{
+					OR: [
+						{
+							previousStatusWatchlistId: null,
+							previousStatusLabel: null,
+						},
+						{ previousStatusWatchlist: { isPublic: true } },
+					],
+				},
 			],
 		},
-		select: {
-			id: true,
-			statusWatchlist: { select: { isPublic: true } },
-			previousStatusWatchlist: { select: { isPublic: true } },
-		},
+		data: { isPublic: true },
 	})
-	for (const event of events) {
-		const isPublic =
-			(event.statusWatchlist?.isPublic ?? true) &&
-			(event.previousStatusWatchlist?.isPublic ?? true)
-		await tx.activityEvent.update({
-			where: { id: event.id },
-			data: { isPublic },
-		})
-	}
 }

--- a/app/utils/lists/visibility.ts
+++ b/app/utils/lists/visibility.ts
@@ -29,10 +29,34 @@ export function visibleTrackingStateWhere(viewerId: string | null) {
 		: publicTrackingStateWhere
 }
 
+/**
+ * Public activity must have immutable public-list provenance and must have
+ * been safe to disclose when created. Historical or private-created rows stay
+ * owner-only even if a related list is later made public.
+ */
+export const publicActivityEventWhere = {
+	isPublic: true,
+	publicEligible: true,
+	AND: [
+		{
+			OR: [
+				{ statusWatchlist: { isPublic: true } },
+				{ statusWatchlistId: null, statusLabel: null },
+			],
+		},
+		{
+			OR: [
+				{ previousStatusWatchlist: { isPublic: true } },
+				{ previousStatusWatchlistId: null, previousStatusLabel: null },
+			],
+		},
+	],
+} satisfies Prisma.ActivityEventWhereInput
+
 export function visibleActivityEventWhere(viewerId: string | null) {
 	return viewerId
 		? ({
-				OR: [{ isPublic: true }, { actorId: viewerId }],
+				OR: [publicActivityEventWhere, { actorId: viewerId }],
 			} satisfies Prisma.ActivityEventWhereInput)
-		: ({ isPublic: true } satisfies Prisma.ActivityEventWhereInput)
+		: publicActivityEventWhere
 }

--- a/app/utils/lists/watchlist-entry-scores.server.ts
+++ b/app/utils/lists/watchlist-entry-scores.server.ts
@@ -1,9 +1,4 @@
-type ScoreValue =
-	| number
-	| string
-	| { toString(): string }
-	| null
-	| undefined
+type ScoreValue = number | string | { toString(): string } | null | undefined
 
 type WatchlistEntryScores = {
 	averaged: ScoreValue
@@ -63,13 +58,17 @@ export type NormalizedWatchlistEntryScores<
 	trackingState: NormalizedTrackingState<TEntry['trackingState']>
 }
 
-function scoreNumber(value: ScoreValue) {
+export function scoreNumber(value: unknown) {
 	if (value === null || value === undefined || value === '') return null
-	const number = Number(value)
-	return Number.isFinite(number) ? number : null
+	try {
+		const number = Number(value)
+		return Number.isFinite(number) ? number : null
+	} catch {
+		return null
+	}
 }
 
-function preferredScore(primary: ScoreValue, fallback: ScoreValue) {
+export function preferredScore(primary: unknown, fallback: unknown) {
 	const primaryScore = scoreNumber(primary)
 	if (primaryScore !== null && primaryScore !== 0) return primaryScore
 	return scoreNumber(fallback)
@@ -86,10 +85,7 @@ function preferredScore(primary: ScoreValue, fallback: ScoreValue) {
 export function normalizeWatchlistEntryScores<
 	TEntry extends WatchlistEntryScores,
 >(entry: TEntry): NormalizedWatchlistEntryScores<TEntry> {
-	const personal = preferredScore(
-		entry.trackingState?.score,
-		entry.personal,
-	)
+	const personal = preferredScore(entry.trackingState?.score, entry.personal)
 	const tmdbScore = preferredScore(entry.media?.tmdbScore, entry.tmdbScore)
 	const malScore = preferredScore(entry.media?.malScore, entry.malScore)
 

--- a/app/utils/lists/watchlist-revision.server.ts
+++ b/app/utils/lists/watchlist-revision.server.ts
@@ -18,7 +18,9 @@ export async function claimWatchlistRevisions(
 		revisions.map(revision => [revision.id, revision.mutationVersion]),
 	)
 	const updatedAt = new Date()
-	for (const [id, mutationVersion] of unique) {
+	for (const [id, mutationVersion] of [...unique].sort(([a], [b]) =>
+		a.localeCompare(b),
+	)) {
 		const claim = await tx.watchlist.updateMany({
 			where: { id, mutationVersion },
 			data: {

--- a/app/utils/profile-activity.test.ts
+++ b/app/utils/profile-activity.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, test } from 'vitest'
+import {
+	createProfileActivityCollector,
+	PROFILE_ACTIVITY_ACTION_LENGTH_LIMIT,
+	PROFILE_ACTIVITY_BYTE_LIMIT,
+	PROFILE_ACTIVITY_MAX_CAPACITY,
+	PROFILE_ACTIVITY_THUMBNAIL_BYTE_LIMIT,
+	PROFILE_ACTIVITY_TITLE_LENGTH_LIMIT,
+	type ProfileActivityCollectorItem,
+} from './profile-activity.ts'
+
+function activity(
+	id: string,
+	time: Date | string,
+	overrides: Partial<ProfileActivityCollectorItem> = {},
+): ProfileActivityCollectorItem {
+	return {
+		id,
+		action: `Updated ${id}`,
+		time,
+		typeId: 'anime',
+		media: {
+			id: `media-${id}`,
+			title: `Title ${id}`,
+			thumbnail: `https://example.com/${id}.jpg`,
+		},
+		...overrides,
+	}
+}
+
+describe('createProfileActivityCollector', () => {
+	test('keeps the newest 100 rows across incremental pages', () => {
+		const collector = createProfileActivityCollector()
+		const rows = Array.from({ length: 145 }, (_, index) =>
+			activity(
+				`activity-${index.toString().padStart(3, '0')}`,
+				new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(),
+			),
+		)
+
+		collector.addBatch(rows.slice(0, 47))
+		expect(collector.size).toBe(47)
+		collector.addBatch(rows.slice(47, 103))
+		expect(collector.size).toBe(PROFILE_ACTIVITY_MAX_CAPACITY)
+		collector.addBatch(rows.slice(103))
+
+		const expected = [...rows]
+			.sort(
+				(left, right) =>
+					new Date(right.time).getTime() - new Date(left.time).getTime() ||
+					right.id.localeCompare(left.id),
+			)
+			.slice(0, PROFILE_ACTIVITY_MAX_CAPACITY)
+
+		expect(collector.size).toBe(PROFILE_ACTIVITY_MAX_CAPACITY)
+		expect(collector.truncated).toBe(true)
+		expect(collector.values().map(item => item.id)).toEqual(
+			expected.map(item => item.id),
+		)
+	})
+
+	test('discards an older batch added after the collector is full', () => {
+		const collector = createProfileActivityCollector()
+		const recent = Array.from({ length: 100 }, (_, index) =>
+			activity(`recent-${index}`, new Date(Date.UTC(2026, 6, 1, 0, index))),
+		)
+		const older = Array.from({ length: 80 }, (_, index) =>
+			activity(`older-${index}`, new Date(Date.UTC(1990, 0, 1, 0, index))),
+		)
+
+		collector.addBatch(recent)
+		expect(collector.truncated).toBe(false)
+		const before = collector.values().map(item => item.id)
+		collector.addBatch(older)
+
+		expect(collector.size).toBe(100)
+		expect(collector.truncated).toBe(true)
+		expect(collector.values().map(item => item.id)).toEqual(before)
+	})
+
+	test('marks a displaced retained row as truncated', () => {
+		const collector = createProfileActivityCollector(2)
+		collector.addBatch([
+			activity('oldest', '2026-01-01T00:00:00.000Z'),
+			activity('middle', '2026-02-01T00:00:00.000Z'),
+		])
+
+		expect(collector.truncated).toBe(false)
+		collector.addBatch([activity('newest', '2026-03-01T00:00:00.000Z')])
+
+		expect(collector.truncated).toBe(true)
+		expect(collector.values().map(item => item.id)).toEqual([
+			'newest',
+			'middle',
+		])
+	})
+
+	test('uses descending ids for equal timestamps and preserves exact ties', () => {
+		const collector = createProfileActivityCollector(6)
+		const sameTime = '2026-07-28T18:30:00.000Z'
+
+		collector.addBatch([
+			activity('alpha', sameTime, { action: 'first alpha' }),
+			activity('charlie', new Date(sameTime)),
+		])
+		collector.addBatch([
+			activity('bravo', sameTime),
+			activity('alpha', new Date(sameTime), { action: 'second alpha' }),
+		])
+
+		expect(collector.values().map(item => [item.id, item.action])).toEqual([
+			['charlie', 'Updated charlie'],
+			['bravo', 'Updated bravo'],
+			['alpha', 'first alpha'],
+			['alpha', 'second alpha'],
+		])
+	})
+
+	test('rejects invalid dates without partially applying a batch', () => {
+		const collector = createProfileActivityCollector(4)
+		collector.addBatch([activity('existing', '2026-01-01T00:00:00.000Z')])
+
+		expect(() =>
+			collector.addBatch([
+				activity('valid', '2027-01-01T00:00:00.000Z'),
+				activity('invalid-string', 'not-a-date'),
+			]),
+		).toThrowError(TypeError)
+		expect(collector.values().map(item => item.id)).toEqual(['existing'])
+		expect(collector.truncated).toBe(true)
+
+		for (const [index, invalidTime] of [
+			new Date(Number.NaN),
+			new Date(0),
+			'0',
+			' ',
+			0,
+			false,
+			[],
+			{},
+		].entries()) {
+			expect(() =>
+				collector.addBatch([
+					activity(`invalid-date-${index}`, invalidTime as Date | string),
+				]),
+			).toThrowError(TypeError)
+			expect(collector.values().map(item => item.id)).toEqual(['existing'])
+			expect(collector.truncated).toBe(true)
+		}
+	})
+
+	test('clips hostile display strings and removes unsafe oversized thumbnails', () => {
+		const collector = createProfileActivityCollector(2)
+		const hostileLength = 512 * 1024
+		collector.addBatch([
+			activity('hostile', '2026-07-28T18:30:00.000Z', {
+				action: 'a'.repeat(hostileLength),
+				media: {
+					id: 'media-hostile',
+					title: '😀'.repeat(hostileLength),
+					thumbnail: 'é'.repeat(
+						Math.floor(PROFILE_ACTIVITY_THUMBNAIL_BYTE_LIMIT / 2) + 1,
+					),
+				},
+			}),
+		])
+
+		const [item] = collector.values()
+		expect(Array.from(item!.action)).toHaveLength(
+			PROFILE_ACTIVITY_ACTION_LENGTH_LIMIT,
+		)
+		expect(item!.action.endsWith('…')).toBe(true)
+		expect(Array.from(item!.media.title)).toHaveLength(
+			PROFILE_ACTIVITY_TITLE_LENGTH_LIMIT,
+		)
+		expect(item!.media.title.endsWith('…')).toBe(true)
+		expect(item!.media.thumbnail).toBeNull()
+		expect(collector.truncated).toBe(true)
+		expect(collector.byteSize).toBeLessThanOrEqual(collector.byteLimit)
+	})
+
+	test('accepts the exact serialized byte boundary and rejects one byte more', () => {
+		const textEncoder = new TextEncoder()
+		const template = {
+			...activity('exact', '2026-07-28T18:30:00.000Z'),
+			padding: '',
+		}
+		const baseBytes = textEncoder.encode(JSON.stringify(template)).byteLength
+		const exact = {
+			...template,
+			padding: 'x'.repeat(PROFILE_ACTIVITY_BYTE_LIMIT - 2 - baseBytes),
+		}
+		const over = { ...exact, padding: `${exact.padding}x` }
+
+		const exactCollector = createProfileActivityCollector<typeof exact>(1)
+		exactCollector.addBatch([exact])
+		expect(exactCollector.size).toBe(1)
+		expect(exactCollector.byteSize).toBe(PROFILE_ACTIVITY_BYTE_LIMIT)
+		expect(exactCollector.truncated).toBe(false)
+
+		const overCollector = createProfileActivityCollector<typeof over>(1)
+		overCollector.addBatch([over])
+		expect(overCollector.size).toBe(0)
+		expect(overCollector.byteSize).toBe(2)
+		expect(overCollector.truncated).toBe(true)
+	})
+
+	test('uses the byte budget to retain the newer prefix deterministically', () => {
+		const collector = createProfileActivityCollector<
+			ProfileActivityCollectorItem & { padding: string }
+		>(3)
+		const older = {
+			...activity('older-large', '2025-01-01T00:00:00.000Z'),
+			padding: 'x'.repeat(50 * 1024),
+		}
+		const newer = {
+			...activity('newer', '2026-01-01T00:00:00.000Z'),
+			padding: 'y'.repeat(20 * 1024),
+		}
+
+		collector.addBatch([older])
+		expect(collector.values().map(item => item.id)).toEqual(['older-large'])
+		collector.addBatch([newer])
+
+		expect(collector.values().map(item => item.id)).toEqual(['newer'])
+		expect(collector.truncated).toBe(true)
+		expect(collector.byteSize).toBe(
+			new TextEncoder().encode(JSON.stringify(collector.values())).byteLength,
+		)
+	})
+
+	test('does not mark exact action and title limits as clipped', () => {
+		const exactCollector = createProfileActivityCollector(1)
+		exactCollector.addBatch([
+			activity('exact-text', '2026-01-01T00:00:00.000Z', {
+				action: 'a'.repeat(PROFILE_ACTIVITY_ACTION_LENGTH_LIMIT),
+				media: {
+					id: 'media-exact-text',
+					title: 't'.repeat(PROFILE_ACTIVITY_TITLE_LENGTH_LIMIT),
+					thumbnail: null,
+				},
+			}),
+		])
+		expect(exactCollector.truncated).toBe(false)
+
+		const clippedCollector = createProfileActivityCollector(1)
+		clippedCollector.addBatch([
+			activity('clipped-text', '2026-01-01T00:00:00.000Z', {
+				action: 'a'.repeat(PROFILE_ACTIVITY_ACTION_LENGTH_LIMIT + 1),
+				media: {
+					id: 'media-clipped-text',
+					title: 't'.repeat(PROFILE_ACTIVITY_TITLE_LENGTH_LIMIT + 1),
+					thumbnail: null,
+				},
+			}),
+		])
+		expect(clippedCollector.truncated).toBe(true)
+	})
+
+	test('marks unencodable rows as rejected without retaining them', () => {
+		const collector = createProfileActivityCollector<
+			ProfileActivityCollectorItem & { invalid: bigint }
+		>(1)
+		collector.addBatch([
+			{
+				...activity('bigint', '2026-01-01T00:00:00.000Z'),
+				invalid: BigInt(1),
+			},
+		])
+
+		expect(collector.values()).toEqual([])
+		expect(collector.truncated).toBe(true)
+	})
+
+	test('supports zero capacity and rejects unsafe capacities', () => {
+		const collector = createProfileActivityCollector(0)
+		collector.addBatch([activity('ignored', '2026-01-01T00:00:00.000Z')])
+
+		expect(collector.capacity).toBe(0)
+		expect(collector.byteLimit).toBe(PROFILE_ACTIVITY_BYTE_LIMIT)
+		expect(collector.byteSize).toBe(2)
+		expect(collector.size).toBe(0)
+		expect(collector.truncated).toBe(true)
+		expect(collector.values()).toEqual([])
+		expect(Object.isFrozen(collector.values())).toBe(true)
+
+		for (const capacity of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			expect(() => createProfileActivityCollector(capacity)).toThrowError(
+				RangeError,
+			)
+		}
+		expect(() =>
+			createProfileActivityCollector(PROFILE_ACTIVITY_MAX_CAPACITY + 1),
+		).toThrowError(RangeError)
+	})
+
+	test('isolates retained values from input and result mutation', () => {
+		const collector = createProfileActivityCollector(2)
+		const inputTime = new Date('2026-07-28T18:30:00.000Z')
+		const input = activity('isolated', inputTime)
+
+		collector.addBatch([input])
+		input.action = 'Mutated input'
+		input.media.title = 'Mutated input title'
+		inputTime.setUTCFullYear(1999)
+
+		const first = collector.values()
+		expect(first[0]).toMatchObject({
+			action: 'Updated isolated',
+			media: { title: 'Title isolated' },
+		})
+		expect(new Date(first[0]!.time).getUTCFullYear()).toBe(2026)
+		expect(Object.isFrozen(first)).toBe(true)
+		expect(Object.isFrozen(first[0])).toBe(true)
+		expect(Object.isFrozen(first[0]!.media)).toBe(true)
+		const mutableFirst = first[0] as { action: string }
+		expect(() => {
+			mutableFirst.action = 'Mutated result'
+		}).toThrowError(TypeError)
+
+		if (first[0]!.time instanceof Date) {
+			first[0]!.time.setUTCFullYear(2001)
+		}
+		const second = collector.values()
+		expect(second).not.toBe(first)
+		expect(second[0]).not.toBe(first[0])
+		expect(second[0]!.media).not.toBe(first[0]!.media)
+		expect(new Date(second[0]!.time).getUTCFullYear()).toBe(2026)
+	})
+})

--- a/app/utils/profile-activity.ts
+++ b/app/utils/profile-activity.ts
@@ -1,0 +1,277 @@
+export const PROFILE_ACTIVITY_MAX_CAPACITY = 100
+export const PROFILE_ACTIVITY_ACTION_LENGTH_LIMIT = 160
+export const PROFILE_ACTIVITY_TITLE_LENGTH_LIMIT = 300
+export const PROFILE_ACTIVITY_THUMBNAIL_BYTE_LIMIT = 2_048
+export const PROFILE_ACTIVITY_RESPONSE_BYTE_LIMIT = 64 * 1024
+// Reserve space for the loader's object envelope and truncation diagnostic.
+export const PROFILE_ACTIVITY_BYTE_LIMIT =
+	PROFILE_ACTIVITY_RESPONSE_BYTE_LIMIT - 4 * 1024
+
+export type ProfileActivityCollectorItem = {
+	id: string
+	action: string
+	time: Date | string
+	typeId: string | null
+	media: {
+		id: string
+		title: string
+		thumbnail: string | null
+	}
+}
+
+type DeepReadonly<Value> = Value extends Date
+	? Readonly<Date>
+	: Value extends readonly (infer Item)[]
+		? readonly DeepReadonly<Item>[]
+		: Value extends object
+			? { readonly [Key in keyof Value]: DeepReadonly<Value[Key]> }
+			: Value
+
+type RankedActivity<Item extends ProfileActivityCollectorItem> = {
+	item: DeepReadonly<Item>
+	timestamp: number
+	serialized: string
+	serializedBytes: number
+}
+
+export type ProfileActivityCollector<
+	Item extends ProfileActivityCollectorItem,
+> = Readonly<{
+	capacity: number
+	byteLimit: number
+	byteSize: number
+	size: number
+	truncated: boolean
+	addBatch: (items: readonly Item[]) => void
+	values: () => readonly DeepReadonly<Item>[]
+}>
+
+function deepFreeze<Value>(value: Value, seen = new WeakSet<object>()): Value {
+	if (value === null || typeof value !== 'object') return value
+	if (seen.has(value)) return value
+	seen.add(value)
+
+	for (const child of Object.values(value)) {
+		deepFreeze(child, seen)
+	}
+
+	return Object.freeze(value)
+}
+
+function cloneAndFreeze<Item extends ProfileActivityCollectorItem>(item: Item) {
+	return deepFreeze(structuredClone(item)) as DeepReadonly<Item>
+}
+
+function activityTimestamp(item: ProfileActivityCollectorItem) {
+	if (!(item.time instanceof Date) && typeof item.time !== 'string') {
+		throw new TypeError(`Profile activity ${item.id} has an invalid time.`)
+	}
+
+	const timestamp =
+		item.time instanceof Date
+			? item.time.getTime()
+			: item.time.trim() && item.time.trim() !== '0'
+				? Date.parse(item.time.trim())
+				: Number.NaN
+	if (!Number.isFinite(timestamp) || timestamp === 0) {
+		throw new TypeError(`Profile activity ${item.id} has an invalid time.`)
+	}
+	return timestamp
+}
+
+function validateActivityItem(item: ProfileActivityCollectorItem) {
+	if (
+		typeof item.id !== 'string' ||
+		typeof item.action !== 'string' ||
+		(item.typeId !== null && typeof item.typeId !== 'string') ||
+		!item.media ||
+		typeof item.media !== 'object' ||
+		typeof item.media.id !== 'string' ||
+		typeof item.media.title !== 'string' ||
+		(item.media.thumbnail !== null && typeof item.media.thumbnail !== 'string')
+	) {
+		throw new TypeError('Profile activity has an invalid row shape.')
+	}
+	activityTimestamp(item)
+}
+
+function utf8ByteLength(value: string) {
+	return new TextEncoder().encode(value).byteLength
+}
+
+function truncateText(value: string, limit: number) {
+	const characters = Array.from(value)
+	if (characters.length <= limit) return { value, truncated: false }
+	return {
+		value: `${characters.slice(0, limit - 1).join('')}…`,
+		truncated: true,
+	}
+}
+
+function normalizeActivityItem<Item extends ProfileActivityCollectorItem>(
+	item: Item,
+) {
+	const action = truncateText(item.action, PROFILE_ACTIVITY_ACTION_LENGTH_LIMIT)
+	const title = truncateText(
+		item.media.title,
+		PROFILE_ACTIVITY_TITLE_LENGTH_LIMIT,
+	)
+	const thumbnailOverLimit =
+		item.media.thumbnail !== null &&
+		utf8ByteLength(item.media.thumbnail) > PROFILE_ACTIVITY_THUMBNAIL_BYTE_LIMIT
+	const normalized = {
+		...item,
+		action: action.value,
+		media: {
+			...item.media,
+			title: title.value,
+			thumbnail: thumbnailOverLimit ? null : item.media.thumbnail,
+		},
+	} as Item
+
+	return {
+		item: normalized,
+		truncated: action.truncated || title.truncated || thumbnailOverLimit,
+	}
+}
+
+function compareActivity<Item extends ProfileActivityCollectorItem>(
+	left: RankedActivity<Item>,
+	right: RankedActivity<Item>,
+) {
+	return (
+		right.timestamp - left.timestamp ||
+		right.item.id.localeCompare(left.item.id) ||
+		left.item.action.localeCompare(right.item.action) ||
+		left.item.media.id.localeCompare(right.item.media.id) ||
+		left.item.media.title.localeCompare(right.item.media.title) ||
+		(left.item.media.thumbnail ?? '').localeCompare(
+			right.item.media.thumbnail ?? '',
+		) ||
+		(left.item.typeId ?? '').localeCompare(right.item.typeId ?? '') ||
+		left.serialized.localeCompare(right.serialized)
+	)
+}
+
+function validateCapacity(capacity: number) {
+	if (
+		!Number.isInteger(capacity) ||
+		capacity < 0 ||
+		capacity > PROFILE_ACTIVITY_MAX_CAPACITY
+	) {
+		throw new RangeError(
+			`Profile activity capacity must be an integer between 0 and ${PROFILE_ACTIVITY_MAX_CAPACITY}.`,
+		)
+	}
+	return capacity
+}
+
+/**
+ * Keeps only the newest profile activity rows while legacy history is scanned
+ * in pages. Timestamp, id, and normalized row fields provide deterministic
+ * ordering; fully identical rows retain their stable insertion order.
+ */
+export function createProfileActivityCollector<
+	Item extends ProfileActivityCollectorItem,
+>(capacity = PROFILE_ACTIVITY_MAX_CAPACITY): ProfileActivityCollector<Item> {
+	const boundedCapacity = validateCapacity(capacity)
+	const ranked: RankedActivity<Item>[] = []
+	let truncated = false
+	let byteSize = 2
+
+	function insert(candidate: RankedActivity<Item>) {
+		if (boundedCapacity === 0) {
+			truncated = true
+			return
+		}
+		if (candidate.serializedBytes + 2 > PROFILE_ACTIVITY_BYTE_LIMIT) {
+			truncated = true
+			return
+		}
+
+		let index = 0
+		while (
+			index < ranked.length &&
+			compareActivity(candidate, ranked[index]!) >= 0
+		) {
+			index++
+		}
+		const previousLength = ranked.length
+		ranked.splice(index, 0, candidate)
+		byteSize += candidate.serializedBytes + (previousLength > 0 ? 1 : 0)
+
+		while (
+			ranked.length > boundedCapacity ||
+			byteSize > PROFILE_ACTIVITY_BYTE_LIMIT
+		) {
+			const removed = ranked.pop()
+			if (!removed) break
+			byteSize -= removed.serializedBytes + (ranked.length > 0 ? 1 : 0)
+			truncated = true
+		}
+	}
+
+	function addBatch(items: readonly Item[]) {
+		// Validate the complete batch before changing collector state. This keeps
+		// invalid input rejection transactional without retaining a page copy.
+		try {
+			for (const item of items) validateActivityItem(item)
+		} catch (error) {
+			truncated = true
+			throw error
+		}
+
+		for (const item of items) {
+			const normalized = normalizeActivityItem(item)
+			if (normalized.truncated) truncated = true
+			let serialized: string
+			try {
+				serialized = JSON.stringify(normalized.item)
+				if (typeof serialized !== 'string') throw new TypeError()
+			} catch {
+				truncated = true
+				continue
+			}
+			const serializedBytes = utf8ByteLength(serialized)
+			if (serializedBytes + 2 > PROFILE_ACTIVITY_BYTE_LIMIT) {
+				truncated = true
+				continue
+			}
+			let frozen: DeepReadonly<Item>
+			try {
+				frozen = cloneAndFreeze(normalized.item)
+			} catch {
+				truncated = true
+				continue
+			}
+			insert({
+				item: frozen,
+				timestamp: activityTimestamp(item),
+				serialized,
+				serializedBytes,
+			})
+		}
+	}
+
+	function values() {
+		return Object.freeze(
+			ranked.map(candidate => cloneAndFreeze(candidate.item as Item)),
+		)
+	}
+
+	return Object.freeze({
+		capacity: boundedCapacity,
+		byteLimit: PROFILE_ACTIVITY_BYTE_LIMIT,
+		get byteSize() {
+			return byteSize
+		},
+		get size() {
+			return ranked.length
+		},
+		get truncated() {
+			return truncated
+		},
+		addBatch,
+		values,
+	})
+}

--- a/app/utils/profile-analytics.test.ts
+++ b/app/utils/profile-analytics.test.ts
@@ -1,0 +1,560 @@
+import { expect, test } from 'vitest'
+import {
+	createProfileAnalyticsAccumulator,
+	createProfileAnalyticsCategoryAccumulator,
+	finalizeProfileAnalytics,
+	PROFILE_COMPONENT_SCORE_FIELDS,
+	PROFILE_ANALYTICS_CATEGORY_CANDIDATE_LIMIT,
+	PROFILE_ANALYTICS_CATEGORY_SOURCE_CODE_UNIT_LIMIT,
+	PROFILE_ANALYTICS_COMPLETION_DAY_LIMIT,
+	PROFILE_ANALYTICS_ENTRY_LIMIT,
+	type ProfileAnalyticsEntry,
+} from './profile-analytics.ts'
+import {
+	PROFILE_HISTORY_CODE_UNIT_LIMIT,
+	PROFILE_HISTORY_EVENT_LIMIT,
+} from './profile-history-bounds.ts'
+
+const listTypes = [
+	{ id: 'live', name: 'liveaction' },
+	{ id: 'anime', name: 'anime' },
+	{ id: 'manga', name: 'manga' },
+]
+const watchlists = [
+	{ id: 'live-list', typeId: 'live' },
+	{ id: 'anime-list', typeId: 'anime' },
+	{ id: 'manga-list', typeId: 'manga' },
+]
+
+function entry(
+	watchlistId: string,
+	overrides: Omit<Partial<ProfileAnalyticsEntry>, 'watchlistId'> = {},
+): ProfileAnalyticsEntry {
+	return { watchlistId, ...overrides }
+}
+
+function aggregate(
+	entries: ProfileAnalyticsEntry[],
+	options: { entryLimit?: number; now?: Date } = {},
+) {
+	const firstAccumulator = createProfileAnalyticsAccumulator({
+		listTypes,
+		watchlists,
+		...options,
+	})
+	firstAccumulator.addMany(entries)
+	const firstPass = firstAccumulator.finish()
+	const categoryAccumulator = createProfileAnalyticsCategoryAccumulator({
+		listTypes,
+		watchlists,
+		plan: firstPass.categoryPlan,
+		entryLimit: options.entryLimit,
+	})
+	categoryAccumulator.addMany(entries)
+	const categories = categoryAccumulator.finish()
+	return {
+		firstPass,
+		categories,
+		result: finalizeProfileAnalytics(firstPass, categories),
+	}
+}
+
+test('aggregates fixed score buckets and decimal objective summaries by provider', () => {
+	const { result } = aggregate([
+		entry('live-list', {
+			story: 1,
+			character: 9.9,
+			personal: 8.1,
+			tmdbScore: 10,
+			malScore: 2,
+		}),
+		entry('live-list', {
+			story: 1.9,
+			personal: 8.2,
+			tmdbScore: 10,
+		}),
+		entry('live-list', {
+			personal: 10,
+			tmdbScore: 9.9,
+		}),
+		entry('anime-list', {
+			personal: 4.5,
+			tmdbScore: 8,
+			malScore: 10,
+		}),
+		entry('manga-list', {
+			personal: 7.4,
+			tmdbScore: 7,
+			malScore: 6,
+		}),
+	])
+
+	expect(result.listTypeCounts).toEqual({ live: 3, anime: 1, manga: 1 })
+	expect(result.scoreBuckets.live.story).toEqual([2, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+	expect(result.scoreBuckets.live.character).toEqual([
+		0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+	])
+	expect(result.scoreBuckets.live.personal).toEqual([
+		0, 0, 0, 0, 0, 0, 0, 2, 0, 1,
+	])
+	expect(result.providerScoreBuckets.live.tmdbScore).toEqual([
+		0, 0, 0, 0, 0, 0, 0, 0, 1, 2,
+	])
+	for (const field of PROFILE_COMPONENT_SCORE_FIELDS) {
+		expect(result.scoreBuckets.anime[field]).toHaveLength(10)
+	}
+
+	expect(result.objectiveScores.live.source).toBe('tmdbScore')
+	expect(result.objectiveScores.live.groups).toEqual([
+		{
+			score: 9,
+			min: 10,
+			q1: 10,
+			median: 10,
+			q3: 10,
+			max: 10,
+			mean: 10,
+			count: 1,
+		},
+		{
+			score: 10,
+			min: 8.1,
+			q1: 8.125,
+			median: 8.15,
+			q3: 8.175,
+			max: 8.2,
+			mean: 8.15,
+			count: 2,
+		},
+	])
+	expect(result.objectiveScores.anime).toEqual({
+		source: 'malScore',
+		groups: [
+			{
+				score: 10,
+				min: 4.5,
+				q1: 4.5,
+				median: 4.5,
+				q3: 4.5,
+				max: 4.5,
+				mean: 4.5,
+				count: 1,
+			},
+		],
+	})
+	expect(result.objectiveScores.manga.source).toBe('malScore')
+	expect(result.objectiveScores.manga.groups[0]?.score).toBe(6)
+})
+
+test('bounds release and finished-year series while deduplicating exact entry timestamps', () => {
+	const now = new Date('2026-07-28T12:00:00.000Z')
+	const { result } = aggregate(
+		[
+			entry('live-list', {
+				airYear: '1869',
+				history: { finished: '1869-01-01T00:00:00.000Z' },
+			}),
+			entry('live-list', {
+				airYear: 'Released in 1870',
+				history: {
+					finished: '1870-01-01T00:00:00.000Z',
+					progress: {
+						1: {
+							finishDate: [
+								'1870-01-01T00:00:00.000Z',
+								'1870-01-01T01:00:00.000Z',
+							],
+						},
+					},
+				},
+			}),
+			entry('live-list', {
+				airYear: '2031',
+				history: JSON.stringify({
+					finished: '2031-01-01T00:00:00.000Z',
+				}),
+			}),
+			entry('live-list', {
+				airYear: '2032',
+				history: { finished: '2032-01-01T00:00:00.000Z' },
+			}),
+			entry('anime-list', {
+				startSeason: null,
+				releaseStart: '2024-04-01T00:00:00.000Z',
+				history: {
+					finished: '2026-01-03T12:00:00.000Z',
+					progress: {
+						episode: {
+							1: {
+								finishDate: [
+									'2026-01-03T12:00:00.000Z',
+									'2026-01-03T18:00:00.000Z',
+								],
+							},
+						},
+					},
+				},
+			}),
+			entry('anime-list', {
+				history: {
+					finished: '2026-01-03T12:00:00.000Z',
+				},
+			}),
+		],
+		{ now },
+	)
+
+	expect(result.releaseYears.live).toEqual([
+		{ year: 1870, count: 1 },
+		{ year: 2031, count: 1 },
+	])
+	expect(result.releaseYears.anime).toEqual([{ year: 2024, count: 1 }])
+	expect(result.completionYears.live).toEqual([
+		{ year: 1870, count: 1 },
+		{ year: 2031, count: 1 },
+	])
+	expect(result.completionYears.anime).toEqual([{ year: 2026, count: 2 }])
+	expect(
+		result.completionDays.find(day => day.day === '1870-01-01')?.value,
+	).toBe(2)
+	expect(
+		result.completionDays.find(day => day.day === '2026-01-03')?.value,
+	).toBe(3)
+	expect(result.completionDays.some(day => day.day.startsWith('1869'))).toBe(
+		false,
+	)
+	expect(result.completionDays.some(day => day.day.startsWith('2032'))).toBe(
+		false,
+	)
+})
+
+test('rejects coercible non-date history values from completion analytics', () => {
+	const { result } = aggregate(
+		[false, [], {}, 0, '0'].map(value =>
+			entry('anime-list', {
+				releaseStart: value,
+				history: {
+					finished: value,
+					progress: { 1: { finishDate: [value] } },
+				},
+			}),
+		),
+	)
+
+	expect(result.releaseYears.anime).toEqual([])
+	expect(result.completionYears.anime).toEqual([])
+	expect(result.completionDays).toEqual([])
+})
+
+test('retains only the latest 1000 sparse UTC completion days and reports truncation', () => {
+	const start = Date.UTC(2000, 0, 1)
+	const entries = Array.from(
+		{ length: PROFILE_ANALYTICS_COMPLETION_DAY_LIMIT + 2 },
+		(_, index) =>
+			entry('anime-list', {
+				history: {
+					finished: new Date(start + index * 86_400_000).toISOString(),
+				},
+			}),
+	)
+	const accumulator = createProfileAnalyticsAccumulator({
+		listTypes,
+		watchlists,
+		now: new Date('2026-07-28T12:00:00.000Z'),
+	})
+	accumulator.addMany(entries)
+	const result = accumulator.finish()
+
+	expect(result.completionDays).toHaveLength(
+		PROFILE_ANALYTICS_COMPLETION_DAY_LIMIT,
+	)
+	expect(result.completionDays[0]?.day).toBe('2000-01-03')
+	expect(result.completionDays.at(-1)?.day).toBe(
+		new Date(start + (PROFILE_ANALYTICS_COMPLETION_DAY_LIMIT + 1) * 86_400_000)
+			.toISOString()
+			.slice(0, 10),
+	)
+	expect(result.diagnostic.completionDaysTruncated).toBe(true)
+})
+
+test('uses a bounded candidate pass then produces exact top counts and matrices', () => {
+	const categoryEntries = [
+		entry('anime-list', {
+			genres: 'Action, Drama, action',
+			type: 'TV',
+		}),
+		entry('anime-list', { genres: 'action', type: 'tv' }),
+		entry('anime-list', { genres: 'Action', type: 'Movie' }),
+		entry('anime-list', { genres: 'Drama', type: 'OVA' }),
+		...Array.from({ length: 25 }, (_, index) =>
+			entry('anime-list', {
+				genres: `Genre ${String(index).padStart(2, '0')}`,
+				type: `Type ${String(index).padStart(2, '0')}`,
+			}),
+		),
+	]
+	const { categories, result } = aggregate(categoryEntries)
+	const genreCounts = categories.genreCounts.anime
+	const mediaTypeCounts = result.mediaTypeCounts.anime
+
+	expect(genreCounts.slice(0, 2)).toEqual([
+		{ key: 'action', label: 'Action', count: 3 },
+		{ key: 'drama', label: 'Drama', count: 2 },
+	])
+	expect(genreCounts).toHaveLength(25)
+	expect(genreCounts.at(-1)).toEqual({
+		key: '__veud_category_rollup__',
+		label: 'All other genres',
+		count: 3,
+		isRollup: true,
+	})
+	expect(mediaTypeCounts[0]).toEqual({ key: 'tv', label: 'TV', count: 2 })
+	expect(mediaTypeCounts.at(-1)).toEqual({
+		key: '__veud_category_rollup__',
+		label: 'All other types',
+		count: 4,
+		isRollup: true,
+	})
+
+	const matrix = result.genreMatrices.anime
+	const action = matrix.labels.indexOf('Action')
+	const drama = matrix.labels.indexOf('Drama')
+	expect(matrix.values[action]?.[action]).toBe(0)
+	expect(matrix.values[action]?.[drama]).toBe(1)
+	expect(matrix.values[drama]?.[action]).toBe(1)
+	expect(matrix.values[drama]?.[drama]).toBe(0)
+	expect(matrix.labels).toHaveLength(24)
+	expect(result.diagnostic.categoryCandidatesApproximate).toBe(false)
+	expect(result.diagnostic.categoryCandidatesTruncated).toBe(false)
+})
+
+test('enforces the server processing ceiling and rejects mismatched passes', () => {
+	expect(PROFILE_ANALYTICS_ENTRY_LIMIT).toBe(100_000)
+	const firstAccumulator = createProfileAnalyticsAccumulator({
+		listTypes,
+		watchlists,
+		entryLimit: 2,
+	})
+	expect(
+		firstAccumulator.addMany([
+			entry('live-list'),
+			entry('anime-list'),
+			entry('manga-list'),
+		]),
+	).toBe(2)
+	const firstPass = firstAccumulator.finish()
+
+	expect(firstPass.diagnostic).toEqual({
+		processed: 2,
+		truncated: true,
+		limit: 2,
+		completionDaysTruncated: false,
+		categoryCandidatesApproximate: false,
+		categoryCandidatesTruncated: false,
+		historyEntriesRejected: 0,
+		historyFinishEventsTruncated: 0,
+	})
+	const categoryAccumulator = createProfileAnalyticsCategoryAccumulator({
+		listTypes,
+		watchlists,
+		plan: firstPass.categoryPlan,
+		entryLimit: 2,
+	})
+	categoryAccumulator.add(entry('live-list'))
+	const categories = categoryAccumulator.finish()
+	expect(() => finalizeProfileAnalytics(firstPass, categories)).toThrow(
+		/did not process the same bounded entry window/,
+	)
+})
+
+test('overview mode skips stats aggregation while retaining completion days', () => {
+	const accumulator = createProfileAnalyticsAccumulator({
+		listTypes,
+		watchlists,
+		mode: 'overview',
+		now: new Date('2026-07-28T12:00:00.000Z'),
+	})
+	accumulator.add(
+		entry('anime-list', {
+			personal: 9,
+			malScore: 8,
+			startSeason: 'Spring 2026',
+			type: 'TV',
+			genres: 'Action',
+			history: {
+				finished: '2026-01-03T12:00:00.000Z',
+				progress: {
+					episode: {
+						1: { finishDate: ['2026-01-04T12:00:00.000Z'] },
+					},
+				},
+			},
+		}),
+	)
+	const result = accumulator.finish()
+
+	expect(result.completionDays).toEqual([
+		{ day: '2026-01-03', value: 1 },
+		{ day: '2026-01-04', value: 1 },
+	])
+	expect(result.listTypeCounts).toEqual({ live: 0, anime: 0, manga: 0 })
+	expect(result.releaseYears.anime).toEqual([])
+	expect(result.completionYears.anime).toEqual([])
+	expect(result.categoryPlan.genres.anime).toEqual([])
+	expect(result.objectiveScores.anime.groups).toEqual([])
+})
+
+test('stats mode skips completion-day expansion but keeps completion years', () => {
+	const accumulator = createProfileAnalyticsAccumulator({
+		listTypes,
+		watchlists,
+		mode: 'stats',
+		now: new Date('2026-07-28T12:00:00.000Z'),
+	})
+	accumulator.add(
+		entry('anime-list', {
+			personal: 9,
+			malScore: 8,
+			startSeason: 'Spring 2026',
+			type: 'TV',
+			genres: 'Action',
+			history: {
+				finished: '2026-01-03T12:00:00.000Z',
+				progress: {
+					episode: {
+						1: { finishDate: ['2026-01-04T12:00:00.000Z'] },
+					},
+				},
+			},
+		}),
+	)
+	const result = accumulator.finish()
+
+	expect(result.completionDays).toEqual([])
+	expect(result.diagnostic.completionDaysTruncated).toBe(false)
+	expect(result.listTypeCounts.anime).toBe(1)
+	expect(result.releaseYears.anime).toEqual([{ year: 2026, count: 1 }])
+	expect(result.completionYears.anime).toEqual([{ year: 2026, count: 1 }])
+	expect(result.categoryPlan.genres.anime).toEqual([
+		{ key: 'action', label: 'Action' },
+	])
+	expect(result.objectiveScores.anime.groups).toHaveLength(1)
+})
+
+test('reports when bounded category candidates become approximate', () => {
+	const accumulator = createProfileAnalyticsAccumulator({
+		listTypes,
+		watchlists,
+		mode: 'stats',
+	})
+	accumulator.addMany(
+		Array.from(
+			{ length: PROFILE_ANALYTICS_CATEGORY_CANDIDATE_LIMIT + 1 },
+			(_, index) =>
+				entry('anime-list', {
+					genres: `Genre ${index}`,
+					type: `Type ${index}`,
+				}),
+		),
+	)
+	const result = accumulator.finish()
+
+	expect(result.categoryPlan.genres.anime).toHaveLength(
+		PROFILE_ANALYTICS_CATEGORY_CANDIDATE_LIMIT,
+	)
+	expect(result.categoryPlan.mediaTypes.anime).toHaveLength(
+		PROFILE_ANALYTICS_CATEGORY_CANDIDATE_LIMIT,
+	)
+	expect(result.diagnostic.categoryCandidatesApproximate).toBe(true)
+	expect(result.diagnostic.categoryCandidatesTruncated).toBe(true)
+})
+
+test('bounds hostile category input and keeps a real Other distinct from rollup', () => {
+	const entries = [
+		...Array.from({ length: 3 }, () =>
+			entry('anime-list', {
+				type: 'Other',
+				genres: Array.from(
+					{ length: 10_000 },
+					(_, index) => `Genre ${index}`,
+				).join(','),
+				categorySourceTruncated: true,
+			}),
+		),
+		...Array.from({ length: 25 }, (_, index) =>
+			entry('anime-list', {
+				type: `Type ${index}`,
+				genres: `Genre ${index}`,
+			}),
+		),
+	]
+	const { result } = aggregate(entries)
+
+	expect(result.diagnostic.categoryCandidatesTruncated).toBe(true)
+	expect(result.mediaTypeCounts.anime).toContainEqual({
+		key: 'other',
+		label: 'Other',
+		count: 3,
+	})
+	expect(result.mediaTypeCounts.anime).toContainEqual({
+		key: '__veud_category_rollup__',
+		label: 'All other types',
+		count: 2,
+		isRollup: true,
+	})
+	expect(PROFILE_ANALYTICS_CATEGORY_SOURCE_CODE_UNIT_LIMIT).toBe(8 * 1024)
+})
+
+test('uses a collision-safe identity for synthetic category rollups', () => {
+	const { result } = aggregate([
+		entry('anime-list', { type: '__veud_category_rollup__' }),
+		entry('anime-list', { type: '__veud_category_rollup__' }),
+		...Array.from({ length: 25 }, (_, index) =>
+			entry('anime-list', { type: `Reserved fixture ${index}` }),
+		),
+	])
+	const categories = result.mediaTypeCounts.anime
+	const real = categories.find(
+		category => category.label === '__veud_category_rollup__',
+	)
+	const rollup = categories.find(category => category.isRollup)
+
+	expect(real).toMatchObject({
+		key: '__veud_category_rollup__',
+		count: 2,
+	})
+	expect(real?.isRollup).toBeUndefined()
+	expect(rollup).toMatchObject({
+		key: '__veud_category_rollup___',
+		label: 'All other types',
+		isRollup: true,
+	})
+})
+
+test('rejects oversized history and caps finish traversal with diagnostics', () => {
+	const finishDates = Array.from(
+		{ length: PROFILE_HISTORY_EVENT_LIMIT + 1 },
+		(_, index) => new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+	)
+	const accumulator = createProfileAnalyticsAccumulator({
+		listTypes,
+		watchlists,
+		mode: 'overview',
+		now: new Date('2026-07-28T12:00:00.000Z'),
+	})
+	accumulator.addMany([
+		entry('anime-list', {
+			history: `{"note":"${'x'.repeat(PROFILE_HISTORY_CODE_UNIT_LIMIT)}"}`,
+		}),
+		entry('anime-list', {
+			history: { progress: { 1: { finishDate: finishDates } } },
+		}),
+	])
+	const result = accumulator.finish()
+
+	expect(result.diagnostic.historyEntriesRejected).toBe(1)
+	expect(result.diagnostic.historyFinishEventsTruncated).toBe(1)
+	expect(
+		result.completionDays.reduce((total, day) => total + day.value, 0),
+	).toBe(PROFILE_HISTORY_EVENT_LIMIT)
+})

--- a/app/utils/profile-analytics.ts
+++ b/app/utils/profile-analytics.ts
@@ -1,0 +1,1011 @@
+import {
+	parseBoundedProfileHistory,
+	PROFILE_HISTORY_EVENT_LIMIT,
+	profileHistoryTimestamp,
+} from './profile-history-bounds.ts'
+
+export const PROFILE_ANALYTICS_ENTRY_LIMIT = 100_000
+export const PROFILE_ANALYTICS_COMPLETION_DAY_LIMIT = 1_000
+export const PROFILE_ANALYTICS_CATEGORY_LIMIT = 24
+export const PROFILE_ANALYTICS_CATEGORY_CANDIDATE_LIMIT = 96
+export const PROFILE_ANALYTICS_CATEGORY_SOURCE_CODE_UNIT_LIMIT = 8 * 1024
+export const PROFILE_ANALYTICS_GENRES_PER_ENTRY_LIMIT = 64
+export const PROFILE_ANALYTICS_MIN_YEAR = 1870
+export const PROFILE_ANALYTICS_FUTURE_YEAR_ALLOWANCE = 5
+
+export const PROFILE_COMPONENT_SCORE_FIELDS = [
+	'story',
+	'character',
+	'presentation',
+	'sound',
+	'performance',
+	'enjoyment',
+	'averaged',
+	'personal',
+] as const
+
+export const PROFILE_PROVIDER_SCORE_FIELDS = ['tmdbScore', 'malScore'] as const
+
+export const PROFILE_SCORE_FIELDS = [
+	...PROFILE_COMPONENT_SCORE_FIELDS,
+	...PROFILE_PROVIDER_SCORE_FIELDS,
+] as const
+
+export type ProfileScoreField = (typeof PROFILE_SCORE_FIELDS)[number]
+export type ProfileComponentScoreField =
+	(typeof PROFILE_COMPONENT_SCORE_FIELDS)[number]
+export type ProfileProviderScoreField =
+	(typeof PROFILE_PROVIDER_SCORE_FIELDS)[number]
+
+export type ProfileScoreBuckets = [
+	number,
+	number,
+	number,
+	number,
+	number,
+	number,
+	number,
+	number,
+	number,
+	number,
+]
+
+export type ProfileAnalyticsDiagnostic = {
+	processed: number
+	truncated: boolean
+	limit: number
+	completionDaysTruncated: boolean
+	categoryCandidatesApproximate: boolean
+	categoryCandidatesTruncated: boolean
+	historyEntriesRejected: number
+	historyFinishEventsTruncated: number
+	watchlistsProcessed?: number
+	watchlistsTruncated?: boolean
+	watchlistLimit?: number
+}
+
+type ProfileAnalyticsScanDiagnostic = Pick<
+	ProfileAnalyticsDiagnostic,
+	'processed' | 'truncated' | 'limit'
+>
+
+export type ProfileAnalyticsMode = 'full' | 'overview' | 'stats'
+
+export type ProfileAnalyticsListType = {
+	id: string
+	name: string
+}
+
+export type ProfileAnalyticsWatchlist = {
+	id: string
+	typeId: string
+}
+
+export type ProfileAnalyticsEntry = {
+	watchlistId: string
+	type?: unknown
+	releaseStart?: unknown
+	history?: unknown
+	genres?: unknown
+	airYear?: unknown
+	startSeason?: unknown
+	startYear?: unknown
+	story?: unknown
+	character?: unknown
+	presentation?: unknown
+	sound?: unknown
+	performance?: unknown
+	enjoyment?: unknown
+	averaged?: unknown
+	personal?: unknown
+	tmdbScore?: unknown
+	malScore?: unknown
+	categorySourceTruncated?: boolean
+}
+
+export type ProfileYearCount = {
+	year: number
+	count: number
+}
+
+export type ProfileObjectiveScoreSummary = {
+	score: number
+	min: number
+	q1: number
+	median: number
+	q3: number
+	max: number
+	mean: number
+	count: number
+}
+
+export type ProfileObjectiveScores = {
+	source: 'tmdbScore' | 'malScore' | null
+	groups: ProfileObjectiveScoreSummary[]
+}
+
+export type ProfileAnalyticsCategoryCandidate = {
+	key: string
+	label: string
+}
+
+export type ProfileAnalyticsCategoryPlan = {
+	genres: Record<string, ProfileAnalyticsCategoryCandidate[]>
+	mediaTypes: Record<string, ProfileAnalyticsCategoryCandidate[]>
+}
+
+export type ProfileCategoryCount = {
+	key: string
+	label: string
+	count: number
+	isRollup?: true
+}
+
+export type ProfileCategoryMatrix = {
+	labels: string[]
+	values: number[][]
+}
+
+export type ProfileAnalyticsCategoryResult = {
+	genreCounts: Record<string, ProfileCategoryCount[]>
+	genreMatrices: Record<string, ProfileCategoryMatrix>
+	mediaTypeCounts: Record<string, ProfileCategoryCount[]>
+	diagnostic: ProfileAnalyticsScanDiagnostic
+}
+
+export type ProfileAnalyticsFirstPass = {
+	listTypeCounts: Record<string, number>
+	scoreBuckets: Record<
+		string,
+		Record<ProfileComponentScoreField, ProfileScoreBuckets>
+	>
+	providerScoreBuckets: Record<
+		string,
+		Record<ProfileProviderScoreField, ProfileScoreBuckets>
+	>
+	objectiveScores: Record<string, ProfileObjectiveScores>
+	releaseYears: Record<string, ProfileYearCount[]>
+	completionYears: Record<string, ProfileYearCount[]>
+	completionDays: Array<{ day: string; value: number }>
+	categoryPlan: ProfileAnalyticsCategoryPlan
+	diagnostic: ProfileAnalyticsDiagnostic
+}
+
+export type ProfileAnalyticsResult = Omit<
+	ProfileAnalyticsFirstPass,
+	'categoryPlan'
+> &
+	Omit<ProfileAnalyticsCategoryResult, 'diagnostic' | 'genreCounts'>
+
+type ObjectiveSource = Exclude<ProfileObjectiveScores['source'], null>
+
+type ObjectiveHistograms = Record<ObjectiveSource, number[][]>
+
+type NormalizedCategory = {
+	key: string
+	label: string
+}
+
+const OBJECTIVE_PERSONAL_BIN_COUNT = 91
+const MILLISECONDS_PER_DAY = 86_400_000
+const OTHER_CATEGORY_KEY = '__veud_category_rollup__'
+
+function emptyScoreBuckets(): ProfileScoreBuckets {
+	return [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+}
+
+function emptyComponentScoreFields() {
+	return Object.fromEntries(
+		PROFILE_COMPONENT_SCORE_FIELDS.map(field => [field, emptyScoreBuckets()]),
+	) as Record<ProfileComponentScoreField, ProfileScoreBuckets>
+}
+
+function emptyProviderScoreFields() {
+	return Object.fromEntries(
+		PROFILE_PROVIDER_SCORE_FIELDS.map(field => [field, emptyScoreBuckets()]),
+	) as Record<ProfileProviderScoreField, ProfileScoreBuckets>
+}
+
+function emptyObjectiveHistograms(): ObjectiveHistograms {
+	const groups = () =>
+		Array.from({ length: 10 }, () =>
+			Array.from({ length: OBJECTIVE_PERSONAL_BIN_COUNT }, () => 0),
+		)
+	return {
+		tmdbScore: groups(),
+		malScore: groups(),
+	}
+}
+
+function finiteScore(value: unknown) {
+	if (value === null || value === undefined || value === '') return null
+	const score = Number(value)
+	return Number.isFinite(score) && score >= 1 && score <= 10 ? score : null
+}
+
+function integerScoreIndex(value: unknown) {
+	const score = finiteScore(value)
+	return score === null ? null : Math.min(9, Math.floor(score) - 1)
+}
+
+function personalTenthIndex(value: unknown) {
+	const score = finiteScore(value)
+	if (score === null) return null
+	return Math.min(
+		OBJECTIVE_PERSONAL_BIN_COUNT - 1,
+		Math.max(0, Math.round((score - 1) * 10)),
+	)
+}
+
+function personalValueAt(index: number) {
+	return 1 + index / 10
+}
+
+function roundStatistic(value: number) {
+	return Math.round((value + Number.EPSILON) * 10_000) / 10_000
+}
+
+function valueAtRank(histogram: readonly number[], rank: number) {
+	let seen = 0
+	for (let index = 0; index < histogram.length; index += 1) {
+		seen += histogram[index] ?? 0
+		if (rank < seen) return personalValueAt(index)
+	}
+	return personalValueAt(histogram.length - 1)
+}
+
+function quantile(
+	histogram: readonly number[],
+	count: number,
+	percentile: number,
+) {
+	const position = (count - 1) * percentile
+	const lowerRank = Math.floor(position)
+	const upperRank = Math.ceil(position)
+	const lower = valueAtRank(histogram, lowerRank)
+	const upper = valueAtRank(histogram, upperRank)
+	return roundStatistic(lower + (upper - lower) * (position - lowerRank))
+}
+
+function summarizeHistogram(
+	score: number,
+	histogram: readonly number[],
+): ProfileObjectiveScoreSummary | null {
+	let count = 0
+	let total = 0
+	for (let index = 0; index < histogram.length; index += 1) {
+		const binCount = histogram[index] ?? 0
+		count += binCount
+		total += personalValueAt(index) * binCount
+	}
+	if (!count) return null
+
+	return {
+		score,
+		min: valueAtRank(histogram, 0),
+		q1: quantile(histogram, count, 0.25),
+		median: quantile(histogram, count, 0.5),
+		q3: quantile(histogram, count, 0.75),
+		max: valueAtRank(histogram, count - 1),
+		mean: roundStatistic(total / count),
+		count,
+	}
+}
+
+function collectFinishTimestamps(
+	value: unknown,
+	timestamps: Set<number>,
+	budget: { remaining: number; truncated: boolean },
+	seen = new Set<object>(),
+) {
+	if (!value || typeof value !== 'object') return
+	if (seen.has(value)) return
+	seen.add(value)
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectFinishTimestamps(item, timestamps, budget, seen)
+			if (budget.truncated) return
+		}
+		return
+	}
+
+	for (const [key, child] of Object.entries(value)) {
+		if (key === 'finishDate' && Array.isArray(child)) {
+			for (const rawDate of child) {
+				if (budget.remaining <= 0) {
+					budget.truncated = true
+					return
+				}
+				budget.remaining -= 1
+				const timestamp = profileHistoryTimestamp(rawDate)
+				if (timestamp !== null) timestamps.add(timestamp)
+			}
+		} else {
+			collectFinishTimestamps(child, timestamps, budget, seen)
+			if (budget.truncated) return
+		}
+	}
+}
+
+function yearFromDate(value: unknown) {
+	const timestamp = profileHistoryTimestamp(value)
+	return timestamp === null ? null : new Date(timestamp).getUTCFullYear()
+}
+
+function yearFromText(value: unknown) {
+	if (typeof value !== 'string' && typeof value !== 'number') return null
+	const match = String(value).match(/(?:^|\D)(\d{4})(?:\D|$)/)
+	return match?.[1] ? Number(match[1]) : null
+}
+
+function releaseYearForEntry(
+	entry: ProfileAnalyticsEntry,
+	listTypeName: string,
+) {
+	const normalizedName = listTypeName.toLowerCase().replace(/[^a-z]/g, '')
+	let year: number | null = null
+	if (normalizedName === 'liveaction') year = yearFromText(entry.airYear)
+	if (normalizedName === 'anime') year = yearFromText(entry.startSeason)
+	if (normalizedName === 'manga') year = yearFromText(entry.startYear)
+	return year ?? yearFromDate(entry.releaseStart)
+}
+
+function objectiveSourceForListType(
+	listTypeName: string,
+): ProfileObjectiveScores['source'] {
+	const normalizedName = listTypeName.toLowerCase().replace(/[^a-z]/g, '')
+	if (normalizedName === 'liveaction') return 'tmdbScore'
+	if (normalizedName === 'anime' || normalizedName === 'manga')
+		return 'malScore'
+	return null
+}
+
+function normalizeCategory(value: unknown): NormalizedCategory | null {
+	if (typeof value !== 'string') return null
+	const label = value.slice(0, 120).trim().replace(/\s+/g, ' ')
+	if (!label || label.toLowerCase() === 'null') return null
+	return { key: label.toLowerCase(), label }
+}
+
+function genresFrom(value: unknown) {
+	if (typeof value !== 'string') {
+		return { genres: [] as NormalizedCategory[], truncated: false }
+	}
+	const boundedValue = value.slice(
+		0,
+		PROFILE_ANALYTICS_CATEGORY_SOURCE_CODE_UNIT_LIMIT,
+	)
+	let truncated = boundedValue.length < value.length
+	const genres = new Map<string, NormalizedCategory>()
+	for (const rawGenre of boundedValue.split(',')) {
+		const genre = normalizeCategory(rawGenre)
+		if (!genre || genres.has(genre.key)) continue
+		if (genres.size >= PROFILE_ANALYTICS_GENRES_PER_ENTRY_LIMIT) {
+			truncated = true
+			break
+		}
+		genres.set(genre.key, genre)
+	}
+	return { genres: [...genres.values()], truncated }
+}
+
+class HeavyHitterSketch {
+	private counters = new Map<
+		string,
+		{ key: string; label: string; estimate: number; error: number }
+	>()
+	private approximate = false
+	private truncated = false
+
+	add(category: NormalizedCategory) {
+		const existing = this.counters.get(category.key)
+		if (existing) {
+			existing.estimate += 1
+			return
+		}
+		if (this.counters.size < PROFILE_ANALYTICS_CATEGORY_CANDIDATE_LIMIT) {
+			this.counters.set(category.key, {
+				...category,
+				estimate: 1,
+				error: 0,
+			})
+			return
+		}
+		this.approximate = true
+		this.truncated = true
+
+		let smallest:
+			| { key: string; label: string; estimate: number; error: number }
+			| undefined
+		for (const candidate of this.counters.values()) {
+			if (
+				!smallest ||
+				candidate.estimate < smallest.estimate ||
+				(candidate.estimate === smallest.estimate &&
+					candidate.key > smallest.key)
+			) {
+				smallest = candidate
+			}
+		}
+		if (!smallest) return
+		this.counters.delete(smallest.key)
+		this.counters.set(category.key, {
+			...category,
+			estimate: smallest.estimate + 1,
+			error: smallest.estimate,
+		})
+	}
+
+	finish(): ProfileAnalyticsCategoryCandidate[] {
+		return [...this.counters.values()]
+			.sort((a, b) => b.estimate - a.estimate || a.key.localeCompare(b.key))
+			.map(({ key, label }) => ({ key, label }))
+	}
+
+	diagnostic() {
+		return {
+			approximate: this.approximate,
+			truncated: this.truncated,
+		}
+	}
+}
+
+class LatestCompletionDays {
+	private counts = new Map<number, number>()
+	private minimumHeap: number[] = []
+	private truncated = false
+
+	add(timestamp: number) {
+		const utcDay = Math.floor(timestamp / MILLISECONDS_PER_DAY)
+		const count = this.counts.get(utcDay)
+		if (count !== undefined) {
+			this.counts.set(utcDay, count + 1)
+			return
+		}
+
+		this.counts.set(utcDay, 1)
+		this.push(utcDay)
+		if (this.counts.size > PROFILE_ANALYTICS_COMPLETION_DAY_LIMIT) {
+			this.truncated = true
+			const oldest = this.pop()
+			if (oldest !== undefined) this.counts.delete(oldest)
+		}
+	}
+
+	finish() {
+		return [...this.counts]
+			.sort(([left], [right]) => left - right)
+			.map(([utcDay, value]) => ({
+				day: new Date(utcDay * MILLISECONDS_PER_DAY).toISOString().slice(0, 10),
+				value,
+			}))
+	}
+
+	get wasTruncated() {
+		return this.truncated
+	}
+
+	private push(value: number) {
+		const heap = this.minimumHeap
+		heap.push(value)
+		let index = heap.length - 1
+		while (index > 0) {
+			const parent = Math.floor((index - 1) / 2)
+			if ((heap[parent] ?? value) <= value) break
+			heap[index] = heap[parent] as number
+			index = parent
+		}
+		heap[index] = value
+	}
+
+	private pop() {
+		const heap = this.minimumHeap
+		const minimum = heap[0]
+		const replacement = heap.pop()
+		if (heap.length && replacement !== undefined) {
+			let index = 0
+			while (true) {
+				const left = index * 2 + 1
+				const right = left + 1
+				if (left >= heap.length) break
+				const smallest =
+					right < heap.length &&
+					(heap[right] as number) < (heap[left] as number)
+						? right
+						: left
+				if ((heap[smallest] as number) >= replacement) break
+				heap[index] = heap[smallest] as number
+				index = smallest
+			}
+			heap[index] = replacement
+		}
+		return minimum
+	}
+}
+
+function yearCounts(years: ReadonlyMap<number, number>) {
+	return [...years]
+		.sort(([left], [right]) => left - right)
+		.map(([year, count]) => ({ year, count }))
+}
+
+function boundedLimit(value: number | undefined) {
+	if (value === undefined) return PROFILE_ANALYTICS_ENTRY_LIMIT
+	if (!Number.isSafeInteger(value) || value < 1) {
+		throw new RangeError(
+			'Profile analytics entry limit must be a positive integer',
+		)
+	}
+	return Math.min(value, PROFILE_ANALYTICS_ENTRY_LIMIT)
+}
+
+export function createProfileAnalyticsAccumulator({
+	listTypes,
+	watchlists,
+	now = new Date(),
+	entryLimit,
+	mode = 'full',
+}: {
+	listTypes: ProfileAnalyticsListType[]
+	watchlists: ProfileAnalyticsWatchlist[]
+	now?: Date
+	entryLimit?: number
+	mode?: ProfileAnalyticsMode
+}) {
+	const limit = boundedLimit(entryLimit)
+	const collectOverview = mode === 'full' || mode === 'overview'
+	const collectStats = mode === 'full' || mode === 'stats'
+	const maxYear = now.getUTCFullYear() + PROFILE_ANALYTICS_FUTURE_YEAR_ALLOWANCE
+	const watchlistType = new Map(
+		watchlists.map(watchlist => [watchlist.id, watchlist.typeId]),
+	)
+	const listTypeById = new Map(
+		listTypes.map(listType => [listType.id, listType]),
+	)
+	const listTypeCounts = Object.fromEntries(
+		listTypes.map(listType => [listType.id, 0]),
+	) as Record<string, number>
+	const scoreBuckets = Object.fromEntries(
+		listTypes.map(listType => [listType.id, emptyComponentScoreFields()]),
+	) as ProfileAnalyticsFirstPass['scoreBuckets']
+	const providerScoreBuckets = Object.fromEntries(
+		listTypes.map(listType => [listType.id, emptyProviderScoreFields()]),
+	) as ProfileAnalyticsFirstPass['providerScoreBuckets']
+	const objectiveHistograms = new Map(
+		listTypes.map(listType => [listType.id, emptyObjectiveHistograms()]),
+	)
+	const releaseYearMaps = new Map(
+		listTypes.map(listType => [listType.id, new Map<number, number>()]),
+	)
+	const completionYearMaps = new Map(
+		listTypes.map(listType => [listType.id, new Map<number, number>()]),
+	)
+	const genreSketches = new Map(
+		listTypes.map(listType => [listType.id, new HeavyHitterSketch()]),
+	)
+	const mediaTypeSketches = new Map(
+		listTypes.map(listType => [listType.id, new HeavyHitterSketch()]),
+	)
+	const completionDays = new LatestCompletionDays()
+	let processed = 0
+	let truncated = false
+	let historyEntriesRejected = 0
+	let historyFinishEventsTruncated = 0
+	let categorySourceTruncated = false
+
+	function inYearRange(year: number) {
+		return year >= PROFILE_ANALYTICS_MIN_YEAR && year <= maxYear
+	}
+
+	function add(entry: ProfileAnalyticsEntry) {
+		if (processed >= limit) {
+			truncated = true
+			return false
+		}
+		processed += 1
+
+		const typeId = watchlistType.get(entry.watchlistId)
+		const listType = typeId ? listTypeById.get(typeId) : null
+		if (!typeId || !listType) return true
+
+		if (collectStats) {
+			listTypeCounts[typeId] = (listTypeCounts[typeId] ?? 0) + 1
+			const typeScoreBuckets = scoreBuckets[typeId]
+			if (typeScoreBuckets) {
+				for (const field of PROFILE_COMPONENT_SCORE_FIELDS) {
+					const index = integerScoreIndex(entry[field])
+					if (index !== null) typeScoreBuckets[field][index] += 1
+				}
+			}
+			const typeProviderScoreBuckets = providerScoreBuckets[typeId]
+			if (typeProviderScoreBuckets) {
+				for (const field of PROFILE_PROVIDER_SCORE_FIELDS) {
+					const index = integerScoreIndex(entry[field])
+					if (index !== null) typeProviderScoreBuckets[field][index] += 1
+				}
+			}
+
+			const objectiveSource = objectiveSourceForListType(listType.name)
+			if (objectiveSource) {
+				const objectiveIndex = integerScoreIndex(entry[objectiveSource])
+				const personalIndex = personalTenthIndex(entry.personal)
+				if (objectiveIndex !== null && personalIndex !== null) {
+					const histogram =
+						objectiveHistograms.get(typeId)?.[objectiveSource][objectiveIndex]
+					if (histogram) histogram[personalIndex] += 1
+				}
+			}
+
+			const releaseYear = releaseYearForEntry(entry, listType.name)
+			if (releaseYear !== null && inYearRange(releaseYear)) {
+				const years = releaseYearMaps.get(typeId)
+				years?.set(releaseYear, (years.get(releaseYear) ?? 0) + 1)
+			}
+		}
+
+		const parsedHistory = parseBoundedProfileHistory(entry.history)
+		if (parsedHistory.rejected) historyEntriesRejected += 1
+		let historyEventsTruncated = parsedHistory.finishEventsTruncated
+		const history = parsedHistory.history
+		if (history) {
+			const finishedTimestamp =
+				collectOverview || collectStats
+					? profileHistoryTimestamp(history.finished)
+					: null
+			if (collectStats && finishedTimestamp !== null) {
+				const finishedYear = new Date(finishedTimestamp).getUTCFullYear()
+				if (inYearRange(finishedYear)) {
+					const years = completionYearMaps.get(typeId)
+					years?.set(finishedYear, (years.get(finishedYear) ?? 0) + 1)
+				}
+			}
+
+			if (collectOverview) {
+				const finishTimestamps = new Set<number>()
+				if (finishedTimestamp !== null) finishTimestamps.add(finishedTimestamp)
+				const finishBudget = {
+					remaining:
+						PROFILE_HISTORY_EVENT_LIMIT - (finishedTimestamp === null ? 0 : 1),
+					truncated: false,
+				}
+				collectFinishTimestamps(
+					history.progress,
+					finishTimestamps,
+					finishBudget,
+				)
+				historyEventsTruncated ||= finishBudget.truncated
+				for (const timestamp of finishTimestamps) {
+					const year = new Date(timestamp).getUTCFullYear()
+					if (inYearRange(year)) completionDays.add(timestamp)
+				}
+			}
+		}
+		if (historyEventsTruncated) historyFinishEventsTruncated += 1
+
+		if (collectStats) {
+			const genreInput = genresFrom(entry.genres)
+			categorySourceTruncated ||=
+				Boolean(entry.categorySourceTruncated) || genreInput.truncated
+			for (const genre of genreInput.genres) {
+				genreSketches.get(typeId)?.add(genre)
+			}
+			if (typeof entry.type === 'string' && entry.type.length > 120) {
+				categorySourceTruncated = true
+			}
+			const mediaType = normalizeCategory(entry.type)
+			if (mediaType) mediaTypeSketches.get(typeId)?.add(mediaType)
+		}
+		return true
+	}
+
+	function addMany(entries: Iterable<ProfileAnalyticsEntry>) {
+		let accepted = 0
+		for (const entry of entries) {
+			if (!add(entry)) break
+			accepted += 1
+		}
+		return accepted
+	}
+
+	function markTruncated() {
+		truncated = true
+	}
+
+	function finish(): ProfileAnalyticsFirstPass {
+		const objectiveScores = Object.fromEntries(
+			listTypes.map(listType => {
+				const source = objectiveSourceForListType(listType.name)
+				const groups = source
+					? (objectiveHistograms.get(listType.id)?.[source] ?? [])
+							.map((histogram, index) =>
+								summarizeHistogram(index + 1, histogram),
+							)
+							.filter(
+								(group): group is ProfileObjectiveScoreSummary =>
+									group !== null,
+							)
+					: []
+				return [listType.id, { source, groups }]
+			}),
+		)
+		const releaseYears = Object.fromEntries(
+			listTypes.map(listType => [
+				listType.id,
+				yearCounts(releaseYearMaps.get(listType.id) ?? new Map()),
+			]),
+		)
+		const completionYears = Object.fromEntries(
+			listTypes.map(listType => [
+				listType.id,
+				yearCounts(completionYearMaps.get(listType.id) ?? new Map()),
+			]),
+		)
+		const categoryPlan: ProfileAnalyticsCategoryPlan = {
+			genres: Object.fromEntries(
+				listTypes.map(listType => [
+					listType.id,
+					genreSketches.get(listType.id)?.finish() ?? [],
+				]),
+			),
+			mediaTypes: Object.fromEntries(
+				listTypes.map(listType => [
+					listType.id,
+					mediaTypeSketches.get(listType.id)?.finish() ?? [],
+				]),
+			),
+		}
+		const categorySketchDiagnostics = [
+			...genreSketches.values(),
+			...mediaTypeSketches.values(),
+		].map(sketch => sketch.diagnostic())
+
+		return {
+			listTypeCounts: { ...listTypeCounts },
+			scoreBuckets,
+			providerScoreBuckets,
+			objectiveScores,
+			releaseYears,
+			completionYears,
+			completionDays: completionDays.finish(),
+			categoryPlan,
+			diagnostic: {
+				processed,
+				truncated,
+				limit,
+				completionDaysTruncated: completionDays.wasTruncated,
+				categoryCandidatesApproximate: categorySketchDiagnostics.some(
+					diagnostic => diagnostic.approximate,
+				),
+				categoryCandidatesTruncated:
+					categorySketchDiagnostics.some(diagnostic => diagnostic.truncated) ||
+					categorySourceTruncated,
+				historyEntriesRejected,
+				historyFinishEventsTruncated,
+			},
+		}
+	}
+
+	return { add, addMany, markTruncated, finish }
+}
+
+type ExactCategoryState = {
+	genreCandidates: ProfileAnalyticsCategoryCandidate[]
+	genreIndex: Map<string, number>
+	genreCounts: number[]
+	genreMatrix: number[][]
+	totalGenres: number
+	mediaTypeCandidates: ProfileAnalyticsCategoryCandidate[]
+	mediaTypeIndex: Map<string, number>
+	mediaTypeCounts: number[]
+	totalMediaTypes: number
+}
+
+function exactCategoryState(
+	genreCandidates: ProfileAnalyticsCategoryCandidate[],
+	mediaTypeCandidates: ProfileAnalyticsCategoryCandidate[],
+): ExactCategoryState {
+	return {
+		genreCandidates,
+		genreIndex: new Map(
+			genreCandidates.map((candidate, index) => [candidate.key, index]),
+		),
+		genreCounts: Array.from({ length: genreCandidates.length }, () => 0),
+		genreMatrix: Array.from({ length: genreCandidates.length }, () =>
+			Array.from({ length: genreCandidates.length }, () => 0),
+		),
+		totalGenres: 0,
+		mediaTypeCandidates,
+		mediaTypeIndex: new Map(
+			mediaTypeCandidates.map((candidate, index) => [candidate.key, index]),
+		),
+		mediaTypeCounts: Array.from(
+			{ length: mediaTypeCandidates.length },
+			() => 0,
+		),
+		totalMediaTypes: 0,
+	}
+}
+
+function topCategories(
+	candidates: readonly ProfileAnalyticsCategoryCandidate[],
+	counts: readonly number[],
+	total: number,
+	otherLabel: string,
+) {
+	const ranked = candidates
+		.map((candidate, index) => ({
+			...candidate,
+			index,
+			count: counts[index] ?? 0,
+		}))
+		.filter(candidate => candidate.count > 0)
+		.sort(
+			(left, right) =>
+				right.count - left.count || left.key.localeCompare(right.key),
+		)
+		.slice(0, PROFILE_ANALYTICS_CATEGORY_LIMIT)
+	const selectedTotal = ranked.reduce(
+		(sum, candidate) => sum + candidate.count,
+		0,
+	)
+	const countsResult: ProfileCategoryCount[] = ranked.map(
+		({ key, label, count }) => ({ key, label, count }),
+	)
+	const other = total - selectedTotal
+	if (other > 0) {
+		let rollupKey = OTHER_CATEGORY_KEY
+		const candidateKeys = new Set(candidates.map(candidate => candidate.key))
+		while (candidateKeys.has(rollupKey)) rollupKey += '_'
+		countsResult.push({
+			key: rollupKey,
+			label: otherLabel,
+			count: other,
+			isRollup: true,
+		})
+	}
+	return { ranked, counts: countsResult }
+}
+
+export function createProfileAnalyticsCategoryAccumulator({
+	listTypes,
+	watchlists,
+	plan,
+	entryLimit,
+}: {
+	listTypes: ProfileAnalyticsListType[]
+	watchlists: ProfileAnalyticsWatchlist[]
+	plan: ProfileAnalyticsCategoryPlan
+	entryLimit?: number
+}) {
+	const limit = boundedLimit(entryLimit)
+	const watchlistType = new Map(
+		watchlists.map(watchlist => [watchlist.id, watchlist.typeId]),
+	)
+	const states = new Map(
+		listTypes.map(listType => [
+			listType.id,
+			exactCategoryState(
+				plan.genres[listType.id] ?? [],
+				plan.mediaTypes[listType.id] ?? [],
+			),
+		]),
+	)
+	let processed = 0
+	let truncated = false
+
+	function add(entry: ProfileAnalyticsEntry) {
+		if (processed >= limit) {
+			truncated = true
+			return false
+		}
+		processed += 1
+
+		const typeId = watchlistType.get(entry.watchlistId)
+		const state = typeId ? states.get(typeId) : null
+		if (!state) return true
+
+		const genreIndexes: number[] = []
+		for (const genre of genresFrom(entry.genres).genres) {
+			state.totalGenres += 1
+			const index = state.genreIndex.get(genre.key)
+			if (index === undefined) continue
+			state.genreCounts[index] = (state.genreCounts[index] ?? 0) + 1
+			genreIndexes.push(index)
+		}
+		for (const row of genreIndexes) {
+			for (const column of genreIndexes) {
+				if (row === column) continue
+				const matrixRow = state.genreMatrix[row]
+				if (matrixRow) matrixRow[column] = (matrixRow[column] ?? 0) + 1
+			}
+		}
+
+		const mediaType = normalizeCategory(entry.type)
+		if (mediaType) {
+			state.totalMediaTypes += 1
+			const index = state.mediaTypeIndex.get(mediaType.key)
+			if (index !== undefined) {
+				state.mediaTypeCounts[index] = (state.mediaTypeCounts[index] ?? 0) + 1
+			}
+		}
+		return true
+	}
+
+	function addMany(entries: Iterable<ProfileAnalyticsEntry>) {
+		let accepted = 0
+		for (const entry of entries) {
+			if (!add(entry)) break
+			accepted += 1
+		}
+		return accepted
+	}
+
+	function markTruncated() {
+		truncated = true
+	}
+
+	function finish(): ProfileAnalyticsCategoryResult {
+		const genreCounts: Record<string, ProfileCategoryCount[]> = {}
+		const genreMatrices: Record<string, ProfileCategoryMatrix> = {}
+		const mediaTypeCounts: Record<string, ProfileCategoryCount[]> = {}
+
+		for (const listType of listTypes) {
+			const state = states.get(listType.id)
+			if (!state) continue
+			const selectedGenres = topCategories(
+				state.genreCandidates,
+				state.genreCounts,
+				state.totalGenres,
+				'All other genres',
+			)
+			genreCounts[listType.id] = selectedGenres.counts
+			genreMatrices[listType.id] = {
+				labels: selectedGenres.ranked.map(candidate => candidate.label),
+				values: selectedGenres.ranked.map(row =>
+					selectedGenres.ranked.map(
+						column => state.genreMatrix[row.index]?.[column.index] ?? 0,
+					),
+				),
+			}
+			mediaTypeCounts[listType.id] = topCategories(
+				state.mediaTypeCandidates,
+				state.mediaTypeCounts,
+				state.totalMediaTypes,
+				'All other types',
+			).counts
+		}
+
+		return {
+			genreCounts,
+			genreMatrices,
+			mediaTypeCounts,
+			diagnostic: { processed, truncated, limit },
+		}
+	}
+
+	return { add, addMany, markTruncated, finish }
+}
+
+export function finalizeProfileAnalytics(
+	firstPass: ProfileAnalyticsFirstPass,
+	categories: ProfileAnalyticsCategoryResult,
+): ProfileAnalyticsResult {
+	if (
+		firstPass.diagnostic.processed !== categories.diagnostic.processed ||
+		firstPass.diagnostic.limit !== categories.diagnostic.limit ||
+		firstPass.diagnostic.truncated !== categories.diagnostic.truncated
+	) {
+		throw new Error(
+			'Profile analytics category pass did not process the same bounded entry window',
+		)
+	}
+
+	const { categoryPlan: _categoryPlan, ...base } = firstPass
+	const {
+		diagnostic: _categoryDiagnostic,
+		genreCounts: _genreCounts,
+		...categoryResult
+	} = categories
+	return { ...base, ...categoryResult }
+}

--- a/app/utils/profile-completion-history.test.ts
+++ b/app/utils/profile-completion-history.test.ts
@@ -1,63 +1,24 @@
 import { expect, test } from 'vitest'
-import { buildCompletionHistory } from './profile-completion-history.ts'
+import { buildCompletionHistoryFromDays } from './profile-completion-history.ts'
 
-test('completion history stays empty without valid finish dates', () => {
+test('builds the compatibility month index from sparse aggregated days', () => {
 	expect(
-		buildCompletionHistory(
-			{
-				anime: [
-					{ history: null },
-					{ history: '{invalid' },
-					{ history: { progress: { episode: {} } } },
-				],
-			},
-			new Date(2026, 2, 20),
-		),
-	).toEqual({ days: [], months: {} })
+		buildCompletionHistoryFromDays([
+			{ day: '2025-12-31', value: 1 },
+			{ day: '2025-12-31', value: 2 },
+			{ day: 'invalid', value: 50 },
+			{ day: '2026-01-01', value: 0 },
+		]),
+	).toEqual({
+		days: [{ day: '2025-12-31', value: 3 }],
+	})
 })
 
-test('completion history deduplicates each entry and aggregates shared days', () => {
-	const history = buildCompletionHistory(
-		{
-			anime: [
-				{
-					history: {
-						finished: '2026-01-03T12:00:00.000Z',
-						progress: {
-							episode: {
-								1: {
-									finishDate: [
-										'2026-01-03T12:00:00.000Z',
-										'2026-01-04T12:00:00.000Z',
-									],
-								},
-							},
-						},
-					},
-				},
-				{
-					history: JSON.stringify({
-						progress: {
-							episode: {
-								1: { finishDate: ['2026-01-03T18:00:00.000Z'] },
-							},
-						},
-					}),
-				},
-			],
-		},
-		new Date(2026, 2, 20),
-	)
-
-	expect(history.days).toEqual([
-		{ day: '2026-01-03', value: 2 },
-		{ day: '2026-01-04', value: 1 },
+test('an old sparse completion does not expand into empty month payloads', () => {
+	const history = buildCompletionHistoryFromDays([
+		{ day: '1870-01-01', value: 1 },
 	])
-	expect(history.months).toEqual({
-		2026: {
-			1: { from: '2026-01-01', to: '2026-01-31' },
-			2: { from: '2026-02-01', to: '2026-02-28' },
-			3: { from: '2026-03-01', to: '2026-03-31' },
-		},
-	})
+
+	expect(history).toEqual({ days: [{ day: '1870-01-01', value: 1 }] })
+	expect(Buffer.byteLength(JSON.stringify(history))).toBeLessThan(128)
 })

--- a/app/utils/profile-completion-history.ts
+++ b/app/utils/profile-completion-history.ts
@@ -3,103 +3,21 @@ export type CompletionHistoryDay = {
 	value: number
 }
 
-export type CompletionHistoryRange = {
-	from: string
-	to: string
-}
-
 export type CompletionHistory = {
 	days: CompletionHistoryDay[]
-	months: Record<string, Record<string, CompletionHistoryRange>>
 }
 
-function collectFinishDates(value: unknown, dates: Set<number>) {
-	if (!value || typeof value !== 'object') return
-	if (Array.isArray(value)) {
-		for (const item of value) collectFinishDates(item, dates)
-		return
-	}
-	for (const [key, child] of Object.entries(value)) {
-		if (key === 'finishDate' && Array.isArray(child)) {
-			for (const date of child) {
-				const timestamp = new Date(date as string | number | Date).getTime()
-				if (Number.isFinite(timestamp)) dates.add(timestamp)
-			}
-		} else {
-			collectFinishDates(child, dates)
-		}
-	}
-}
-
-function addDate(days: CompletionHistoryDay[], finishDate: number) {
-	const day = new Date(finishDate).toISOString().split('T')[0]
-	const existing = days.find(candidate => candidate.day === day)
-	if (existing) {
-		existing.value += 1
-		return
-	}
-	days.push({ day, value: 1 })
-}
-
-export function buildCompletionHistory(
-	typedEntries: Record<string, any[]>,
-	endDate = new Date(),
+export function buildCompletionHistoryFromDays(
+	inputDays: Iterable<CompletionHistoryDay>,
 ): CompletionHistory {
-	const days: CompletionHistoryDay[] = []
-
-	for (const entries of Object.values(typedEntries)) {
-		for (const entry of entries) {
-			try {
-				const history =
-					typeof entry.history === 'string'
-						? JSON.parse(entry.history)
-						: entry.history
-				if (!history || typeof history !== 'object') continue
-				const finishDates = new Set<number>()
-				collectFinishDates(history.progress, finishDates)
-				if (history.finished) {
-					const finished = new Date(history.finished).getTime()
-					if (Number.isFinite(finished)) finishDates.add(finished)
-				}
-				for (const finishDate of finishDates) addDate(days, finishDate)
-			} catch {
-				continue
-			}
-		}
+	const dayCounts = new Map<string, number>()
+	for (const day of inputDays) {
+		if (!/^\d{4}-\d{2}-\d{2}$/.test(day.day)) continue
+		if (!Number.isFinite(day.value) || day.value <= 0) continue
+		dayCounts.set(day.day, (dayCounts.get(day.day) ?? 0) + day.value)
 	}
-
-	if (!days.length) return { days, months: {} }
-
-	days.sort((a, b) => a.day.localeCompare(b.day))
-	const firstDay = days.reduce(
-		(earliest, current) => (current.day < earliest.day ? current : earliest),
-		days[0],
-	)
-	const [firstYear, firstMonth] = firstDay.day
-		.split('-')
-		.map(component => Number(component))
-	let year = firstYear
-	let month = firstMonth
-	const endYear = endDate.getFullYear()
-	const endMonth = endDate.getMonth() + 1
-	const months: CompletionHistory['months'] = {}
-
-	while (year <= endYear) {
-		const yearMonths: Record<string, CompletionHistoryRange> = {}
-		while (month <= 12) {
-			if (year >= endYear && month > endMonth) break
-			const paddedMonth = String(month).padStart(2, '0')
-			const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate()
-			yearMonths[month] = {
-				from: `${year}-${paddedMonth}-01`,
-				to: `${year}-${paddedMonth}-${lastDay}`,
-			}
-			month += 1
-		}
-		months[year] = yearMonths
-		year += 1
-		month = 1
-	}
-
-	return { days, months }
+	const days = [...dayCounts]
+		.map(([day, value]) => ({ day, value }))
+		.sort((a, b) => a.day.localeCompare(b.day))
+	return { days }
 }

--- a/app/utils/profile-data.server.ts
+++ b/app/utils/profile-data.server.ts
@@ -1,5 +1,5 @@
 import { invariantResponse } from '@epic-web/invariant'
-import { type Prisma } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 import {
 	activityEventLabel,
 	activityListTypeName,
@@ -7,16 +7,78 @@ import {
 } from '#app/utils/activity.ts'
 import { getUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import { preferredScore } from '#app/utils/lists/watchlist-entry-scores.server.ts'
 import {
-	visibleActivityEventWhere,
-	visibleWatchlistWhere,
-} from '#app/utils/lists/visibility.server.ts'
+	createProfileActivityCollector,
+	PROFILE_ACTIVITY_MAX_CAPACITY,
+} from '#app/utils/profile-activity.ts'
+import {
+	createProfileAnalyticsAccumulator,
+	createProfileAnalyticsCategoryAccumulator,
+	finalizeProfileAnalytics,
+	PROFILE_ANALYTICS_ENTRY_LIMIT,
+	type ProfileAnalyticsEntry,
+} from '#app/utils/profile-analytics.ts'
+import { buildCompletionHistoryFromDays } from '#app/utils/profile-completion-history.ts'
 import { buildProfileHistory } from '#app/utils/profile-history.ts'
-import { buildProfileTrackingSummaries } from '#app/utils/profile-tracking.ts'
+import {
+	createProfileTrackingAccumulator,
+	type ProfileTrackingEntry,
+} from '#app/utils/profile-tracking.ts'
 import { type Timings, time } from '#app/utils/timing.server.ts'
 import { getUserSafetyState } from '#app/utils/user-safety.server.ts'
+import { PROFILE_WATCHLIST_LIMIT } from '#app/utils/watchlist-limits.ts'
 
-const LEGACY_ACTIVITY_GRACE_MS = 60_000
+const PROFILE_ENTRY_BATCH_SIZE = 500
+const PROFILE_HISTORY_ENTRY_BATCH_SIZE = PROFILE_ENTRY_BATCH_SIZE
+const PROFILE_SNAPSHOT_TIMEOUT_MS = 20_000
+const PROFILE_ACTIVITY_DEDUPLICATION_WINDOW_MS = 60_000
+const PROFILE_HISTORY_DB_CODE_UNIT_LIMIT = 128 * 1024
+const PROFILE_HISTORY_REQUEST_CODE_UNIT_LIMIT = 16 * 1024 * 1024
+// DB substr counts characters, so one projected character can occupy two JS
+// UTF-16 code units. This is the independent hard transfer/materialization cap,
+// including one fixed sentinel per possible scanned Entry.
+const PROFILE_HISTORY_RAW_REQUEST_CODE_UNIT_LIMIT =
+	2 * PROFILE_HISTORY_REQUEST_CODE_UNIT_LIMIT + PROFILE_ANALYTICS_ENTRY_LIMIT
+export const PROFILE_CATEGORY_REQUEST_CODE_UNIT_LIMIT = 48 * 1024 * 1024
+export const PROFILE_CATEGORY_CANDIDATE_CODE_UNIT_LIMIT =
+	PROFILE_CATEGORY_REQUEST_CODE_UNIT_LIMIT / 2
+export const PROFILE_CATEGORY_EXACT_CODE_UNIT_LIMIT =
+	PROFILE_CATEGORY_REQUEST_CODE_UNIT_LIMIT / 2
+export const PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT = 64
+export const PROFILE_CATEGORY_GENRES_CODE_UNIT_LIMIT =
+	Math.floor(
+		PROFILE_CATEGORY_CANDIDATE_CODE_UNIT_LIMIT / PROFILE_ANALYTICS_ENTRY_LIMIT,
+	) - PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT
+// SQL substr counts characters, while the request budget counts JS UTF-16
+// code units. Each projected field includes one database-character sentinel,
+// and every such character can occupy two UTF-16 code units.
+export const PROFILE_CATEGORY_CANDIDATE_RAW_CODE_UNIT_LIMIT =
+	PROFILE_ANALYTICS_ENTRY_LIMIT *
+	2 *
+	(PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT +
+		1 +
+		PROFILE_CATEGORY_GENRES_CODE_UNIT_LIMIT +
+		1)
+export const PROFILE_CATEGORY_EXACT_RAW_CODE_UNIT_LIMIT =
+	PROFILE_CATEGORY_CANDIDATE_RAW_CODE_UNIT_LIMIT
+export const PROFILE_CATEGORY_RAW_REQUEST_CODE_UNIT_LIMIT =
+	PROFILE_CATEGORY_CANDIDATE_RAW_CODE_UNIT_LIMIT +
+	PROFILE_CATEGORY_EXACT_RAW_CODE_UNIT_LIMIT
+const PROFILE_YEAR_TEXT_CODE_UNIT_LIMIT = 64
+const PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT = 128
+const PROFILE_ACTIVITY_TITLE_CODE_UNIT_LIMIT = 240
+const PROFILE_ACTIVITY_THUMBNAIL_CODE_UNIT_LIMIT = 2_048
+const PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT = 160
+const PROFILE_ACTIVITY_PROGRESS_UNIT_CODE_UNIT_LIMIT = 64
+const PROFILE_FAVORITE_LIMIT = 300
+const PROFILE_FAVORITE_META_CODE_UNIT_LIMIT = 120
+const PROFILE_SUPPORTED_PROGRESS_UNITS = ['episode', 'chapter', 'volume']
+const PROFILE_ACTIVITY_LIST_TYPE_NAMES = [
+	'liveaction',
+	'anime',
+	'manga',
+] as const
 
 const listTypeSelect = {
 	id: true,
@@ -33,16 +95,16 @@ const watchlistSelect = {
 	header: true,
 	typeId: true,
 	position: true,
+	isPublic: true,
+	mutationVersion: true,
+	updatedAt: true,
 } satisfies Prisma.WatchlistSelect
 
 const analyticsEntrySelect = {
 	id: true,
 	watchlistId: true,
 	mediaId: true,
-	type: true,
 	releaseStart: true,
-	history: true,
-	genres: true,
 	story: true,
 	character: true,
 	presentation: true,
@@ -51,48 +113,708 @@ const analyticsEntrySelect = {
 	enjoyment: true,
 	averaged: true,
 	personal: true,
-	airYear: true,
-	startSeason: true,
-	startYear: true,
-	length: true,
-	chapters: true,
-	volumes: true,
 	tmdbScore: true,
 	malScore: true,
-	media: { select: { kind: true } },
+	media: { select: { kind: true, tmdbScore: true, malScore: true } },
 	trackingState: {
 		select: {
 			id: true,
-			status: true,
+			ownerId: true,
+			mediaId: true,
 			statusWatchlistId: true,
 			score: true,
 			repeatCount: true,
-			progress: { select: { unit: true, current: true } },
+			progress: {
+				where: { unit: { in: PROFILE_SUPPORTED_PROGRESS_UNITS } },
+				orderBy: { unit: 'asc' },
+				take: PROFILE_SUPPORTED_PROGRESS_UNITS.length,
+				select: { unit: true, current: true },
+			},
 		},
 	},
 } satisfies Prisma.EntrySelect
 
+const overviewEntrySelect = {
+	id: true,
+	watchlistId: true,
+	mediaId: true,
+	personal: true,
+	media: { select: { kind: true } },
+	trackingState: analyticsEntrySelect.trackingState,
+} satisfies Prisma.EntrySelect
+
+const analyticsCategoryEntrySelect = {
+	id: true,
+	watchlistId: true,
+} satisfies Prisma.EntrySelect
+
 const activityEventSelect = {
 	id: true,
-	type: true,
-	status: true,
-	statusLabel: true,
-	previousStatus: true,
-	previousStatusLabel: true,
 	score: true,
 	previousScore: true,
-	progressUnit: true,
 	progressCurrent: true,
 	progressPrevious: true,
 	progressTotal: true,
 	createdAt: true,
 	media: {
-		select: { id: true, kind: true, title: true, thumbnail: true },
+		select: { id: true, kind: true },
 	},
 } satisfies Prisma.ActivityEventSelect
 
-async function requireProfileUser(username: string | undefined) {
-	const user = await prisma.user.findUnique({
+type AnalyticsEntryRow = Prisma.EntryGetPayload<{
+	select: typeof analyticsEntrySelect
+}>
+
+type OverviewEntryRow = Prisma.EntryGetPayload<{
+	select: typeof overviewEntrySelect
+}>
+
+type AnalyticsCategoryEntryRow = Prisma.EntryGetPayload<{
+	select: typeof analyticsCategoryEntrySelect
+}>
+
+type ProfileDbClient = Prisma.TransactionClient | typeof prisma
+type AnalyticsEntryWithText = AnalyticsEntryRow & BoundedAnalyticsEntryText
+type OverviewEntryWithText = OverviewEntryRow & BoundedOverviewEntryText
+
+type ProfileHistoryProjectionBudget = {
+	remaining: number
+	rawRemaining: number
+	truncated: boolean
+}
+
+type ProfileCategoryProjectionBudget = {
+	remaining: number
+	rawRemaining: number
+	truncated: boolean
+}
+
+type ProfileCategoryRequestBudget = {
+	candidate: ProfileCategoryProjectionBudget
+	exact: ProfileCategoryProjectionBudget
+}
+
+type ProfileHistoryProjection = {
+	id: string
+	history: string | null
+}
+
+type ProfileOverviewTextProjection = ProfileHistoryProjection & {
+	length: string | null
+	chapters: string | null
+	volumes: string | null
+}
+
+type ProfileAnalyticsTextProjection = ProfileOverviewTextProjection & {
+	type: string | null
+	genres: string | null
+	airYear: string | null
+	startSeason: string | null
+	startYear: string | null
+}
+
+type ProfileCategoryTextProjection = {
+	id: string
+	type: string | null
+	genres: string | null
+}
+
+type ProfileActivityEntryTextProjection = ProfileHistoryProjection & {
+	title: string
+	thumbnail: string | null
+}
+
+type BoundedOverviewEntryText = Omit<ProfileOverviewTextProjection, 'id'>
+
+type BoundedAnalyticsEntryText = Omit<ProfileAnalyticsTextProjection, 'id'> & {
+	categorySourceTruncated: boolean
+}
+
+type BoundedCategoryEntryText = Omit<ProfileCategoryTextProjection, 'id'> & {
+	categorySourceTruncated: boolean
+}
+
+type BoundedActivityEntryText = Omit<ProfileActivityEntryTextProjection, 'id'>
+
+type ProfileMediaTextProjection = {
+	id: string
+	title: string | null
+	thumbnail: string | null
+}
+
+type BoundedProfileMediaText = Omit<ProfileMediaTextProjection, 'id'> & {
+	truncated: boolean
+}
+
+type ProfileActivityEventTextProjection = {
+	id: string
+	type: string
+	status: string | null
+	statusLabel: string | null
+	previousStatus: string | null
+	previousStatusLabel: string | null
+	progressUnit: string | null
+}
+
+type BoundedProfileActivityEventText = Omit<
+	ProfileActivityEventTextProjection,
+	'id'
+> & {
+	truncated: boolean
+}
+
+type ProfileFavoriteTextProjection = {
+	id: string
+	title: string
+	thumbnail: string | null
+	mediaType: string | null
+	startYear: string | null
+}
+
+type BoundedProfileFavoriteText = {
+	title: string
+	thumbnail: string | null
+	mediaType: string
+	startYear: string
+	truncated: boolean
+}
+
+function boundedProjectedText(
+	value: string | null,
+	limit: number,
+): { value: string | null; truncated: boolean } {
+	if (value === null) return { value: null, truncated: false }
+	if (value.length <= limit) return { value, truncated: false }
+	let end = limit
+	const last = value.charCodeAt(end - 1)
+	const next = value.charCodeAt(end)
+	if (last >= 0xd800 && last <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
+		end--
+	}
+	return { value: value.slice(0, end), truncated: true }
+}
+
+/**
+ * SQLite/PostgreSQL substr count Unicode characters while JS budgets UTF-16
+ * code units. Fetch one extra database character as a truncation sentinel, then
+ * enforce the exact semantic limit in JS. Raw transfer has a separate ceiling
+ * of at most twice this character count, preserving BMP/ASCII behavior while
+ * keeping astral-heavy source memory explicitly bounded.
+ */
+function sqlProjectionCharacterLimit(codeUnitLimit: number) {
+	return codeUnitLimit + 1
+}
+
+function createProfileHistoryProjectionBudget(): ProfileHistoryProjectionBudget {
+	return {
+		remaining: PROFILE_HISTORY_REQUEST_CODE_UNIT_LIMIT,
+		rawRemaining: PROFILE_HISTORY_RAW_REQUEST_CODE_UNIT_LIMIT,
+		truncated: false,
+	}
+}
+
+function createProfileCategoryRequestBudget(): ProfileCategoryRequestBudget {
+	return {
+		candidate: {
+			remaining: PROFILE_CATEGORY_CANDIDATE_CODE_UNIT_LIMIT,
+			rawRemaining: PROFILE_CATEGORY_CANDIDATE_RAW_CODE_UNIT_LIMIT,
+			truncated: false,
+		},
+		exact: {
+			remaining: PROFILE_CATEGORY_EXACT_CODE_UNIT_LIMIT,
+			rawRemaining: PROFILE_CATEGORY_EXACT_RAW_CODE_UNIT_LIMIT,
+			truncated: false,
+		},
+	}
+}
+
+function consumeProjectedCategoryText(
+	value: string | null,
+	limit: number,
+	budget: ProfileCategoryProjectionBudget,
+) {
+	if (value === null) return { value: null, truncated: false }
+
+	const rawLimit = 2 * sqlProjectionCharacterLimit(limit)
+	const rawLength = value.length
+	if (rawLength > rawLimit || rawLength > budget.rawRemaining) {
+		budget.rawRemaining = Math.max(0, budget.rawRemaining - rawLength)
+		budget.truncated = true
+		return { value: null, truncated: true }
+	}
+	budget.rawRemaining -= rawLength
+
+	const projected = boundedProjectedText(value, limit)
+	const semanticLength = projected.value?.length ?? 0
+	if (semanticLength > budget.remaining) {
+		budget.remaining = 0
+		budget.truncated = true
+		return { value: null, truncated: true }
+	}
+	budget.remaining -= semanticLength
+	budget.truncated ||= projected.truncated
+	return projected
+}
+
+function consumeProjectedCategoryRow(
+	row: ProfileCategoryTextProjection,
+	budget: ProfileCategoryProjectionBudget,
+): BoundedCategoryEntryText {
+	const type = consumeProjectedCategoryText(
+		row.type,
+		PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT,
+		budget,
+	)
+	const genres = consumeProjectedCategoryText(
+		row.genres,
+		PROFILE_CATEGORY_GENRES_CODE_UNIT_LIMIT,
+		budget,
+	)
+	return {
+		type: type.value,
+		genres: genres.value,
+		categorySourceTruncated: type.truncated || genres.truncated,
+	}
+}
+
+function historyProjection(
+	budget: ProfileHistoryProjectionBudget,
+	rowCount: number,
+) {
+	const perRowLimit = Math.min(
+		PROFILE_HISTORY_DB_CODE_UNIT_LIMIT,
+		Math.max(0, Math.floor(budget.remaining / Math.max(rowCount, 1)) - 1),
+		Math.max(
+			0,
+			Math.floor(budget.rawRemaining / (2 * Math.max(rowCount, 1))) - 1,
+		),
+	)
+	const projectedCharacterLimit =
+		perRowLimit > 0 ? sqlProjectionCharacterLimit(perRowLimit) : 0
+	return {
+		perRowLimit,
+		projectedCharacterLimit,
+		sql:
+			projectedCharacterLimit > 0
+				? Prisma.sql`substr("history", 1, CAST(${projectedCharacterLimit} AS INTEGER))`
+				: Prisma.sql`CASE
+						WHEN "history" IS NULL OR "history" = '' OR "history" = 'null'
+						THEN NULL
+						ELSE '{'
+					END`,
+	}
+}
+
+function consumeProjectedHistory(
+	value: string | null,
+	perRowLimit: number,
+	projectedCharacterLimit: number,
+	budget: ProfileHistoryProjectionBudget,
+) {
+	if (value === null) return null
+	budget.rawRemaining = Math.max(0, budget.rawRemaining - value.length)
+	if (
+		perRowLimit <= 0 ||
+		projectedCharacterLimit <= 0 ||
+		value.length > perRowLimit
+	) {
+		budget.truncated = true
+		if (perRowLimit > 0) {
+			budget.remaining = Math.max(0, budget.remaining - perRowLimit)
+		}
+		// A clipped JSON prefix must never be interpreted as complete.
+		return '{'
+	}
+	budget.remaining = Math.max(0, budget.remaining - value.length)
+	return value
+}
+
+async function loadBoundedProfileOverviewText(
+	db: Prisma.TransactionClient,
+	entryIds: readonly string[],
+	historyBudget: ProfileHistoryProjectionBudget,
+) {
+	if (!entryIds.length) return new Map<string, BoundedOverviewEntryText>()
+	const history = historyProjection(historyBudget, entryIds.length)
+	const rows = await db.$queryRaw<ProfileOverviewTextProjection[]>(Prisma.sql`
+		SELECT
+			"id",
+			${history.sql} AS "history",
+			substr("length", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "length",
+			substr("chapters", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "chapters",
+			substr("volumes", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "volumes"
+		FROM "Entry"
+		WHERE "id" IN (${Prisma.join(entryIds)})
+	`)
+
+	return new Map(
+		rows.map(row => {
+			const length = boundedProjectedText(
+				row.length,
+				PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT,
+			)
+			const chapters = boundedProjectedText(
+				row.chapters,
+				PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT,
+			)
+			const volumes = boundedProjectedText(
+				row.volumes,
+				PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT,
+			)
+			return [
+				row.id,
+				{
+					history: consumeProjectedHistory(
+						row.history,
+						history.perRowLimit,
+						history.projectedCharacterLimit,
+						historyBudget,
+					),
+					length: length.truncated ? null : length.value,
+					chapters: chapters.truncated ? null : chapters.value,
+					volumes: volumes.truncated ? null : volumes.value,
+				},
+			]
+		}),
+	)
+}
+
+async function loadBoundedProfileAnalyticsText(
+	db: Prisma.TransactionClient,
+	entryIds: readonly string[],
+	historyBudget: ProfileHistoryProjectionBudget,
+	categoryBudget: ProfileCategoryProjectionBudget,
+) {
+	if (!entryIds.length) return new Map<string, BoundedAnalyticsEntryText>()
+	const history = historyProjection(historyBudget, entryIds.length)
+	const rows = await db.$queryRaw<ProfileAnalyticsTextProjection[]>(Prisma.sql`
+		SELECT
+			"id",
+			${history.sql} AS "history",
+			substr("type", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT)} AS INTEGER)) AS "type",
+			substr("genres", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_CATEGORY_GENRES_CODE_UNIT_LIMIT)} AS INTEGER)) AS "genres",
+			substr("airYear", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_YEAR_TEXT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "airYear",
+			substr("startSeason", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_YEAR_TEXT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "startSeason",
+			substr("startYear", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_YEAR_TEXT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "startYear",
+			substr("length", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "length",
+			substr("chapters", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "chapters",
+			substr("volumes", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "volumes"
+		FROM "Entry"
+		WHERE "id" IN (${Prisma.join(entryIds)})
+	`)
+
+	return new Map(
+		rows.map(row => {
+			const category = consumeProjectedCategoryRow(row, categoryBudget)
+			const airYear = boundedProjectedText(
+				row.airYear,
+				PROFILE_YEAR_TEXT_CODE_UNIT_LIMIT,
+			)
+			const startSeason = boundedProjectedText(
+				row.startSeason,
+				PROFILE_YEAR_TEXT_CODE_UNIT_LIMIT,
+			)
+			const startYear = boundedProjectedText(
+				row.startYear,
+				PROFILE_YEAR_TEXT_CODE_UNIT_LIMIT,
+			)
+			const length = boundedProjectedText(
+				row.length,
+				PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT,
+			)
+			const chapters = boundedProjectedText(
+				row.chapters,
+				PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT,
+			)
+			const volumes = boundedProjectedText(
+				row.volumes,
+				PROFILE_PROGRESS_TEXT_CODE_UNIT_LIMIT,
+			)
+			return [
+				row.id,
+				{
+					history: consumeProjectedHistory(
+						row.history,
+						history.perRowLimit,
+						history.projectedCharacterLimit,
+						historyBudget,
+					),
+					type: category.type,
+					genres: category.genres,
+					airYear: airYear.truncated ? null : airYear.value,
+					startSeason: startSeason.truncated ? null : startSeason.value,
+					startYear: startYear.truncated ? null : startYear.value,
+					length: length.truncated ? null : length.value,
+					chapters: chapters.truncated ? null : chapters.value,
+					volumes: volumes.truncated ? null : volumes.value,
+					categorySourceTruncated:
+						category.categorySourceTruncated ||
+						airYear.truncated ||
+						startSeason.truncated ||
+						startYear.truncated ||
+						length.truncated ||
+						chapters.truncated ||
+						volumes.truncated,
+				},
+			]
+		}),
+	)
+}
+
+async function loadBoundedProfileCategoryText(
+	db: Prisma.TransactionClient,
+	entryIds: readonly string[],
+	categoryBudget: ProfileCategoryProjectionBudget,
+) {
+	if (!entryIds.length) return new Map<string, BoundedCategoryEntryText>()
+	const rows = await db.$queryRaw<ProfileCategoryTextProjection[]>(Prisma.sql`
+		SELECT
+			"id",
+			substr("type", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_CATEGORY_TYPE_CODE_UNIT_LIMIT)} AS INTEGER)) AS "type",
+			substr("genres", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_CATEGORY_GENRES_CODE_UNIT_LIMIT)} AS INTEGER)) AS "genres"
+		FROM "Entry"
+		WHERE "id" IN (${Prisma.join(entryIds)})
+	`)
+	return new Map(
+		rows.map(row => [row.id, consumeProjectedCategoryRow(row, categoryBudget)]),
+	)
+}
+
+async function loadBoundedProfileActivityEntryText(
+	db: Prisma.TransactionClient,
+	entryIds: readonly string[],
+	historyBudget: ProfileHistoryProjectionBudget,
+) {
+	if (!entryIds.length) return new Map<string, BoundedActivityEntryText>()
+	const history = historyProjection(historyBudget, entryIds.length)
+	const rows = await db.$queryRaw<ProfileActivityEntryTextProjection[]>(
+		Prisma.sql`
+			SELECT
+				"id",
+				${history.sql} AS "history",
+				substr("title", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_TITLE_CODE_UNIT_LIMIT)} AS INTEGER)) AS "title",
+				substr("thumbnail", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_THUMBNAIL_CODE_UNIT_LIMIT)} AS INTEGER)) AS "thumbnail"
+			FROM "Entry"
+			WHERE "id" IN (${Prisma.join(entryIds)})
+		`,
+	)
+	return new Map(
+		rows.map(row => {
+			const title = boundedProjectedText(
+				row.title,
+				PROFILE_ACTIVITY_TITLE_CODE_UNIT_LIMIT,
+			)
+			const thumbnail = boundedProjectedText(
+				row.thumbnail,
+				PROFILE_ACTIVITY_THUMBNAIL_CODE_UNIT_LIMIT,
+			)
+			return [
+				row.id,
+				{
+					history: consumeProjectedHistory(
+						row.history,
+						history.perRowLimit,
+						history.projectedCharacterLimit,
+						historyBudget,
+					),
+					title: title.truncated ? `${title.value}…` : (title.value ?? ''),
+					thumbnail: thumbnail.truncated ? null : thumbnail.value,
+				},
+			]
+		}),
+	)
+}
+
+async function loadBoundedProfileMediaText(
+	db: Prisma.TransactionClient,
+	mediaIds: readonly string[],
+) {
+	if (!mediaIds.length) return new Map<string, BoundedProfileMediaText>()
+	const rows = await db.$queryRaw<ProfileMediaTextProjection[]>(Prisma.sql`
+		SELECT
+			"id",
+			substr("title", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_TITLE_CODE_UNIT_LIMIT)} AS INTEGER)) AS "title",
+			substr("thumbnail", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_THUMBNAIL_CODE_UNIT_LIMIT)} AS INTEGER)) AS "thumbnail"
+		FROM "Media"
+		WHERE "id" IN (${Prisma.join(mediaIds)})
+	`)
+	return new Map(
+		rows.map(row => {
+			const title = boundedProjectedText(
+				row.title,
+				PROFILE_ACTIVITY_TITLE_CODE_UNIT_LIMIT,
+			)
+			const thumbnail = boundedProjectedText(
+				row.thumbnail,
+				PROFILE_ACTIVITY_THUMBNAIL_CODE_UNIT_LIMIT,
+			)
+			return [
+				row.id,
+				{
+					title: title.truncated ? `${title.value}…` : title.value,
+					thumbnail: thumbnail.truncated ? null : thumbnail.value,
+					truncated: title.truncated || thumbnail.truncated,
+				},
+			]
+		}),
+	)
+}
+
+async function loadBoundedProfileActivityEventText(
+	db: Prisma.TransactionClient,
+	eventIds: readonly string[],
+) {
+	if (!eventIds.length)
+		return new Map<string, BoundedProfileActivityEventText>()
+	const rows = await db.$queryRaw<ProfileActivityEventTextProjection[]>(
+		Prisma.sql`
+			SELECT
+				"id",
+				substr("type", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT)} AS INTEGER)) AS "type",
+				substr("status", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT)} AS INTEGER)) AS "status",
+				substr("statusLabel", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT)} AS INTEGER)) AS "statusLabel",
+				substr("previousStatus", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT)} AS INTEGER)) AS "previousStatus",
+				substr("previousStatusLabel", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT)} AS INTEGER)) AS "previousStatusLabel",
+				substr("progressUnit", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_PROGRESS_UNIT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "progressUnit"
+			FROM "ActivityEvent"
+			WHERE "id" IN (${Prisma.join(eventIds)})
+		`,
+	)
+	return new Map(
+		rows.map(row => {
+			const type = boundedProjectedText(
+				row.type,
+				PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT,
+			)
+			const status = boundedProjectedText(
+				row.status,
+				PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT,
+			)
+			const statusLabel = boundedProjectedText(
+				row.statusLabel,
+				PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT,
+			)
+			const previousStatus = boundedProjectedText(
+				row.previousStatus,
+				PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT,
+			)
+			const previousStatusLabel = boundedProjectedText(
+				row.previousStatusLabel,
+				PROFILE_ACTIVITY_LABEL_CODE_UNIT_LIMIT,
+			)
+			const progressUnit = boundedProjectedText(
+				row.progressUnit,
+				PROFILE_ACTIVITY_PROGRESS_UNIT_CODE_UNIT_LIMIT,
+			)
+			return [
+				row.id,
+				{
+					type: type.value ?? 'tracking',
+					status: status.value,
+					statusLabel: statusLabel.value,
+					previousStatus: previousStatus.value,
+					previousStatusLabel: previousStatusLabel.value,
+					progressUnit: progressUnit.value,
+					truncated: [
+						type,
+						status,
+						statusLabel,
+						previousStatus,
+						previousStatusLabel,
+						progressUnit,
+					].some(value => value.truncated),
+				},
+			]
+		}),
+	)
+}
+
+async function loadBoundedProfileFavoriteText(
+	db: ProfileDbClient,
+	favoriteIds: readonly string[],
+) {
+	if (!favoriteIds.length) return new Map<string, BoundedProfileFavoriteText>()
+	const rows = await db.$queryRaw<ProfileFavoriteTextProjection[]>(Prisma.sql`
+		SELECT
+			"id",
+			substr("title", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_TITLE_CODE_UNIT_LIMIT)} AS INTEGER)) AS "title",
+			substr("thumbnail", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_ACTIVITY_THUMBNAIL_CODE_UNIT_LIMIT)} AS INTEGER)) AS "thumbnail",
+			substr("mediaType", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_FAVORITE_META_CODE_UNIT_LIMIT)} AS INTEGER)) AS "mediaType",
+			substr("startYear", 1, CAST(${sqlProjectionCharacterLimit(PROFILE_YEAR_TEXT_CODE_UNIT_LIMIT)} AS INTEGER)) AS "startYear"
+		FROM "UserFavorite"
+		WHERE "id" IN (${Prisma.join(favoriteIds)})
+	`)
+	return new Map(
+		rows.map(row => {
+			const title = boundedProjectedText(
+				row.title,
+				PROFILE_ACTIVITY_TITLE_CODE_UNIT_LIMIT,
+			)
+			const thumbnail = boundedProjectedText(
+				row.thumbnail,
+				PROFILE_ACTIVITY_THUMBNAIL_CODE_UNIT_LIMIT,
+			)
+			const mediaType = boundedProjectedText(
+				row.mediaType,
+				PROFILE_FAVORITE_META_CODE_UNIT_LIMIT,
+			)
+			const startYear = boundedProjectedText(
+				row.startYear,
+				PROFILE_YEAR_TEXT_CODE_UNIT_LIMIT,
+			)
+			return [
+				row.id,
+				{
+					title: title.truncated ? `${title.value}…` : (title.value ?? ''),
+					thumbnail: thumbnail.truncated ? null : thumbnail.value,
+					mediaType: mediaType.value ?? '',
+					startYear: startYear.value ?? '',
+					truncated: [title, thumbnail, mediaType, startYear].some(
+						value => value.truncated,
+					),
+				},
+			]
+		}),
+	)
+}
+
+function isRetryableProfileSnapshotError(error: unknown) {
+	return (
+		error !== null &&
+		typeof error === 'object' &&
+		'code' in error &&
+		error.code === 'P2034'
+	)
+}
+
+async function withProfileSnapshot<Result>(
+	callback: (tx: Prisma.TransactionClient) => Promise<Result>,
+) {
+	const isolationLevel = process.env.DATABASE_URL?.startsWith('postgres')
+		? ('RepeatableRead' as Prisma.TransactionIsolationLevel)
+		: ('Serializable' as Prisma.TransactionIsolationLevel)
+
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		try {
+			return await prisma.$transaction(callback, {
+				isolationLevel,
+				maxWait: 5_000,
+				timeout: PROFILE_SNAPSHOT_TIMEOUT_MS,
+			})
+		} catch (error) {
+			if (attempt === 0 && isRetryableProfileSnapshotError(error)) continue
+			throw error
+		}
+	}
+
+	throw new Error('Unable to read a consistent profile snapshot')
+}
+
+async function requireProfileUser(
+	username: string | undefined,
+	db: ProfileDbClient = prisma,
+) {
+	const user = await db.user.findUnique({
 		where: { username },
 		select: { id: true },
 	})
@@ -122,6 +844,343 @@ function typeIdForKind(
 	return listTypeName ? (listTypeIdByName.get(listTypeName) ?? null) : null
 }
 
+export async function scanProfileEntryPages<Row extends { id: string }>({
+	watchlistIds,
+	fetchPage,
+	onPage,
+	limit = PROFILE_ANALYTICS_ENTRY_LIMIT,
+	batchSize = PROFILE_ENTRY_BATCH_SIZE,
+}: {
+	watchlistIds: readonly string[]
+	fetchPage: (
+		watchlistId: string,
+		cursor: string | undefined,
+		take: number,
+	) => Promise<Row[]>
+	onPage: (rows: readonly Row[]) => void | Promise<void>
+	limit?: number
+	batchSize?: number
+}) {
+	if (
+		!Number.isSafeInteger(batchSize) ||
+		batchSize < 1 ||
+		batchSize > PROFILE_ENTRY_BATCH_SIZE
+	) {
+		throw new RangeError(
+			`Profile entry batch size must be between 1 and ${PROFILE_ENTRY_BATCH_SIZE}`,
+		)
+	}
+	let processed = 0
+
+	for (
+		let watchlistIndex = 0;
+		watchlistIndex < watchlistIds.length;
+		watchlistIndex += 1
+	) {
+		const watchlistId = watchlistIds[watchlistIndex]
+		if (!watchlistId) continue
+		let cursor: string | undefined
+		while (processed < limit) {
+			const remaining = limit - processed
+			const take = remaining <= batchSize ? remaining + 1 : batchSize
+			const rows = await fetchPage(watchlistId, cursor, take)
+			const page = rows.slice(0, remaining)
+			if (!page.length) break
+
+			await onPage(page)
+			processed += page.length
+			cursor = page.at(-1)?.id
+
+			if (rows.length > page.length) {
+				return { processed, truncated: true }
+			}
+			if (rows.length < take) break
+		}
+
+		if (processed >= limit) {
+			for (
+				let remainingIndex = watchlistIndex + 1;
+				remainingIndex < watchlistIds.length;
+				remainingIndex += 1
+			) {
+				const remainingWatchlistId = watchlistIds[remainingIndex]
+				if (
+					remainingWatchlistId &&
+					(await fetchPage(remainingWatchlistId, undefined, 1)).length
+				) {
+					return { processed, truncated: true }
+				}
+			}
+			return { processed, truncated: false }
+		}
+	}
+
+	return { processed, truncated: false }
+}
+
+function visibleProfileTrackingState(
+	entry: Pick<AnalyticsEntryRow, 'mediaId' | 'trackingState'>,
+	visibleWatchlistIds: ReadonlySet<string>,
+	isOwner: boolean,
+	profileOwnerId: string,
+): {
+	trackingState: AnalyticsEntryRow['trackingState']
+	redactLegacyTracking: boolean
+} {
+	const trackingState =
+		entry.trackingState &&
+		entry.trackingState.ownerId === profileOwnerId &&
+		entry.trackingState.mediaId === entry.mediaId &&
+		(isOwner ||
+			entry.trackingState.statusWatchlistId === null ||
+			visibleWatchlistIds.has(entry.trackingState.statusWatchlistId))
+			? entry.trackingState
+			: null
+	return {
+		trackingState,
+		redactLegacyTracking:
+			!isOwner && entry.trackingState !== null && trackingState === null,
+	}
+}
+
+function normalizeAnalyticsEntry(
+	entry: AnalyticsEntryWithText,
+	visibleWatchlistIds: ReadonlySet<string>,
+	isOwner: boolean,
+	profileOwnerId: string,
+): ProfileAnalyticsEntry & ProfileTrackingEntry {
+	const { trackingState, redactLegacyTracking } = visibleProfileTrackingState(
+		entry,
+		visibleWatchlistIds,
+		isOwner,
+		profileOwnerId,
+	)
+	const entryPersonal = redactLegacyTracking ? null : entry.personal
+	const personal = preferredScore(trackingState?.score, entryPersonal)
+	const tmdbScore = preferredScore(entry.media?.tmdbScore, entry.tmdbScore)
+	const malScore = preferredScore(entry.media?.malScore, entry.malScore)
+
+	return {
+		...entry,
+		history: redactLegacyTracking ? null : entry.history,
+		length: redactLegacyTracking ? null : entry.length,
+		chapters: redactLegacyTracking ? null : entry.chapters,
+		volumes: redactLegacyTracking ? null : entry.volumes,
+		averaged: entry.averaged === null ? null : Number(entry.averaged),
+		personal: personal === null ? null : Number(personal),
+		tmdbScore: tmdbScore === null ? null : Number(tmdbScore),
+		malScore: malScore === null ? null : Number(malScore),
+		trackingState: trackingState
+			? {
+					...trackingState,
+					score:
+						trackingState.score === null ? null : Number(trackingState.score),
+				}
+			: null,
+	}
+}
+
+function normalizeOverviewEntry(
+	entry: OverviewEntryWithText,
+	visibleWatchlistIds: ReadonlySet<string>,
+	isOwner: boolean,
+	profileOwnerId: string,
+): ProfileAnalyticsEntry & ProfileTrackingEntry {
+	const { trackingState, redactLegacyTracking } = visibleProfileTrackingState(
+		entry,
+		visibleWatchlistIds,
+		isOwner,
+		profileOwnerId,
+	)
+	const entryPersonal = redactLegacyTracking ? null : entry.personal
+	const personal = preferredScore(trackingState?.score, entryPersonal)
+
+	return {
+		...entry,
+		history: redactLegacyTracking ? null : entry.history,
+		length: redactLegacyTracking ? null : entry.length,
+		chapters: redactLegacyTracking ? null : entry.chapters,
+		volumes: redactLegacyTracking ? null : entry.volumes,
+		personal: personal === null ? null : Number(personal),
+		trackingState: trackingState
+			? {
+					...trackingState,
+					score:
+						trackingState.score === null ? null : Number(trackingState.score),
+				}
+			: null,
+	}
+}
+
+async function loadProfileAnalyticsFirstPass(
+	{
+		db,
+		viewerId,
+		user,
+		mode,
+		categoryBudget,
+	}: {
+		db: Prisma.TransactionClient
+		viewerId: string | null
+		user: { id: string }
+		mode: 'overview' | 'stats'
+		categoryBudget?: ProfileCategoryProjectionBudget
+	},
+	timings?: Timings,
+) {
+	if (mode === 'stats' && !categoryBudget) {
+		throw new Error('Stats analytics requires a category projection budget')
+	}
+	const isOwner = viewerId === user.id
+	const watchlistWhere = {
+		ownerId: user.id,
+		...(isOwner ? {} : { isPublic: true }),
+	} satisfies Prisma.WatchlistWhereInput
+	const { listTypes, watchlistRows } = await time(
+		async () => {
+			const watchlistRows = await db.watchlist.findMany({
+				where: watchlistWhere,
+				orderBy: [{ typeId: 'asc' }, { position: 'asc' }, { id: 'asc' }],
+				take: PROFILE_WATCHLIST_LIMIT + 1,
+				select: watchlistSelect,
+			})
+			const typeIds = [
+				...new Set(
+					watchlistRows
+						.slice(0, PROFILE_WATCHLIST_LIMIT)
+						.map(watchlist => watchlist.typeId),
+				),
+			]
+			const listTypes = typeIds.length
+				? await db.listType.findMany({
+						where: { id: { in: typeIds } },
+						select: listTypeSelect,
+					})
+				: []
+			return { listTypes, watchlistRows }
+		},
+		{ type: 'profile_db', desc: 'visible analytics scope', timings },
+	)
+	const watchlists = watchlistRows.slice(0, PROFILE_WATCHLIST_LIMIT)
+	const watchlistsTruncated = watchlistRows.length > watchlists.length
+	const watchlistIds = watchlists.map(watchlist => watchlist.id)
+	const visibleWatchlistIds = new Set(watchlistIds)
+	const analyticsAccumulator = createProfileAnalyticsAccumulator({
+		listTypes,
+		watchlists,
+		mode,
+	})
+	const trackingAccumulator = createProfileTrackingAccumulator({
+		listTypes,
+		watchlists,
+	})
+	const historyBudget = createProfileHistoryProjectionBudget()
+
+	const scan = await time(
+		mode === 'overview'
+			? scanProfileEntryPages<OverviewEntryRow>({
+					watchlistIds,
+					batchSize: PROFILE_HISTORY_ENTRY_BATCH_SIZE,
+					fetchPage: (watchlistId, cursor, take) =>
+						db.entry.findMany({
+							where: {
+								watchlistId,
+								...(cursor ? { id: { gt: cursor } } : {}),
+								watchlist: watchlistWhere,
+							},
+							orderBy: { id: 'asc' },
+							take,
+							select: overviewEntrySelect,
+						}),
+					onPage: async rows => {
+						const textByEntry = await loadBoundedProfileOverviewText(
+							db,
+							rows.map(entry => entry.id),
+							historyBudget,
+						)
+						const normalizedRows = rows.map(entry =>
+							normalizeOverviewEntry(
+								{
+									...entry,
+									...(textByEntry.get(entry.id) ??
+										({
+											history: null,
+											length: null,
+											chapters: null,
+											volumes: null,
+										} satisfies BoundedOverviewEntryText)),
+								},
+								visibleWatchlistIds,
+								isOwner,
+								user.id,
+							),
+						)
+						analyticsAccumulator.addMany(normalizedRows)
+						trackingAccumulator.addMany(normalizedRows)
+					},
+				})
+			: scanProfileEntryPages<AnalyticsEntryRow>({
+					watchlistIds,
+					batchSize: PROFILE_HISTORY_ENTRY_BATCH_SIZE,
+					fetchPage: (watchlistId, cursor, take) =>
+						db.entry.findMany({
+							where: {
+								watchlistId,
+								...(cursor ? { id: { gt: cursor } } : {}),
+								watchlist: watchlistWhere,
+							},
+							orderBy: { id: 'asc' },
+							take,
+							select: analyticsEntrySelect,
+						}),
+					onPage: async rows => {
+						const textByEntry = await loadBoundedProfileAnalyticsText(
+							db,
+							rows.map(entry => entry.id),
+							historyBudget,
+							categoryBudget!,
+						)
+						const normalizedRows = rows.map(entry =>
+							normalizeAnalyticsEntry(
+								{
+									...entry,
+									...(textByEntry.get(entry.id) ??
+										({
+											history: null,
+											type: null,
+											genres: null,
+											airYear: null,
+											startSeason: null,
+											startYear: null,
+											length: null,
+											chapters: null,
+											volumes: null,
+											categorySourceTruncated: true,
+										} satisfies BoundedAnalyticsEntryText)),
+								},
+								visibleWatchlistIds,
+								isOwner,
+								user.id,
+							),
+						)
+						analyticsAccumulator.addMany(normalizedRows)
+						trackingAccumulator.addMany(normalizedRows)
+					},
+				}),
+		{ type: 'profile_db', desc: 'bounded analytics entry pages', timings },
+	)
+	if (scan.truncated) analyticsAccumulator.markTruncated()
+
+	return {
+		listTypes,
+		watchlists,
+		watchlistIds,
+		watchlistsTruncated,
+		firstPass: analyticsAccumulator.finish(),
+		trackingSummaries: trackingAccumulator.finish(),
+	}
+}
+
 export async function loadProfileShell(
 	request: Request,
 	username: string | undefined,
@@ -149,7 +1208,7 @@ export async function loadProfileShell(
 
 	invariantResponse(user, 'User not found', { status: 404 })
 
-	const [isFollowing, safetyState, listTypes, watchLists] = await time(
+	const [isFollowing, safetyState, listTypes] = await time(
 		Promise.all([
 			viewerId && viewerId !== user.id
 				? prisma.follow
@@ -172,14 +1231,6 @@ export async function loadProfileShell(
 						isBlockedByTarget: false,
 					},
 			prisma.listType.findMany({ select: listTypeSelect }),
-			prisma.watchlist.findMany({
-				where: {
-					ownerId: user.id,
-					AND: [visibleWatchlistWhere(viewerId)],
-				},
-				orderBy: [{ typeId: 'asc' }, { position: 'asc' }, { id: 'asc' }],
-				select: watchlistSelect,
-			}),
 		]),
 		{ type: 'profile_db', desc: 'profile shell relations', timings },
 	)
@@ -200,7 +1251,6 @@ export async function loadProfileShell(
 		}),
 		lastActiveAt: user.lastActiveAt,
 		listTypes,
-		watchLists,
 		followerCount: user._count.followers,
 		followingCount: user._count.following,
 		isFollowing,
@@ -208,78 +1258,472 @@ export async function loadProfileShell(
 	}
 }
 
-export async function loadProfileAnalytics(
+export async function loadProfileOverview(
 	request: Request,
 	username: string | undefined,
 	timings?: Timings,
 ) {
-	const [viewerId, user] = await time(
-		Promise.all([getUserId(request), requireProfileUser(username)]),
-		{ type: 'profile_db', desc: 'analytics visibility scope', timings },
-	)
-
-	const [listTypes, watchLists, entries] = await time(
-		Promise.all([
-			prisma.listType.findMany({ select: listTypeSelect }),
-			prisma.watchlist.findMany({
-				where: {
-					ownerId: user.id,
-					AND: [visibleWatchlistWhere(viewerId)],
+	const viewerId = await time(getUserId(request), {
+		type: 'profile_db',
+		desc: 'overview viewer scope',
+		timings,
+	})
+	return withProfileSnapshot(async db => {
+		const user = await requireProfileUser(username, db)
+		const { firstPass, trackingSummaries, watchlists, watchlistsTruncated } =
+			await loadProfileAnalyticsFirstPass(
+				{ db, viewerId, user, mode: 'overview' },
+				timings,
+			)
+		return time(
+			() => ({
+				trackingSummaries,
+				completionHistory: buildCompletionHistoryFromDays(
+					firstPass.completionDays,
+				),
+				diagnostic: {
+					...firstPass.diagnostic,
+					watchlistsProcessed: watchlists.length,
+					watchlistsTruncated,
+					watchlistLimit: PROFILE_WATCHLIST_LIMIT,
 				},
+			}),
+			{ type: 'profile_compute', desc: 'overview analytics DTO', timings },
+		)
+	})
+}
+
+export async function loadProfileStats(
+	request: Request,
+	username: string | undefined,
+	timings?: Timings,
+) {
+	const viewerId = await time(getUserId(request), {
+		type: 'profile_db',
+		desc: 'stats viewer scope',
+		timings,
+	})
+	return withProfileSnapshot(async db => {
+		const user = await requireProfileUser(username, db)
+		const categoryBudget = createProfileCategoryRequestBudget()
+		const {
+			listTypes,
+			watchlists,
+			watchlistIds,
+			watchlistsTruncated,
+			firstPass,
+			trackingSummaries,
+		} = await loadProfileAnalyticsFirstPass(
+			{
+				db,
+				viewerId,
+				user,
+				mode: 'stats',
+				categoryBudget: categoryBudget.candidate,
+			},
+			timings,
+		)
+		const watchlistWhere = {
+			ownerId: user.id,
+			...(viewerId === user.id ? {} : { isPublic: true }),
+		} satisfies Prisma.WatchlistWhereInput
+		const categoryAccumulator = createProfileAnalyticsCategoryAccumulator({
+			listTypes,
+			watchlists,
+			plan: firstPass.categoryPlan,
+		})
+		const categoryScan = await time(
+			scanProfileEntryPages<AnalyticsCategoryEntryRow>({
+				watchlistIds,
+				fetchPage: (watchlistId, cursor, take) =>
+					db.entry.findMany({
+						where: {
+							watchlistId,
+							...(cursor ? { id: { gt: cursor } } : {}),
+							watchlist: watchlistWhere,
+						},
+						orderBy: { id: 'asc' },
+						take,
+						select: analyticsCategoryEntrySelect,
+					}),
+				onPage: async rows => {
+					const textByEntry = await loadBoundedProfileCategoryText(
+						db,
+						rows.map(entry => entry.id),
+						categoryBudget.exact,
+					)
+					categoryAccumulator.addMany(
+						rows.map(entry => {
+							const text = textByEntry.get(entry.id)
+							return {
+								...entry,
+								type: text?.type ?? null,
+								genres: text?.genres ?? null,
+								categorySourceTruncated: text?.categorySourceTruncated ?? true,
+							}
+						}),
+					)
+				},
+			}),
+			{ type: 'profile_db', desc: 'bounded analytics category pages', timings },
+		)
+		if (categoryScan.truncated) categoryAccumulator.markTruncated()
+
+		return time(
+			() => {
+				const analytics = finalizeProfileAnalytics(
+					firstPass,
+					categoryAccumulator.finish(),
+				)
+				const { completionDays: _completionDays, ...statsAnalytics } = analytics
+				return {
+					trackingSummaries,
+					...statsAnalytics,
+					diagnostic: {
+						...statsAnalytics.diagnostic,
+						categoryCandidatesTruncated:
+							statsAnalytics.diagnostic.categoryCandidatesTruncated ||
+							categoryBudget.candidate.truncated ||
+							categoryBudget.exact.truncated,
+						watchlistsProcessed: watchlists.length,
+						watchlistsTruncated,
+						watchlistLimit: PROFILE_WATCHLIST_LIMIT,
+					},
+				}
+			},
+			{ type: 'profile_compute', desc: 'stats analytics DTO', timings },
+		)
+	})
+}
+
+async function loadProfileActivitySnapshot(
+	db: Prisma.TransactionClient,
+	viewerId: string | null,
+	user: { id: string },
+	timings?: Timings,
+) {
+	const isOwner = viewerId === user.id
+	const activityWhere = {
+		actorId: user.id,
+		...(isOwner
+			? {}
+			: {
+					isPublic: true,
+					publicEligible: true,
+					AND: [
+						{
+							OR: [
+								{ statusWatchlistId: null, statusLabel: null },
+								{
+									statusWatchlist: {
+										ownerId: user.id,
+										isPublic: true,
+									},
+								},
+							],
+						},
+						{
+							OR: [
+								{
+									previousStatusWatchlistId: null,
+									previousStatusLabel: null,
+								},
+								{
+									previousStatusWatchlist: {
+										ownerId: user.id,
+										isPublic: true,
+									},
+								},
+							],
+						},
+					],
+				}),
+	} satisfies Prisma.ActivityEventWhereInput
+	const watchlistWhere = {
+		ownerId: user.id,
+		...(isOwner ? {} : { isPublic: true }),
+	} satisfies Prisma.WatchlistWhereInput
+
+	const [watchlistRows, activityRows, reviewRows, diaryRows] = await time(
+		Promise.all([
+			db.watchlist.findMany({
+				where: watchlistWhere,
 				orderBy: [{ typeId: 'asc' }, { position: 'asc' }, { id: 'asc' }],
+				take: PROFILE_WATCHLIST_LIMIT + 1,
 				select: watchlistSelect,
 			}),
-			prisma.entry.findMany({
-				where: {
-					watchlist: {
-						ownerId: user.id,
-						AND: [visibleWatchlistWhere(viewerId)],
+			db.activityEvent.findMany({
+				where: activityWhere,
+				orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+				take: PROFILE_ACTIVITY_MAX_CAPACITY + 1,
+				select: activityEventSelect,
+			}),
+			db.review.findMany({
+				where: { authorId: user.id, moderationStatus: 'visible' },
+				orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+				take: PROFILE_ACTIVITY_MAX_CAPACITY + 1,
+				select: {
+					id: true,
+					createdAt: true,
+					media: {
+						select: { id: true, kind: true },
 					},
 				},
-				select: analyticsEntrySelect,
+			}),
+			db.diaryEntry.findMany({
+				where: { ownerId: user.id },
+				orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+				take: PROFILE_ACTIVITY_MAX_CAPACITY + 1,
+				select: {
+					id: true,
+					isRepeat: true,
+					createdAt: true,
+					media: {
+						select: { id: true, kind: true },
+					},
+				},
 			}),
 		]),
-		{ type: 'profile_db', desc: 'visible profile analytics rows', timings },
+		{ type: 'profile_db', desc: 'bounded normalized activity rows', timings },
+	)
+	const watchLists = watchlistRows.slice(0, PROFILE_WATCHLIST_LIMIT)
+	const watchlistsTruncated = watchlistRows.length > watchLists.length
+	const visibleWatchlistIds = new Set(watchLists.map(watchlist => watchlist.id))
+	const visibleListTypeIds = [
+		...new Set(watchLists.map(watchlist => watchlist.typeId)),
+	]
+	const normalizedMediaIds = [
+		...new Set(
+			[...activityRows, ...reviewRows, ...diaryRows].map(row => row.media.id),
+		),
+	]
+	const [unorderedListTypes, mediaTextById, activityTextById] = await time(
+		Promise.all([
+			db.listType.findMany({
+				where: {
+					OR: [
+						{ name: { in: [...PROFILE_ACTIVITY_LIST_TYPE_NAMES] } },
+						{ id: { in: visibleListTypeIds } },
+					],
+				},
+				select: listTypeSelect,
+			}),
+			loadBoundedProfileMediaText(db, normalizedMediaIds),
+			loadBoundedProfileActivityEventText(
+				db,
+				activityRows.map(event => event.id),
+			),
+		]),
+		{ type: 'profile_db', desc: 'bounded normalized activity text', timings },
+	)
+	const listTypeOrder = new Map<string, number>(
+		PROFILE_ACTIVITY_LIST_TYPE_NAMES.map((name, index) => [name, index]),
+	)
+	const listTypes = [...unorderedListTypes].sort(
+		(left, right) =>
+			(listTypeOrder.get(left.name) ?? Number.MAX_SAFE_INTEGER) -
+				(listTypeOrder.get(right.name) ?? Number.MAX_SAFE_INTEGER) ||
+			left.name.localeCompare(right.name) ||
+			left.id.localeCompare(right.id),
 	)
 
 	return time(
-		() => {
-			// Prisma Decimal instances render numerically on the server but do not
-			// hydrate as equivalent browser values. Normalize the analytics boundary
-			// so chart calculations are deterministic on both sides.
-			const normalizedEntries = entries.map(entry => ({
-				...entry,
-				averaged: entry.averaged === null ? null : Number(entry.averaged),
-				personal: entry.personal === null ? null : Number(entry.personal),
-				tmdbScore: entry.tmdbScore === null ? null : Number(entry.tmdbScore),
-				malScore: entry.malScore === null ? null : Number(entry.malScore),
-				trackingState: entry.trackingState
-					? {
-							...entry.trackingState,
-							score:
-								entry.trackingState.score === null
-									? null
-									: Number(entry.trackingState.score),
-						}
-					: null,
-			}))
-			const trackingSummaries = buildProfileTrackingSummaries({
-				listTypes,
-				watchlists: watchLists,
-				entries: normalizedEntries,
-			})
-			const historyEntries = normalizedEntries.map(
-				({ media: _media, trackingState: _trackingState, ...entry }) => entry,
+		async () => {
+			let normalizedSourceLimited =
+				mediaTextById.size !== normalizedMediaIds.length ||
+				activityTextById.size !== activityRows.length ||
+				[...mediaTextById.values()].some(text => text.truncated) ||
+				[...activityTextById.values()].some(text => text.truncated)
+			const boundedMediaItem = (media: { id: string; kind: string }) => {
+				const text = mediaTextById.get(media.id)
+				if (!text) normalizedSourceLimited = true
+				return mediaItem({
+					...media,
+					title: text?.title ?? null,
+					thumbnail: text?.thumbnail ?? null,
+				})
+			}
+			const listTypeIdByName = new Map(
+				listTypes.map(listType => [listType.name, listType.id]),
 			)
-			const { typedEntries } = buildProfileHistory({
-				listTypes,
-				watchlists: watchLists,
-				entries: historyEntries,
+			const trackingActivity = activityRows.map(event => {
+				const text = activityTextById.get(event.id)
+				if (!text) normalizedSourceLimited = true
+				return {
+					id: `tracking:${event.id}`,
+					action: activityEventLabel({
+						...event,
+						type: text?.type ?? 'tracking',
+						status: text?.status ?? null,
+						statusLabel: text?.statusLabel ?? null,
+						previousStatus: text?.previousStatus ?? null,
+						previousStatusLabel: text?.previousStatusLabel ?? null,
+						progressUnit: text?.progressUnit ?? null,
+					}),
+					time: event.createdAt,
+					typeId: typeIdForKind(event.media.kind, listTypeIdByName),
+					media: boundedMediaItem(event.media),
+				}
+			})
+			const normalizedTrackingTimes = new Map<string, number[]>()
+			for (const event of trackingActivity) {
+				const key = `${event.media.id}\u0000${event.action.toLowerCase()}`
+				const times = normalizedTrackingTimes.get(key) ?? []
+				times.push(event.time.getTime())
+				normalizedTrackingTimes.set(key, times)
+			}
+			const collector = createProfileActivityCollector()
+			collector.addBatch([
+				...trackingActivity,
+				...reviewRows.map(review => ({
+					id: `review:${review.id}`,
+					action: 'Published a review',
+					time: review.createdAt,
+					typeId: typeIdForKind(review.media.kind, listTypeIdByName),
+					media: boundedMediaItem(review.media),
+				})),
+				...diaryRows.map(entry => ({
+					id: `diary:${entry.id}`,
+					action: diaryActivityLabel(entry.media.kind, entry.isRepeat),
+					time: entry.createdAt,
+					typeId: typeIdForKind(entry.media.kind, listTypeIdByName),
+					media: boundedMediaItem(entry.media),
+				})),
+			])
+			// Legacy Entry.history has no immutable public-at-creation provenance.
+			// Keep compatibility history owner-only; visitors receive normalized
+			// public-eligible activity, reviews, and diary rows.
+			const watchlistIds = isOwner
+				? watchLists.map(watchlist => watchlist.id)
+				: []
+			const listTypeById = new Map(
+				listTypes.map(listType => [listType.id, listType]),
+			)
+			const watchlistById = new Map(
+				watchLists.map(watchlist => [watchlist.id, watchlist]),
+			)
+			let legacyHistoryLimited = false
+			const historyBudget = createProfileHistoryProjectionBudget()
+			const activityScan = await scanProfileEntryPages({
+				watchlistIds,
+				batchSize: PROFILE_HISTORY_ENTRY_BATCH_SIZE,
+				fetchPage: (watchlistId, cursor, take) =>
+					db.entry.findMany({
+						where: {
+							watchlistId,
+							...(cursor ? { id: { gt: cursor } } : {}),
+							watchlist: watchlistWhere,
+						},
+						orderBy: { id: 'asc' },
+						take,
+						select: {
+							id: true,
+							watchlistId: true,
+							mediaId: true,
+							trackingState: {
+								select: {
+									ownerId: true,
+									mediaId: true,
+									statusWatchlistId: true,
+								},
+							},
+						},
+					}),
+				onPage: async page => {
+					const textByEntry = await loadBoundedProfileActivityEntryText(
+						db,
+						page.map(entry => entry.id),
+						historyBudget,
+					)
+					for (const sourceEntry of page) {
+						const text = textByEntry.get(sourceEntry.id)
+						const state = sourceEntry.trackingState
+						const stateVisible =
+							state !== null &&
+							state.ownerId === user.id &&
+							state.mediaId === sourceEntry.mediaId &&
+							(isOwner ||
+								state.statusWatchlistId === null ||
+								visibleWatchlistIds.has(state.statusWatchlistId))
+						const redactLegacyTracking =
+							!isOwner && state !== null && !stateVisible
+						const sourceWatchlist = watchlistById.get(sourceEntry.watchlistId)
+						const sourceListType = sourceWatchlist
+							? listTypeById.get(sourceWatchlist.typeId)
+							: null
+						if (!sourceWatchlist || !sourceListType) {
+							legacyHistoryLimited = true
+							continue
+						}
+						const { typedEntries, typedHistory, diagnostic } =
+							buildProfileHistory({
+								listTypes: [sourceListType],
+								watchlists: [sourceWatchlist],
+								entries: [
+									{
+										id: sourceEntry.id,
+										watchlistId: sourceEntry.watchlistId,
+										mediaId: sourceEntry.mediaId,
+										title: text?.title ?? '',
+										thumbnail: text?.thumbnail ?? null,
+										history: redactLegacyTracking
+											? null
+											: (text?.history ?? null),
+									},
+								],
+							})
+						if (diagnostic) legacyHistoryLimited = true
+						for (const [typeId, items] of Object.entries(typedHistory)) {
+							const entry = typedEntries[typeId]?.[0]
+							if (!entry) continue
+							collector.addBatch(
+								items.flatMap((item, legacyIndex) => {
+									const semanticKey = `${entry.mediaId ?? ''}\u0000${item.type.toLowerCase()}`
+									if (
+										normalizedTrackingTimes
+											.get(semanticKey)
+											?.some(
+												time =>
+													Math.abs(time - item.time.getTime()) <=
+													PROFILE_ACTIVITY_DEDUPLICATION_WINDOW_MS,
+											)
+									) {
+										return []
+									}
+									return {
+										id: `legacy:${typeId}:${entry.id}:${legacyIndex}`,
+										action: item.type,
+										time: item.time,
+										typeId,
+										media: {
+											id: entry.mediaId ?? '',
+											title: entry.title.trim() || 'Untitled',
+											thumbnail: entry.thumbnail,
+										},
+									}
+								}),
+							)
+						}
+					}
+				},
 			})
 
-			return { typedEntries, trackingSummaries }
+			return {
+				activityEvents: collector.values(),
+				activityLimited:
+					activityScan.truncated ||
+					watchlistsTruncated ||
+					normalizedSourceLimited ||
+					historyBudget.truncated ||
+					legacyHistoryLimited ||
+					collector.truncated,
+			}
 		},
-		{ type: 'profile_compute', desc: 'analytics aggregation', timings },
+		{
+			type: 'profile_compute',
+			desc: 'bounded activity aggregation',
+			timings,
+		},
 	)
 }
 
@@ -288,160 +1732,15 @@ export async function loadProfileActivity(
 	username: string | undefined,
 	timings?: Timings,
 ) {
-	const [viewerId, user] = await time(
-		Promise.all([getUserId(request), requireProfileUser(username)]),
-		{ type: 'profile_db', desc: 'activity visibility scope', timings },
-	)
-
-	const [
-		listTypes,
-		watchLists,
-		activityRows,
-		firstActivity,
-		reviewRows,
-		diaryRows,
-		legacyEntries,
-	] = await time(
-		Promise.all([
-			prisma.listType.findMany({ select: listTypeSelect }),
-			prisma.watchlist.findMany({
-				where: {
-					ownerId: user.id,
-					AND: [visibleWatchlistWhere(viewerId)],
-				},
-				select: watchlistSelect,
-			}),
-			prisma.activityEvent.findMany({
-				where: {
-					actorId: user.id,
-					AND: [visibleActivityEventWhere(viewerId)],
-				},
-				orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-				take: 100,
-				select: activityEventSelect,
-			}),
-			prisma.activityEvent.findFirst({
-				where: {
-					actorId: user.id,
-					AND: [visibleActivityEventWhere(viewerId)],
-				},
-				orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
-				select: { createdAt: true },
-			}),
-			prisma.review.findMany({
-				where: { authorId: user.id, moderationStatus: 'visible' },
-				orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-				take: 100,
-				select: {
-					id: true,
-					createdAt: true,
-					media: {
-						select: { id: true, kind: true, title: true, thumbnail: true },
-					},
-				},
-			}),
-			prisma.diaryEntry.findMany({
-				where: { ownerId: user.id },
-				orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-				take: 100,
-				select: {
-					id: true,
-					isRepeat: true,
-					createdAt: true,
-					media: {
-						select: { id: true, kind: true, title: true, thumbnail: true },
-					},
-				},
-			}),
-			prisma.entry.findMany({
-				where: {
-					watchlist: {
-						ownerId: user.id,
-						AND: [visibleWatchlistWhere(viewerId)],
-					},
-				},
-				select: {
-					id: true,
-					watchlistId: true,
-					mediaId: true,
-					title: true,
-					thumbnail: true,
-					history: true,
-				},
-			}),
-		]),
-		{ type: 'profile_db', desc: 'bounded activity and legacy rows', timings },
-	)
-
-	return time(
-		() => {
-			const listTypeIdByName = new Map(
-				listTypes.map(listType => [listType.name, listType.id]),
-			)
-			const trackingActivity = activityRows.map(event => ({
-				id: `tracking:${event.id}`,
-				action: activityEventLabel(event),
-				time: event.createdAt,
-				typeId: typeIdForKind(event.media.kind, listTypeIdByName),
-				media: mediaItem(event.media),
-			}))
-			const normalizedActivity = [
-				...trackingActivity,
-				...reviewRows.map(review => ({
-					id: `review:${review.id}`,
-					action: 'Published a review',
-					time: review.createdAt,
-					typeId: typeIdForKind(review.media.kind, listTypeIdByName),
-					media: mediaItem(review.media),
-				})),
-				...diaryRows.map(entry => ({
-					id: `diary:${entry.id}`,
-					action: diaryActivityLabel(entry.media.kind, entry.isRepeat),
-					time: entry.createdAt,
-					typeId: typeIdForKind(entry.media.kind, listTypeIdByName),
-					media: mediaItem(entry.media),
-				})),
-			]
-			const { typedEntries, typedHistory } = buildProfileHistory({
-				listTypes,
-				watchlists: watchLists,
-				entries: legacyEntries,
-			})
-			const normalizedCutoff = firstActivity?.createdAt.getTime() ?? null
-			const legacyActivity = Object.entries(typedHistory)
-				.flatMap(([typeId, items]) =>
-					items.flatMap((item, legacyIndex) => {
-						const entry = typedEntries[typeId]?.[item.index]
-						if (!entry) return []
-						return {
-							id: `legacy:${typeId}:${entry.id}:${legacyIndex}`,
-							action: item.type,
-							time: item.time,
-							typeId,
-							media: {
-								id: entry.mediaId ?? '',
-								title: entry.title.trim() || 'Untitled',
-								thumbnail: entry.thumbnail,
-							},
-						}
-					}),
-				)
-				.filter(
-					item =>
-						normalizedCutoff === null ||
-						item.time.getTime() < normalizedCutoff - LEGACY_ACTIVITY_GRACE_MS,
-				)
-			const activityEvents = [...normalizedActivity, ...legacyActivity]
-				.sort(
-					(a, b) =>
-						b.time.getTime() - a.time.getTime() || b.id.localeCompare(a.id),
-				)
-				.slice(0, 100)
-
-			return { activityEvents }
-		},
-		{ type: 'profile_compute', desc: 'activity aggregation', timings },
-	)
+	const viewerId = await time(getUserId(request), {
+		type: 'profile_db',
+		desc: 'activity viewer scope',
+		timings,
+	})
+	return withProfileSnapshot(async db => {
+		const user = await requireProfileUser(username, db)
+		return loadProfileActivitySnapshot(db, viewerId, user, timings)
+	})
 }
 
 export async function loadProfileReviews(
@@ -540,22 +1839,38 @@ export async function loadProfileFavorites(
 		desc: 'favorites profile identity',
 		timings,
 	})
-	const favorites = await time(
+	const favoriteRows = await time(
 		prisma.userFavorite.findMany({
 			where: { ownerId: user.id },
 			orderBy: [{ typeId: 'asc' }, { position: 'asc' }, { id: 'asc' }],
+			take: PROFILE_FAVORITE_LIMIT + 1,
 			select: {
 				id: true,
 				position: true,
-				thumbnail: true,
-				title: true,
 				typeId: true,
-				mediaType: true,
-				startYear: true,
 				mediaId: true,
 			},
 		}),
 		{ type: 'profile_db', desc: 'profile favorites', timings },
 	)
-	return { favorites }
+	const visibleRows = favoriteRows.slice(0, PROFILE_FAVORITE_LIMIT)
+	const textByFavorite = await time(
+		loadBoundedProfileFavoriteText(
+			prisma,
+			visibleRows.map(favorite => favorite.id),
+		),
+		{ type: 'profile_db', desc: 'bounded favorite text', timings },
+	)
+	let favoritesLimited = favoriteRows.length > visibleRows.length
+	const favorites = visibleRows.flatMap(favorite => {
+		const text = textByFavorite.get(favorite.id)
+		if (!text) {
+			favoritesLimited = true
+			return []
+		}
+		const { truncated, ...publicText } = text
+		if (truncated) favoritesLimited = true
+		return [{ ...favorite, ...publicText }]
+	})
+	return { favorites, favoritesLimited }
 }

--- a/app/utils/profile-entry-scan.test.ts
+++ b/app/utils/profile-entry-scan.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from 'vitest'
+import { scanProfileEntryPages } from './profile-data.server.ts'
+
+function rows(count: number, prefix = 'entry') {
+	return Array.from({ length: count }, (_, index) => ({
+		id: `${prefix}-${index.toString().padStart(6, '0')}`,
+	}))
+}
+
+function scannerFor(data: Record<string, Array<{ id: string }>>) {
+	const takes: number[] = []
+	const pageSizes: number[] = []
+	return {
+		takes,
+		pageSizes,
+		scan: (limit: number) =>
+			scanProfileEntryPages({
+				watchlistIds: Object.keys(data),
+				limit,
+				fetchPage: async (watchlistId, cursor, take) => {
+					takes.push(take)
+					const start = cursor
+						? (data[watchlistId]?.findIndex(row => row.id === cursor) ?? -1) + 1
+						: 0
+					return (data[watchlistId] ?? []).slice(start, start + take)
+				},
+				onPage: page => {
+					pageSizes.push(page.length)
+				},
+			}),
+	}
+}
+
+test('distinguishes an exact entry ceiling from a ceiling plus one', async () => {
+	const exact = scannerFor({ list: rows(1_000) })
+	await expect(exact.scan(1_000)).resolves.toEqual({
+		processed: 1_000,
+		truncated: false,
+	})
+	expect(Math.max(...exact.pageSizes)).toBe(500)
+	expect(Math.max(...exact.takes)).toBe(501)
+
+	const overflow = scannerFor({ list: rows(1_001) })
+	await expect(overflow.scan(1_000)).resolves.toEqual({
+		processed: 1_000,
+		truncated: true,
+	})
+	expect(Math.max(...overflow.pageSizes)).toBe(500)
+})
+
+test('probes later watchlists after reaching the ceiling', async () => {
+	const exact = scannerFor({
+		first: rows(500, 'first'),
+		second: [],
+	})
+	await expect(exact.scan(500)).resolves.toEqual({
+		processed: 500,
+		truncated: false,
+	})
+
+	const overflow = scannerFor({
+		first: rows(500, 'first'),
+		second: rows(1, 'second'),
+	})
+	await expect(overflow.scan(500)).resolves.toEqual({
+		processed: 500,
+		truncated: true,
+	})
+})

--- a/app/utils/profile-history-bounds.test.ts
+++ b/app/utils/profile-history-bounds.test.ts
@@ -1,0 +1,197 @@
+import { expect, test } from 'vitest'
+import {
+	parseBoundedProfileHistory,
+	profileHistoryTimestamp,
+	PROFILE_HISTORY_CODE_UNIT_LIMIT,
+	PROFILE_HISTORY_DEPTH_LIMIT,
+	PROFILE_HISTORY_EVENT_LIMIT,
+	PROFILE_HISTORY_NODE_LIMIT,
+} from './profile-history-bounds.ts'
+
+function nestedHistory(depth: number) {
+	const root: Record<string, unknown> = {}
+	let cursor = root
+	for (let index = 0; index < depth; index += 1) {
+		const child: Record<string, unknown> = {}
+		cursor.next = child
+		cursor = child
+	}
+	return root
+}
+
+test('parses a detached JSON-compatible history object', () => {
+	const source = {
+		finished: '2026-01-01T00:00:00.000Z',
+		progress: { 1: { finishDate: ['2026-01-01T00:00:00.000Z'] } },
+	}
+	const result = parseBoundedProfileHistory(source)
+
+	expect(result).toEqual({
+		history: source,
+		rejected: false,
+		reason: null,
+		nodeCount: 6,
+		finishEventsTruncated: false,
+	})
+	expect(result.history).not.toBe(source)
+	expect(result.history?.progress).not.toBe(source.progress)
+})
+
+test('rejects oversized strings before JSON decoding', () => {
+	const input = `{"value":"${'x'.repeat(PROFILE_HISTORY_CODE_UNIT_LIMIT)}"}`
+	expect(parseBoundedProfileHistory(input)).toEqual({
+		history: null,
+		rejected: true,
+		reason: 'code-unit-limit',
+		nodeCount: 0,
+		finishEventsTruncated: false,
+	})
+})
+
+test('accepts the depth boundary and rejects the next nested container', () => {
+	expect(
+		parseBoundedProfileHistory(nestedHistory(PROFILE_HISTORY_DEPTH_LIMIT))
+			.rejected,
+	).toBe(false)
+	expect(
+		parseBoundedProfileHistory(nestedHistory(PROFILE_HISTORY_DEPTH_LIMIT + 1)),
+	).toEqual(
+		expect.objectContaining({
+			history: null,
+			rejected: true,
+			reason: 'depth-limit',
+		}),
+	)
+})
+
+test('accepts exactly the decoded-node ceiling and rejects one more node', () => {
+	const accepted = {
+		values: Array.from({ length: PROFILE_HISTORY_NODE_LIMIT - 2 }, () => null),
+	}
+	const rejected = { values: [...accepted.values, null] }
+
+	expect(parseBoundedProfileHistory(accepted)).toEqual(
+		expect.objectContaining({
+			rejected: false,
+			nodeCount: PROFILE_HISTORY_NODE_LIMIT,
+		}),
+	)
+	expect(parseBoundedProfileHistory(rejected)).toEqual(
+		expect.objectContaining({
+			rejected: true,
+			reason: 'node-limit',
+		}),
+	)
+})
+
+test('rejects cyclic, invalid, and non-record histories safely', () => {
+	const cyclic: Record<string, unknown> = {}
+	cyclic.self = cyclic
+
+	expect(parseBoundedProfileHistory(cyclic).reason).toBe('cycle')
+	expect(parseBoundedProfileHistory('{invalid').reason).toBe('invalid-json')
+	expect(parseBoundedProfileHistory('[]').reason).toBe('invalid-root')
+	expect(parseBoundedProfileHistory({ value: BigInt(1) }).reason).toBe(
+		'invalid-structure',
+	)
+})
+
+test('copies special JSON keys without changing object prototypes', () => {
+	const result = parseBoundedProfileHistory(
+		'{"__proto__":{"polluted":true},"constructor":"stored"}',
+	)
+
+	expect(result.rejected).toBe(false)
+	expect(Object.getPrototypeOf(result.history)).toBe(Object.prototype)
+	expect(
+		Object.prototype.hasOwnProperty.call(result.history, '__proto__'),
+	).toBe(true)
+	expect((result.history?.__proto__ as { polluted?: boolean }).polluted).toBe(
+		true,
+	)
+	expect(({} as { polluted?: boolean }).polluted).toBeUndefined()
+})
+
+test('caps finish timestamps across arrays to the newest valid values', () => {
+	const timestamps = Array.from(
+		{ length: PROFILE_HISTORY_EVENT_LIMIT + 1 },
+		(_, index) => new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+	)
+	const result = parseBoundedProfileHistory({
+		progress: {
+			episode: {
+				1: {
+					finishDate: [false, [], {}, 0, 'invalid', ...timestamps],
+				},
+			},
+		},
+	})
+	const history = result.history as {
+		progress: { episode: { 1: { finishDate: unknown[] } } }
+	}
+
+	expect(result.rejected).toBe(false)
+	expect(result.finishEventsTruncated).toBe(true)
+	expect(history.progress.episode[1].finishDate).toHaveLength(
+		PROFILE_HISTORY_EVENT_LIMIT + 5,
+	)
+	expect(history.progress.episode[1].finishDate).not.toContain(timestamps[0])
+	expect(history.progress.episode[1].finishDate).toContain(timestamps.at(-1))
+	expect(history.progress.episode[1].finishDate.slice(0, 5)).toEqual([
+		false,
+		[],
+		{},
+		0,
+		'invalid',
+	])
+})
+
+test('does not duplicate long ancestor keys for every finish candidate', () => {
+	const ancestor = 'ancestor'.repeat(8_000)
+	const timestamps = Array.from(
+		{ length: PROFILE_HISTORY_EVENT_LIMIT + 1 },
+		(_, index) => index + 1,
+	)
+	const result = parseBoundedProfileHistory({
+		progress: {
+			[ancestor]: { finishDate: timestamps },
+		},
+	})
+	const history = result.history as {
+		progress: Record<string, { finishDate: number[] }>
+	}
+
+	expect(result.rejected).toBe(false)
+	expect(result.finishEventsTruncated).toBe(true)
+	expect(history.progress[ancestor]?.finishDate).toHaveLength(
+		PROFILE_HISTORY_EVENT_LIMIT,
+	)
+	expect(history.progress[ancestor]?.finishDate[0]).toBe(2)
+	expect(history.progress[ancestor]?.finishDate.at(-1)).toBe(
+		PROFILE_HISTORY_EVENT_LIMIT + 1,
+	)
+})
+
+test('recognizes only explicit nonzero scalar history dates', () => {
+	const epoch = '1970-01-01T00:00:00.001Z'
+	expect(profileHistoryTimestamp(epoch)).toBe(1)
+	expect(profileHistoryTimestamp(1)).toBe(1)
+	expect(profileHistoryTimestamp(new Date(epoch))).toBe(1)
+
+	for (const value of [
+		true,
+		false,
+		[],
+		[epoch],
+		{},
+		{ valueOf: () => 1 },
+		1e100,
+		-1e100,
+		0,
+		'0',
+		' ',
+		'invalid',
+	]) {
+		expect(profileHistoryTimestamp(value)).toBeNull()
+	}
+})

--- a/app/utils/profile-history-bounds.ts
+++ b/app/utils/profile-history-bounds.ts
@@ -1,0 +1,321 @@
+export const PROFILE_HISTORY_CODE_UNIT_LIMIT = 512 * 1024
+export const PROFILE_HISTORY_DEPTH_LIMIT = 32
+export const PROFILE_HISTORY_NODE_LIMIT = 20_000
+export const PROFILE_HISTORY_EVENT_LIMIT = 10_000
+
+export type ProfileHistoryRejectReason =
+	| 'invalid-json'
+	| 'invalid-root'
+	| 'invalid-structure'
+	| 'code-unit-limit'
+	| 'depth-limit'
+	| 'node-limit'
+	| 'cycle'
+
+export type BoundedProfileHistoryResult = {
+	history: Record<string, unknown> | null
+	rejected: boolean
+	reason: ProfileHistoryRejectReason | null
+	nodeCount: number
+	finishEventsTruncated: boolean
+}
+
+type Container = Record<string, unknown> | unknown[]
+
+type CloneFrame = {
+	source: Container
+	target: Container
+	depth: number
+	finishDateArray: boolean
+}
+
+type FinishTimestampCandidate = {
+	array: unknown[]
+	index: number
+	timestamp: number
+	ordinal: number
+}
+
+function rejected(
+	reason: ProfileHistoryRejectReason,
+	nodeCount = 0,
+	finishEventsTruncated = false,
+): BoundedProfileHistoryResult {
+	return {
+		history: null,
+		rejected: true,
+		reason,
+		nodeCount,
+		finishEventsTruncated,
+	}
+}
+
+function isPlainObject(value: object) {
+	const prototype = Object.getPrototypeOf(value)
+	return prototype === Object.prototype || prototype === null
+}
+
+function isContainer(value: unknown): value is Container {
+	return (
+		value !== null &&
+		typeof value === 'object' &&
+		(Array.isArray(value) || isPlainObject(value))
+	)
+}
+
+function setCloneValue(target: Container, key: string, value: unknown) {
+	Object.defineProperty(target, key, {
+		value,
+		writable: true,
+		enumerable: true,
+		configurable: true,
+	})
+}
+
+function arrayIndex(key: string) {
+	const index = Number(key)
+	return Number.isInteger(index) &&
+		index >= 0 &&
+		index < 4_294_967_295 &&
+		String(index) === key
+		? index
+		: null
+}
+
+/**
+ * Converts only explicit scalar date values used by legacy history. JavaScript
+ * also accepts values such as false, [], {}, and numeric zero as dates; those
+ * coercions are not stored history events and must not consume event budgets.
+ */
+export function profileHistoryTimestamp(value: unknown) {
+	let timestamp: number
+	if (value instanceof Date) {
+		timestamp = value.getTime()
+	} else if (typeof value === 'number') {
+		if (!Number.isFinite(value) || value === 0) return null
+		timestamp = value
+	} else if (typeof value === 'string') {
+		const normalized = value.trim()
+		if (!normalized || normalized === '0') return null
+		timestamp = Date.parse(normalized)
+	} else {
+		return null
+	}
+
+	if (!Number.isFinite(timestamp) || timestamp === 0) return null
+	const clippedTimestamp = new Date(timestamp).getTime()
+	return Number.isFinite(clippedTimestamp) && clippedTimestamp !== 0
+		? clippedTimestamp
+		: null
+}
+
+function pruneOldFinishTimestamps(
+	candidates: FinishTimestampCandidate[],
+): boolean {
+	if (candidates.length <= PROFILE_HISTORY_EVENT_LIMIT) return false
+
+	const retained = new Set(
+		[...candidates]
+			.sort(
+				(left, right) =>
+					right.timestamp - left.timestamp || left.ordinal - right.ordinal,
+			)
+			.slice(0, PROFILE_HISTORY_EVENT_LIMIT),
+	)
+	const removedByArray = new Map<unknown[], Set<number>>()
+	for (const candidate of candidates) {
+		if (retained.has(candidate)) continue
+		const removed = removedByArray.get(candidate.array) ?? new Set<number>()
+		removed.add(candidate.index)
+		removedByArray.set(candidate.array, removed)
+	}
+
+	for (const [array, removed] of removedByArray) {
+		const originalLength = array.length
+		let writeIndex = 0
+		for (let readIndex = 0; readIndex < originalLength; readIndex += 1) {
+			if (removed.has(readIndex)) continue
+			if (Object.prototype.hasOwnProperty.call(array, readIndex)) {
+				if (writeIndex !== readIndex) {
+					Object.defineProperty(array, writeIndex, {
+						value: array[readIndex],
+						writable: true,
+						enumerable: true,
+						configurable: true,
+					})
+				}
+			} else if (Object.prototype.hasOwnProperty.call(array, writeIndex)) {
+				delete array[writeIndex]
+			}
+			writeIndex += 1
+		}
+		for (let index = writeIndex; index < originalLength; index += 1) {
+			delete array[index]
+		}
+		array.length = writeIndex
+	}
+
+	return true
+}
+
+/**
+ * Parses and clones legacy Entry history without allowing one row to create an
+ * unbounded traversal. The returned value contains only JSON-compatible data,
+ * is detached from object inputs, and has all finishDate arrays capped across
+ * the whole entry.
+ */
+export function parseBoundedProfileHistory(
+	input: unknown,
+): BoundedProfileHistoryResult {
+	if (
+		input === null ||
+		input === undefined ||
+		input === '' ||
+		input === 'null'
+	) {
+		return {
+			history: null,
+			rejected: false,
+			reason: null,
+			nodeCount: 0,
+			finishEventsTruncated: false,
+		}
+	}
+
+	let decoded: unknown = input
+	if (typeof input === 'string') {
+		if (input.length > PROFILE_HISTORY_CODE_UNIT_LIMIT) {
+			return rejected('code-unit-limit')
+		}
+		try {
+			decoded = JSON.parse(input)
+		} catch {
+			return rejected('invalid-json')
+		}
+	}
+
+	if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) {
+		return rejected('invalid-root')
+	}
+
+	try {
+		if (!isPlainObject(decoded)) return rejected('invalid-root')
+
+		const clone: Record<string, unknown> = {}
+		const seen = new WeakSet<object>([decoded])
+		const frames: CloneFrame[] = [
+			{
+				source: decoded as Record<string, unknown>,
+				target: clone,
+				depth: 0,
+				finishDateArray: false,
+			},
+		]
+		let nodeCount = 1
+		let codeUnits = 0
+		const finishTimestampCandidates: FinishTimestampCandidate[] = []
+		let finishTimestampOrdinal = 0
+
+		while (frames.length) {
+			const frame = frames.pop()
+			if (!frame) break
+
+			for (const key in frame.source) {
+				if (!Object.prototype.hasOwnProperty.call(frame.source, key)) continue
+
+				codeUnits += key.length
+				if (codeUnits > PROFILE_HISTORY_CODE_UNIT_LIMIT) {
+					return rejected('code-unit-limit', nodeCount)
+				}
+
+				const value = (frame.source as Record<string, unknown>)[key]
+				nodeCount += 1
+				if (nodeCount > PROFILE_HISTORY_NODE_LIMIT) {
+					return rejected('node-limit', nodeCount)
+				}
+
+				if (value === null || typeof value === 'boolean') {
+					setCloneValue(frame.target, key, value)
+					continue
+				}
+				if (typeof value === 'string') {
+					codeUnits += value.length
+					if (codeUnits > PROFILE_HISTORY_CODE_UNIT_LIMIT) {
+						return rejected('code-unit-limit', nodeCount)
+					}
+					setCloneValue(frame.target, key, value)
+					const finishArray =
+						frame.finishDateArray && Array.isArray(frame.target)
+							? frame.target
+							: null
+					const index = finishArray === null ? null : arrayIndex(key)
+					const timestamp =
+						index === null ? null : profileHistoryTimestamp(value)
+					if (finishArray !== null && index !== null && timestamp !== null) {
+						finishTimestampCandidates.push({
+							array: finishArray,
+							index,
+							timestamp,
+							ordinal: finishTimestampOrdinal++,
+						})
+					}
+					continue
+				}
+				if (typeof value === 'number' && Number.isFinite(value)) {
+					setCloneValue(frame.target, key, value)
+					const finishArray =
+						frame.finishDateArray && Array.isArray(frame.target)
+							? frame.target
+							: null
+					const index = finishArray === null ? null : arrayIndex(key)
+					const timestamp =
+						index === null ? null : profileHistoryTimestamp(value)
+					if (finishArray !== null && index !== null && timestamp !== null) {
+						finishTimestampCandidates.push({
+							array: finishArray,
+							index,
+							timestamp,
+							ordinal: finishTimestampOrdinal++,
+						})
+					}
+					continue
+				}
+				if (!isContainer(value)) {
+					return rejected('invalid-structure', nodeCount)
+				}
+				if (seen.has(value)) {
+					return rejected('cycle', nodeCount)
+				}
+				if (frame.depth >= PROFILE_HISTORY_DEPTH_LIMIT) {
+					return rejected('depth-limit', nodeCount)
+				}
+				if (Array.isArray(value) && value.length > PROFILE_HISTORY_NODE_LIMIT) {
+					return rejected('node-limit', nodeCount)
+				}
+
+				seen.add(value)
+				const child: Container = Array.isArray(value) ? [] : {}
+				setCloneValue(frame.target, key, child)
+				frames.push({
+					source: value,
+					target: child,
+					depth: frame.depth + 1,
+					finishDateArray: Array.isArray(value) && key === 'finishDate',
+				})
+			}
+		}
+
+		const finishEventsTruncated = pruneOldFinishTimestamps(
+			finishTimestampCandidates,
+		)
+		return {
+			history: clone,
+			rejected: false,
+			reason: null,
+			nodeCount,
+			finishEventsTruncated,
+		}
+	} catch {
+		return rejected('invalid-structure')
+	}
+}

--- a/app/utils/profile-history.test.ts
+++ b/app/utils/profile-history.test.ts
@@ -1,4 +1,8 @@
 import { expect, test } from 'vitest'
+import {
+	PROFILE_HISTORY_CODE_UNIT_LIMIT,
+	PROFILE_HISTORY_EVENT_LIMIT,
+} from './profile-history-bounds.ts'
 import { buildProfileHistory } from './profile-history.ts'
 
 const animeType = {
@@ -181,6 +185,35 @@ test('does not duplicate a unit when stored timestamps are newest-first', () => 
 	])
 })
 
+test('groups high-cardinality same-day progress in linear-keyed maps', () => {
+	const base = Date.parse('2025-01-03T18:00:00.000Z')
+	const progress = Object.fromEntries(
+		Array.from({ length: 5_000 }, (_, index) => [
+			String(index + 1),
+			{ finishDate: [new Date(base + index).toISOString()] },
+		]),
+	)
+	const result = buildProfileHistory({
+		listTypes: [animeType],
+		watchlists: [animeWatchlist],
+		entries: [
+			{
+				id: 'high-cardinality',
+				watchlistId: animeWatchlist.id,
+				history: JSON.stringify({ progress }),
+			},
+		],
+	})
+
+	expect(result.typedHistory.anime).toEqual([
+		{
+			type: 'Watched Episodes 1 - 5000',
+			time: new Date(base + 4_999),
+			index: 0,
+		},
+	])
+})
+
 test('reads media-specific progress when the list type has no length column', () => {
 	const mangaType = {
 		id: 'manga',
@@ -238,20 +271,20 @@ test('degrades malformed stored history and list settings safely', () => {
 				completionType: '{not-json}',
 			},
 		],
-			watchlists: [animeWatchlist],
-			entries: [
-				{
-					id: 'entry-1',
-					watchlistId: animeWatchlist.id,
-					history: '{not-json}',
-				},
+		watchlists: [animeWatchlist],
+		entries: [
+			{
+				id: 'entry-1',
+				watchlistId: animeWatchlist.id,
+				history: '{not-json}',
+			},
 			{
 				id: 'entry-2',
 				watchlistId: animeWatchlist.id,
 				history: JSON.stringify({
 					added: 'not-a-date',
 					progress: { 1: { finishDate: ['also-not-a-date'] } },
-		}),
+				}),
 			},
 		],
 	})
@@ -264,4 +297,195 @@ test('degrades malformed stored history and list settings safely', () => {
 		lastUpdated: null,
 	})
 	expect(result.typedHistory.anime).toEqual([])
+})
+
+test('rejects coercible non-scalar and zero history dates consistently', () => {
+	const result = buildProfileHistory({
+		listTypes: [animeType],
+		watchlists: [animeWatchlist],
+		entries: [
+			{
+				id: 'coercible-dates',
+				watchlistId: animeWatchlist.id,
+				history: JSON.stringify({
+					booleanDate: false,
+					arrayDate: [],
+					objectDate: {},
+					hugeDate: 1e100,
+					zeroDate: 0,
+					stringZeroDate: '0',
+					progress: {
+						1: {
+							finishDate: [
+								false,
+								[],
+								{},
+								1e100,
+								-1e100,
+								0,
+								'0',
+								'1970-01-01T00:00:00.001Z',
+							],
+						},
+					},
+				}),
+			},
+		],
+	})
+
+	expect(result.typedHistory.anime).toEqual([
+		{
+			type: 'Watched Episode 1',
+			time: new Date(1),
+			index: 0,
+		},
+	])
+})
+
+test('rejects oversized and overly deep stored histories without throwing', () => {
+	let deepHistory: Record<string, unknown> = {}
+	const root = deepHistory
+	for (let index = 0; index < 33; index += 1) {
+		const child: Record<string, unknown> = {}
+		deepHistory.next = child
+		deepHistory = child
+	}
+
+	const result = buildProfileHistory({
+		listTypes: [animeType],
+		watchlists: [animeWatchlist],
+		entries: [
+			{
+				id: 'oversized',
+				watchlistId: animeWatchlist.id,
+				history: `{"note":"${'x'.repeat(PROFILE_HISTORY_CODE_UNIT_LIMIT)}"}`,
+			},
+			{
+				id: 'deep',
+				watchlistId: animeWatchlist.id,
+				history: JSON.stringify(root),
+			},
+		],
+	})
+
+	expect(result.typedEntries.anime?.map(entry => entry.history)).toEqual([
+		{
+			added: null,
+			started: null,
+			finished: null,
+			progress: null,
+			lastUpdated: null,
+		},
+		{
+			added: null,
+			started: null,
+			finished: null,
+			progress: null,
+			lastUpdated: null,
+		},
+	])
+	expect(result.typedHistory.anime).toEqual([])
+	expect(result.diagnostic).toEqual({
+		rejectedHistories: 2,
+		truncatedHistories: 0,
+		activityEventsTruncated: 0,
+		perEntryEventLimit: PROFILE_HISTORY_EVENT_LIMIT,
+	})
+})
+
+test('caps arbitrary legacy activity events per entry and reports truncation', () => {
+	const history = Object.fromEntries(
+		Array.from({ length: PROFILE_HISTORY_EVENT_LIMIT + 1 }, (_, index) => [
+			`event${String(index).padStart(5, '0')}`,
+			new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+		]),
+	)
+	const result = buildProfileHistory({
+		listTypes: [animeType],
+		watchlists: [animeWatchlist],
+		entries: [
+			{
+				id: 'many-events',
+				watchlistId: animeWatchlist.id,
+				history: JSON.stringify(history),
+			},
+		],
+	})
+
+	expect(result.typedHistory.anime).toHaveLength(PROFILE_HISTORY_EVENT_LIMIT)
+	expect(
+		result.typedHistory.anime?.some(event => event.type === 'Event10000'),
+	).toBe(true)
+	expect(
+		result.typedHistory.anime?.some(event => event.type === 'Event00000'),
+	).toBe(false)
+	expect(result.diagnostic).toEqual({
+		rejectedHistories: 0,
+		truncatedHistories: 0,
+		activityEventsTruncated: 1,
+		perEntryEventLimit: PROFILE_HISTORY_EVENT_LIMIT,
+	})
+})
+
+test('retains newest progress activity when arbitrary keys fill the event cap', () => {
+	const arbitraryHistory = Object.fromEntries(
+		Array.from({ length: PROFILE_HISTORY_EVENT_LIMIT }, (_, index) => [
+			`oldEvent${String(index).padStart(5, '0')}`,
+			new Date(Date.UTC(2025, 0, 1, 0, 0, index)).toISOString(),
+		]),
+	)
+	const newest = '2026-07-28T20:00:00.000Z'
+	const result = buildProfileHistory({
+		listTypes: [animeType],
+		watchlists: [animeWatchlist],
+		entries: [
+			{
+				id: 'mixed-events',
+				watchlistId: animeWatchlist.id,
+				history: JSON.stringify({
+					...arbitraryHistory,
+					progress: { 1: { finishDate: [newest] } },
+				}),
+			},
+		],
+	})
+
+	expect(result.typedHistory.anime).toHaveLength(PROFILE_HISTORY_EVENT_LIMIT)
+	expect(result.typedHistory.anime?.[0]).toEqual({
+		type: 'Watched Episode 1',
+		time: new Date(newest),
+		index: 0,
+	})
+	expect(
+		result.typedHistory.anime?.some(event => event.type === 'Old Event00000'),
+	).toBe(false)
+	expect(result.diagnostic?.activityEventsTruncated).toBe(1)
+})
+
+test('caps finish timestamps across an entry before generating activity', () => {
+	const finishDates = Array.from(
+		{ length: PROFILE_HISTORY_EVENT_LIMIT + 1 },
+		(_, index) => new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+	)
+	const result = buildProfileHistory({
+		listTypes: [animeType],
+		watchlists: [animeWatchlist],
+		entries: [
+			{
+				id: 'many-finishes',
+				watchlistId: animeWatchlist.id,
+				history: JSON.stringify({
+					progress: { 1: { finishDate: finishDates } },
+				}),
+			},
+		],
+	})
+
+	expect(result.typedHistory.anime).toHaveLength(1)
+	expect(result.diagnostic).toEqual({
+		rejectedHistories: 0,
+		truncatedHistories: 1,
+		activityEventsTruncated: 1,
+		perEntryEventLimit: PROFILE_HISTORY_EVENT_LIMIT,
+	})
 })

--- a/app/utils/profile-history.ts
+++ b/app/utils/profile-history.ts
@@ -1,4 +1,9 @@
 import { type ListType, type Watchlist } from '@prisma/client'
+import {
+	parseBoundedProfileHistory,
+	profileHistoryTimestamp,
+	PROFILE_HISTORY_EVENT_LIMIT,
+} from '#app/utils/profile-history-bounds.ts'
 import { type ActivityItem } from '#app/utils/profile.ts'
 
 type HistoryListType = Pick<
@@ -39,6 +44,12 @@ type BuildProfileHistoryArgs<TEntry extends HistorySourceEntry> = {
 type BuildProfileHistoryResult<TEntry extends HistorySourceEntry> = {
 	typedEntries: Record<string, ParsedHistoryEntry<TEntry>[]>
 	typedHistory: Record<string, ComputedActivityItem[]>
+	diagnostic?: {
+		rejectedHistories: number
+		truncatedHistories: number
+		activityEventsTruncated: number
+		perEntryEventLimit: number
+	}
 }
 
 const emptyEntryHistory = (): ParsedEntryHistory => ({
@@ -55,18 +66,6 @@ function toTitleCase(input: string) {
 		.split(' ')
 		.map(word => word.charAt(0).toUpperCase() + word.slice(1))
 		.join(' ')
-}
-
-function parseEntryHistory(history: string | null): ParsedEntryHistory {
-	if (!history || history === 'null') return emptyEntryHistory()
-	try {
-		const parsed = JSON.parse(history)
-		return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-			? (parsed as ParsedEntryHistory)
-			: emptyEntryHistory()
-	} catch {
-		return emptyEntryHistory()
-	}
 }
 
 function parseMediaTypes(value: string) {
@@ -102,8 +101,19 @@ function parseCompletionPast(value: string) {
 }
 
 function dateOrNull(value: unknown) {
-	const date = new Date(value as string | number | Date)
-	return Number.isFinite(date.getTime()) ? date : null
+	const timestamp = profileHistoryTimestamp(value)
+	return timestamp === null ? null : new Date(timestamp)
+}
+
+function compareComputedActivity(
+	left: ComputedActivityItem,
+	right: ComputedActivityItem,
+) {
+	return (
+		right.time.getTime() - left.time.getTime() ||
+		left.type.localeCompare(right.type) ||
+		left.index - right.index
+	)
 }
 
 /**
@@ -118,6 +128,9 @@ export function buildProfileHistory<TEntry extends HistorySourceEntry>({
 }: BuildProfileHistoryArgs<TEntry>): BuildProfileHistoryResult<TEntry> {
 	const typedEntries: Record<string, ParsedHistoryEntry<TEntry>[]> = {}
 	const typedHistory: Record<string, ComputedActivityItem[]> = {}
+	let rejectedHistories = 0
+	let truncatedHistories = 0
+	let activityEventsTruncated = 0
 
 	// Preserve the profile loader's empty-state payload: it historically omits
 	// per-type keys until the user has at least one watchlist.
@@ -131,17 +144,36 @@ export function buildProfileHistory<TEntry extends HistorySourceEntry>({
 	)
 
 	for (const listType of listTypes) {
+		const historyBounds: Array<{
+			finishEventsTruncated: boolean
+		}> = []
 		const entriesForType = entries
 			.filter(entry => typeByWatchlist.get(entry.watchlistId) === listType.id)
-			.map(entry => ({
-				...entry,
-				history: parseEntryHistory(entry.history),
-			})) as ParsedHistoryEntry<TEntry>[]
+			.map(entry => {
+				const parsed = parseBoundedProfileHistory(entry.history)
+				if (parsed.rejected) rejectedHistories += 1
+				if (parsed.finishEventsTruncated) truncatedHistories += 1
+				historyBounds.push({
+					finishEventsTruncated: parsed.finishEventsTruncated,
+				})
+				return {
+					...entry,
+					history: (parsed.history ??
+						emptyEntryHistory()) as ParsedEntryHistory,
+				}
+			}) as ParsedHistoryEntry<TEntry>[]
 
 		typedEntries[listType.id] = entriesForType
 		typedHistory[listType.id] = []
 
 		for (const [index, entry] of entriesForType.entries()) {
+			const eventCandidates: ComputedActivityItem[] = []
+			let entryEventsTruncated =
+				historyBounds[index]?.finishEventsTruncated ?? false
+			const addActivity = (activity: ComputedActivityItem) => {
+				eventCandidates.push(activity)
+			}
+
 			for (const [historyKey, historyValue] of Object.entries(entry.history)) {
 				if (historyValue == null || historyValue === 'null') continue
 				if (historyKey === 'lastUpdated') continue
@@ -151,65 +183,95 @@ export function buildProfileHistory<TEntry extends HistorySourceEntry>({
 					const completionPast = parseCompletionPast(listType.completionType)
 
 					for (const mediaType of mediaTypes) {
+						if (
+							!historyValue ||
+							typeof historyValue !== 'object' ||
+							Array.isArray(historyValue)
+						) {
+							continue
+						}
 						const progressByMedia = historyValue as Record<string, unknown>
 						const progressObject = listType.columns.includes('length')
 							? progressByMedia
 							: (progressByMedia[mediaType] as
 									Record<string, unknown> | undefined)
 
-						if (!progressObject) continue
+						if (
+							!progressObject ||
+							typeof progressObject !== 'object' ||
+							Array.isArray(progressObject)
+						) {
+							continue
+						}
 
-						const dayGroups: Record<
-							string,
-							Array<{ date: Date; progressKey: string }>
-						> = {}
+						const dayGroups = new Map<string, Map<string, Date>>()
 
 						for (const [progressKey, progressValue] of Object.entries(
 							progressObject,
 						)) {
+							if (
+								!progressValue ||
+								typeof progressValue !== 'object' ||
+								Array.isArray(progressValue)
+							) {
+								continue
+							}
 							const finishDates = (progressValue as { finishDate?: unknown })
 								.finishDate
-							if (!finishDates) continue
+							if (!Array.isArray(finishDates)) continue
 
-							for (const dateCompleted of finishDates as unknown[]) {
+							for (const dateCompleted of finishDates) {
 								const date = dateOrNull(dateCompleted)
 								if (!date) continue
 								const dayKey = `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
-								const dayGroup = (dayGroups[dayKey] ??= [])
-								const duplicate = dayGroup.find(
-									completion => completion.progressKey === progressKey,
-								)
+								const dayGroup =
+									dayGroups.get(dayKey) ?? new Map<string, Date>()
+								const previous = dayGroup.get(progressKey)
 
 								// Match the existing history semantics: for a later repeat of
 								// the same unit on a day, retain its latest timestamp.
-								if (duplicate) {
-									if (duplicate.date < date) duplicate.date = date
-									continue
+								if (!previous || previous < date) {
+									dayGroup.set(progressKey, date)
 								}
-
-								dayGroup.push({ date, progressKey })
+								dayGroups.set(dayKey, dayGroup)
 							}
 						}
 
-						for (const groupedCompletions of Object.values(dayGroups)) {
-							if (groupedCompletions.length > 1) {
-								const latest = groupedCompletions.reduce((max, completion) =>
-									max.date > completion.date ? max : completion,
-								)
-								const oldest = groupedCompletions.reduce((min, completion) =>
-									min.date < completion.date ? min : completion,
-								)
-
-								typedHistory[listType.id].push({
+						for (const groupedCompletionMap of dayGroups.values()) {
+							let oldest: { date: Date; progressKey: string } | null = null
+							let latest: { date: Date; progressKey: string } | null = null
+							let completionCount = 0
+							for (const [progressKey, date] of groupedCompletionMap) {
+								const completion = { date, progressKey }
+								completionCount += 1
+								if (
+									!oldest ||
+									oldest.date > date ||
+									(oldest.date.getTime() === date.getTime() &&
+										oldest.progressKey.localeCompare(progressKey) > 0)
+								) {
+									oldest = completion
+								}
+								if (
+									!latest ||
+									latest.date < date ||
+									(latest.date.getTime() === date.getTime() &&
+										latest.progressKey.localeCompare(progressKey) < 0)
+								) {
+									latest = completion
+								}
+							}
+							if (completionCount > 1 && oldest && latest) {
+								addActivity({
 									type: `${toTitleCase(completionPast)} ${toTitleCase(mediaType)}s ${oldest.progressKey} - ${latest.progressKey}`,
 									time: new Date(latest.date),
 									index,
 								})
 							} else {
-								const completion = groupedCompletions[0]
+								const completion = oldest
 								if (!completion) continue
 
-								typedHistory[listType.id].push({
+								addActivity({
 									type: `${toTitleCase(completionPast)} ${toTitleCase(mediaType)} ${completion.progressKey}`,
 									time: new Date(completion.date),
 									index,
@@ -224,7 +286,7 @@ export function buildProfileHistory<TEntry extends HistorySourceEntry>({
 				const watchlist = watchlistById.get(entry.watchlistId)
 				const eventTime = dateOrNull(historyValue)
 				if (!eventTime) continue
-				typedHistory[listType.id].push({
+				addActivity({
 					type:
 						historyKey === 'added'
 							? `Added to ${watchlist?.header ?? ''}`
@@ -233,12 +295,34 @@ export function buildProfileHistory<TEntry extends HistorySourceEntry>({
 					index,
 				})
 			}
+			eventCandidates.sort(compareComputedActivity)
+			if (eventCandidates.length > PROFILE_HISTORY_EVENT_LIMIT) {
+				entryEventsTruncated = true
+			}
+			typedHistory[listType.id].push(
+				...eventCandidates.slice(0, PROFILE_HISTORY_EVENT_LIMIT),
+			)
+			if (entryEventsTruncated) activityEventsTruncated += 1
 		}
 
-		typedHistory[listType.id].sort(
-			(a, b) => b.time.getTime() - a.time.getTime(),
-		)
+		typedHistory[listType.id].sort(compareComputedActivity)
 	}
 
-	return { typedEntries, typedHistory }
+	const result: BuildProfileHistoryResult<TEntry> = {
+		typedEntries,
+		typedHistory,
+	}
+	if (
+		rejectedHistories > 0 ||
+		truncatedHistories > 0 ||
+		activityEventsTruncated > 0
+	) {
+		result.diagnostic = {
+			rejectedHistories,
+			truncatedHistories,
+			activityEventsTruncated,
+			perEntryEventLimit: PROFILE_HISTORY_EVENT_LIMIT,
+		}
+	}
+	return result
 }

--- a/app/utils/profile-tracking.test.ts
+++ b/app/utils/profile-tracking.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from 'vitest'
+import { PROFILE_HISTORY_CODE_UNIT_LIMIT } from './profile-history-bounds.ts'
 import {
 	buildProfileTrackingSummaries,
+	createProfileTrackingAccumulator,
 	type ProfileTrackingEntry,
 } from './profile-tracking.ts'
 
@@ -81,6 +83,31 @@ test('uses one normalized state for duplicate entry snapshots', () => {
 		],
 	})
 })
+
+test.each([null, 0])(
+	'falls back to a legacy personal score when canonical score is %s',
+	score => {
+		const summaries = buildProfileTrackingSummaries({
+			listTypes,
+			watchlists,
+			entries: [
+				entry({
+					personal: 7.5,
+					trackingState: {
+						id: 'state-score-fallback',
+						status: 'watching',
+						statusWatchlistId: 'watching',
+						score,
+						repeatCount: 0,
+						progress: [],
+					},
+				}),
+			],
+		})
+
+		expect(summaries.anime?.meanScore).toBe(7.5)
+	},
+)
 
 test('normalized state wins over an unlinked legacy row for the same media', () => {
 	const summaries = buildProfileTrackingSummaries({
@@ -205,4 +232,150 @@ test('recovers completed totals from legacy metadata when normalized progress is
 	})
 
 	expect(summaries.anime?.progress).toEqual([{ unit: 'episode', current: 26 }])
+})
+
+test('incremental pages preserve normalized and legacy deduplication semantics', () => {
+	const accumulator = createProfileTrackingAccumulator({
+		listTypes,
+		watchlists,
+	})
+	accumulator.addMany([
+		entry({
+			id: 'older-legacy',
+			personal: 4,
+			history: JSON.stringify({ lastUpdated: '2025-01-01' }),
+		}),
+		entry({
+			id: 'newer-legacy',
+			watchlistId: 'completed',
+			personal: 7,
+			history: JSON.stringify({ lastUpdated: '2025-02-01' }),
+		}),
+	])
+	accumulator.add(
+		entry({
+			id: 'normalized',
+			trackingState: {
+				id: 'state-1',
+				status: 'watching',
+				statusWatchlistId: 'watching',
+				score: 8.5,
+				repeatCount: 1,
+				progress: [{ unit: 'episode', current: 6 }],
+			},
+		}),
+	)
+
+	expect(accumulator.finish().anime).toEqual({
+		totalTitles: 1,
+		meanScore: 8.5,
+		repeatCount: 1,
+		progress: [{ unit: 'episode', current: 6 }],
+		statuses: [
+			{ key: 'watching', label: 'Watching', count: 1 },
+			{ key: 'completed', label: 'Completed', count: 0 },
+		],
+	})
+})
+
+test('retains only supported episode, chapter, and volume progress dimensions', () => {
+	const summaries = buildProfileTrackingSummaries({
+		listTypes,
+		watchlists,
+		entries: [
+			entry({
+				trackingState: {
+					id: 'state-1',
+					status: 'watching',
+					statusWatchlistId: 'watching',
+					score: null,
+					repeatCount: 0,
+					progress: [
+						{ unit: 'seasons', current: 2 },
+						{ unit: 'custom-field', current: 999 },
+						{ unit: 'Episodes', current: 4 },
+						{ unit: 'episode', current: 6 },
+						{ unit: 'chapters', current: 3 },
+						{ unit: 'volume', current: 1 },
+					],
+				},
+			}),
+		],
+	})
+
+	expect(summaries.anime?.progress).toEqual([
+		{ unit: 'episode', current: 6 },
+		{ unit: 'chapter', current: 3 },
+		{ unit: 'volume', current: 1 },
+	])
+})
+
+test('filters arbitrary legacy history units from profile summaries', () => {
+	const summaries = buildProfileTrackingSummaries({
+		listTypes,
+		watchlists,
+		entries: [
+			entry({
+				history: JSON.stringify({
+					progress: {
+						seasons: {
+							2: { finishDate: ['2026-01-01T00:00:00.000Z'] },
+						},
+						episode: {
+							5: { finishDate: ['2026-01-02T00:00:00.000Z'] },
+						},
+					},
+				}),
+			}),
+		],
+	})
+
+	expect(summaries.anime?.progress).toEqual([{ unit: 'episode', current: 5 }])
+})
+
+test('rejects oversized and cyclic histories before legacy tracking traversal', () => {
+	const cyclic: Record<string, unknown> = {}
+	cyclic.progress = cyclic
+
+	expect(() =>
+		buildProfileTrackingSummaries({
+			listTypes,
+			watchlists,
+			entries: [
+				entry({
+					id: 'oversized',
+					mediaId: 'oversized',
+					length: null,
+					history: `{"note":"${'x'.repeat(PROFILE_HISTORY_CODE_UNIT_LIMIT)}"}`,
+				}),
+				entry({
+					id: 'cyclic',
+					mediaId: 'cyclic',
+					length: null,
+					history: cyclic,
+				}),
+			],
+		}),
+	).not.toThrow()
+
+	const summaries = buildProfileTrackingSummaries({
+		listTypes,
+		watchlists,
+		entries: [
+			entry({
+				id: 'oversized',
+				mediaId: 'oversized',
+				length: null,
+				history: `{"note":"${'x'.repeat(PROFILE_HISTORY_CODE_UNIT_LIMIT)}"}`,
+			}),
+			entry({
+				id: 'cyclic',
+				mediaId: 'cyclic',
+				length: null,
+				history: cyclic,
+			}),
+		],
+	})
+	expect(summaries.anime?.totalTitles).toBe(2)
+	expect(summaries.anime?.progress).toEqual([])
 })

--- a/app/utils/profile-tracking.ts
+++ b/app/utils/profile-tracking.ts
@@ -1,3 +1,5 @@
+import { preferredScore } from './lists/watchlist-entry-scores.server.ts'
+import { parseBoundedProfileHistory } from './profile-history-bounds.ts'
 import {
 	trackingStateFromEntry,
 	type TrackingEntryLike,
@@ -36,7 +38,8 @@ type TrackingWatchlist = {
 
 type NormalizedState = {
 	id: string
-	status: string
+	/** Compatibility-only input; aggregation derives the bounded list name. */
+	status?: string
 	statusWatchlistId: string | null
 	score: unknown
 	repeatCount: number
@@ -61,11 +64,7 @@ type SummaryItem = {
 }
 
 const preferredUnitOrder = ['episode', 'chapter', 'volume']
-
-function numberOrNull(value: unknown) {
-	const number = Number(value)
-	return Number.isFinite(number) && number > 0 ? number : null
-}
+const supportedProgressUnits = new Set(preferredUnitOrder)
 
 function labelFromStatus(status: string) {
 	return status
@@ -83,20 +82,52 @@ function compareUnits(a: string, b: string) {
 	return a.localeCompare(b)
 }
 
+function supportedProgressUnit(value: unknown) {
+	if (typeof value !== 'string') return null
+	const normalized = value.toLowerCase().replace(/[^a-z]/g, '')
+	const singular =
+		normalized === 'episodes'
+			? 'episode'
+			: normalized === 'chapters'
+				? 'chapter'
+				: normalized === 'volumes'
+					? 'volume'
+					: normalized
+	return supportedProgressUnits.has(singular) ? singular : null
+}
+
+function boundedHistory(value: unknown) {
+	const parsed = parseBoundedProfileHistory(value)
+	return parsed.history
+}
+
+function supportedProgress(
+	progress: Iterable<{ unit: string; current: number }>,
+) {
+	const result = new Map<string, number>()
+	for (const item of progress) {
+		const unit = supportedProgressUnit(item.unit)
+		const current = Number(item.current)
+		if (!unit || !Number.isFinite(current)) continue
+		result.set(unit, Math.max(result.get(unit) ?? 0, Math.max(0, current)))
+	}
+	return result
+}
+
 /**
- * Build profile-level totals from normalized tracking rows. Entries without a
- * TrackingState remain readable during rollout and are deduplicated by Media
- * when canonical identity is already available.
+ * Incrementally builds profile-level totals from normalized tracking rows.
+ * Callers may feed deterministic database pages without retaining the full
+ * Entry result set in memory. The compact item map is required to preserve the
+ * rollout rule that a normalized state wins over every legacy snapshot and
+ * that the newest canonical legacy snapshot wins otherwise.
  */
-export function buildProfileTrackingSummaries({
+export function createProfileTrackingAccumulator({
 	listTypes,
 	watchlists,
-	entries,
 }: {
 	listTypes: TrackingListType[]
 	watchlists: TrackingWatchlist[]
-	entries: ProfileTrackingEntry[]
-}): Record<string, ProfileTrackingSummary> {
+}) {
 	const watchlistById = new Map(
 		watchlists.map(watchlist => [watchlist.id, watchlist]),
 	)
@@ -105,9 +136,13 @@ export function buildProfileTrackingSummaries({
 		SummaryItem & { sourceUpdatedAt: number; sourceId: string }
 	>()
 
-	for (const entry of entries) {
+	function add(entry: ProfileTrackingEntry) {
 		const entryWatchlist = watchlistById.get(entry.watchlistId)
-		if (!entryWatchlist) continue
+		if (!entryWatchlist) return
+		const boundedEntry = {
+			...entry,
+			history: boundedHistory(entry.history),
+		}
 
 		if (entry.trackingState) {
 			const state = entry.trackingState
@@ -119,32 +154,29 @@ export function buildProfileTrackingSummaries({
 					? stateWatchlist
 					: entryWatchlist
 			const key = entry.mediaId ? `media:${entry.mediaId}` : `state:${state.id}`
-			if (items.get(key)?.sourceUpdatedAt === Infinity) continue
-			const legacySnapshot = trackingStateFromEntry(entry, {
-				status: state.status,
+			if (items.get(key)?.sourceUpdatedAt === Infinity) return
+			const legacySnapshot = trackingStateFromEntry(boundedEntry, {
+				status: statusWatchlist.name,
 				statusWatchlistId: state.statusWatchlistId,
 				mediaKind: entry.media?.kind ?? 'unknown',
 			})
-			const recoveredProgress = new Map(
-				state.progress.map(progress => [
-					progress.unit,
-					Math.max(0, progress.current),
-				]),
-			)
+			const recoveredProgress = supportedProgress(state.progress)
 			for (const progress of legacySnapshot.progress) {
-				const current = recoveredProgress.get(progress.unit)
+				const unit = supportedProgressUnit(progress.unit)
+				if (!unit) continue
+				const current = recoveredProgress.get(unit)
 				if (
 					current === undefined ||
 					(current === 0 && progress.current > current)
 				) {
-					recoveredProgress.set(progress.unit, progress.current)
+					recoveredProgress.set(unit, progress.current)
 				}
 			}
 			items.set(key, {
 				typeId: statusWatchlist.typeId,
 				statusKey: statusWatchlist.id,
-				status: state.status,
-				score: numberOrNull(state.score),
+				status: statusWatchlist.name,
+				score: preferredScore(state.score, boundedEntry.personal),
 				repeatCount: Math.max(0, state.repeatCount),
 				progress: [...recoveredProgress].map(([unit, current]) => ({
 					unit,
@@ -153,10 +185,10 @@ export function buildProfileTrackingSummaries({
 				sourceUpdatedAt: Infinity,
 				sourceId: entry.id,
 			})
-			continue
+			return
 		}
 
-		const snapshot = trackingStateFromEntry(entry, {
+		const snapshot = trackingStateFromEntry(boundedEntry, {
 			status: entryWatchlist.name,
 			statusWatchlistId: entryWatchlist.id,
 			mediaKind: entry.media?.kind ?? 'unknown',
@@ -169,85 +201,140 @@ export function buildProfileTrackingSummaries({
 				(previous.sourceUpdatedAt === snapshot.sourceUpdatedAt &&
 					previous.sourceId <= entry.id))
 		)
-			continue
+			return
 		items.set(key, {
 			typeId: entryWatchlist.typeId,
 			statusKey: entryWatchlist.id,
 			status: snapshot.status,
 			score: snapshot.score,
 			repeatCount: snapshot.repeatCount,
-			progress: snapshot.progress.map(progress => ({
-				unit: progress.unit,
-				current: progress.current,
-			})),
+			progress: [...supportedProgress(snapshot.progress)].map(
+				([unit, current]) => ({ unit, current }),
+			),
 			sourceUpdatedAt: snapshot.sourceUpdatedAt,
 			sourceId: entry.id,
 		})
 	}
 
-	const summaries: Record<string, ProfileTrackingSummary> = {}
-	for (const listType of listTypes) {
-		const typeItems = [...items.values()].filter(
-			item => item.typeId === listType.id,
+	function addMany(entries: Iterable<ProfileTrackingEntry>) {
+		for (const entry of entries) add(entry)
+	}
+
+	function finish(): Record<string, ProfileTrackingSummary> {
+		const aggregateByType = new Map(
+			listTypes.map(listType => [
+				listType.id,
+				{
+					totalTitles: 0,
+					scoreTotal: 0,
+					scoreCount: 0,
+					repeatCount: 0,
+					progress: new Map<string, number>(),
+					statusCounts: new Map<string, number>(),
+					unconfiguredStatusCounts: new Map<string, number>(),
+				},
+			]),
 		)
-		const scored = typeItems
-			.map(item => item.score)
-			.filter((score): score is number => score !== null)
-		const progressByUnit = new Map<string, number>()
-		for (const item of typeItems) {
+
+		const configuredStatusKeysByType = new Map<string, Set<string>>()
+		for (const listType of listTypes) {
+			configuredStatusKeysByType.set(
+				listType.id,
+				new Set(
+					watchlists
+						.filter(watchlist => watchlist.typeId === listType.id)
+						.map(watchlist => watchlist.id),
+				),
+			)
+		}
+
+		for (const item of items.values()) {
+			const aggregate = aggregateByType.get(item.typeId)
+			if (!aggregate) continue
+			aggregate.totalTitles += 1
+			if (item.score !== null) {
+				aggregate.scoreTotal += item.score
+				aggregate.scoreCount += 1
+			}
+			aggregate.repeatCount += item.repeatCount
 			for (const progress of item.progress) {
-				progressByUnit.set(
+				aggregate.progress.set(
 					progress.unit,
-					(progressByUnit.get(progress.unit) ?? 0) + progress.current,
+					(aggregate.progress.get(progress.unit) ?? 0) + progress.current,
+				)
+			}
+			if (configuredStatusKeysByType.get(item.typeId)?.has(item.statusKey)) {
+				aggregate.statusCounts.set(
+					item.statusKey,
+					(aggregate.statusCounts.get(item.statusKey) ?? 0) + 1,
+				)
+			} else {
+				aggregate.unconfiguredStatusCounts.set(
+					item.status,
+					(aggregate.unconfiguredStatusCounts.get(item.status) ?? 0) + 1,
 				)
 			}
 		}
 
-		const typeWatchlists = watchlists
-			.filter(watchlist => watchlist.typeId === listType.id)
-			.slice()
-			.sort(
-				(a, b) => a.position - b.position || a.header.localeCompare(b.header),
-			)
-		const configuredStatusKeys = new Set(
-			typeWatchlists.map(status => status.id),
-		)
-		const statuses = typeWatchlists.map(watchlist => ({
-			key: watchlist.id,
-			label: watchlist.header,
-			count: typeItems.filter(item => item.statusKey === watchlist.id).length,
-		}))
-		const unconfiguredStatuses = new Map<string, number>()
-		for (const item of typeItems) {
-			if (configuredStatusKeys.has(item.statusKey)) continue
-			unconfiguredStatuses.set(
-				item.status,
-				(unconfiguredStatuses.get(item.status) ?? 0) + 1,
-			)
-		}
-		for (const [status, count] of unconfiguredStatuses) {
-			statuses.push({
-				key: `status:${status}`,
-				label: labelFromStatus(status),
-				count,
-			})
+		const summaries: Record<string, ProfileTrackingSummary> = {}
+		for (const listType of listTypes) {
+			const aggregate = aggregateByType.get(listType.id)
+			if (!aggregate) continue
+			const typeWatchlists = watchlists
+				.filter(watchlist => watchlist.typeId === listType.id)
+				.slice()
+				.sort(
+					(a, b) => a.position - b.position || a.header.localeCompare(b.header),
+				)
+			const statuses = typeWatchlists.map(watchlist => ({
+				key: watchlist.id,
+				label: watchlist.header,
+				count: aggregate.statusCounts.get(watchlist.id) ?? 0,
+			}))
+			for (const [status, count] of aggregate.unconfiguredStatusCounts) {
+				statuses.push({
+					key: `status:${status}`,
+					label: labelFromStatus(status),
+					count,
+				})
+			}
+
+			summaries[listType.id] = {
+				totalTitles: aggregate.totalTitles,
+				meanScore: aggregate.scoreCount
+					? aggregate.scoreTotal / aggregate.scoreCount
+					: null,
+				repeatCount: aggregate.repeatCount,
+				progress: [...aggregate.progress]
+					.map(([unit, current]) => ({ unit, current }))
+					.sort((a, b) => compareUnits(a.unit, b.unit)),
+				statuses,
+			}
 		}
 
-		summaries[listType.id] = {
-			totalTitles: typeItems.length,
-			meanScore: scored.length
-				? scored.reduce((total, score) => total + score, 0) / scored.length
-				: null,
-			repeatCount: typeItems.reduce(
-				(total, item) => total + item.repeatCount,
-				0,
-			),
-			progress: [...progressByUnit]
-				.map(([unit, current]) => ({ unit, current }))
-				.sort((a, b) => compareUnits(a.unit, b.unit)),
-			statuses,
-		}
+		return summaries
 	}
 
-	return summaries
+	return { add, addMany, finish }
+}
+
+/**
+ * Compatibility wrapper for callers that already have a row array. New
+ * database callers should prefer `createProfileTrackingAccumulator`.
+ */
+export function buildProfileTrackingSummaries({
+	listTypes,
+	watchlists,
+	entries,
+}: {
+	listTypes: TrackingListType[]
+	watchlists: TrackingWatchlist[]
+	entries: ProfileTrackingEntry[]
+}): Record<string, ProfileTrackingSummary> {
+	const accumulator = createProfileTrackingAccumulator({
+		listTypes,
+		watchlists,
+	})
+	accumulator.addMany(entries)
+	return accumulator.finish()
 }

--- a/app/utils/profile.ts
+++ b/app/utils/profile.ts
@@ -3,10 +3,39 @@ import {
 	type UserFavorite,
 	type Watchlist,
 } from '@prisma/client'
+import {
+	type ProfileAnalyticsDiagnostic,
+	type ProfileAnalyticsResult,
+} from './profile-analytics.ts'
+import { type CompletionHistory } from './profile-completion-history.ts'
 import { type ProfileTrackingSummary } from './profile-tracking.ts'
 
 export const PROFILE_COMMENT_MAX_LENGTH = 1000
 export const PROFILE_BIO_MAX_LENGTH = 5000
+export const PROFILE_STATUS_DISPLAY_LIMIT = 12
+
+export function compactProfileStatuses(
+	statuses: readonly { key: string; label: string; count: number }[],
+) {
+	const populated = statuses.filter(status => status.count > 0)
+	if (populated.length <= PROFILE_STATUS_DISPLAY_LIMIT) return populated
+	const ranked = populated
+		.slice()
+		.sort(
+			(left, right) =>
+				right.count - left.count || left.label.localeCompare(right.label),
+		)
+	return [
+		...ranked.slice(0, PROFILE_STATUS_DISPLAY_LIMIT - 1),
+		{
+			key: '__other_statuses__',
+			label: 'Other statuses',
+			count: ranked
+				.slice(PROFILE_STATUS_DISPLAY_LIMIT - 1)
+				.reduce((sum, status) => sum + status.count, 0),
+		},
+	]
+}
 
 /**
  * Shared types for the profile page (`users+/$username`).
@@ -39,7 +68,7 @@ export type FavoriteItem = Pick<
 	| 'mediaId'
 >
 
-/** The watchlist (status list) metadata the profile reads for status breakdowns. */
+/** The watchlist (status list) metadata used while building profile summaries. */
 export type WatchlistMeta = Pick<
 	Watchlist,
 	'id' | 'name' | 'header' | 'typeId' | 'position'
@@ -128,7 +157,6 @@ export type ProfileShellData = {
 	userJoinedDisplay: string
 	lastActiveDisplay: string | null
 	listTypes: ListTypeMeta[]
-	watchLists: WatchlistMeta[]
 	followerCount: number
 	followingCount: number
 	isFollowing: boolean
@@ -139,15 +167,25 @@ export type ProfileShellData = {
 	}
 }
 
-/** Heavy chart inputs, loaded only for Overview and Stats. */
-export type ProfileAnalyticsData = {
-	typedEntries: Record<string, any[]>
+/** Compact Overview-only aggregates; no raw library rows cross this boundary. */
+export type ProfileOverviewData = {
 	trackingSummaries: Record<string, ProfileTrackingSummary>
+	completionHistory: CompletionHistory
+	diagnostic: ProfileAnalyticsDiagnostic
 }
+
+/** Compact Stats-only aggregates; all variable dimensions are server-bounded. */
+export type ProfileStatsData = {
+	trackingSummaries: Record<string, ProfileTrackingSummary>
+} & Omit<ProfileAnalyticsResult, 'completionDays'>
+
+/** Compatibility alias for components shared within the Stats route. */
+export type ProfileAnalyticsData = ProfileStatsData
 
 /** Bounded normalized activity with legacy history merged on the server. */
 export type ProfileActivityData = Pick<ProfileShellData, 'listTypes'> & {
-	activityEvents: ProfileActivityEvent[]
+	activityEvents: ReadonlyArray<ProfileActivityEvent>
+	activityLimited: boolean
 }
 
 export type ProfileReviewsData = Pick<
@@ -166,11 +204,13 @@ export type ProfileFavoritesData = Pick<
 	'user' | 'listTypes'
 > & {
 	favorites: FavoriteItem[]
+	favoritesLimited: boolean
 }
 
 /** Compatibility shape for code that intentionally consumes every profile area. */
 export type ProfileData = ProfileShellData &
-	ProfileAnalyticsData &
+	ProfileOverviewData &
+	ProfileStatsData &
 	ProfileActivityData &
 	ProfileReviewsData &
 	ProfileDiaryData &

--- a/app/utils/tracking-command.server.test.ts
+++ b/app/utils/tracking-command.server.test.ts
@@ -1,3 +1,4 @@
+import { type Prisma, type PrismaClient } from '@prisma/client'
 import { afterEach, expect, test, vi } from 'vitest'
 import { resetAiGatewayStateForTests } from './ai-gateway.server.ts'
 import { prisma } from './db.server.ts'
@@ -25,6 +26,194 @@ function aiResponse(output: unknown) {
 		{ status: 200, headers: { 'content-type': 'application/json' } },
 	)
 }
+
+type TransactionCallback = (tx: Prisma.TransactionClient) => Promise<unknown>
+
+function transactionConflict() {
+	return Object.assign(new Error('serialization conflict'), { code: 'P2034' })
+}
+
+function createTransactionHarness(commitErrors: readonly unknown[]) {
+	const attempts: string[][] = []
+	const options: Array<{ isolationLevel?: string } | undefined> = []
+	let createTransactionClient!: () => Prisma.TransactionClient
+	let activeAttempt: string[] | undefined
+	const transaction = vi.fn(
+		async (
+			callback: TransactionCallback,
+			transactionOptions?: { isolationLevel?: string },
+		) => {
+			activeAttempt = []
+			attempts.push(activeAttempt)
+			options.push(transactionOptions)
+			const result = await callback(createTransactionClient())
+			const error = commitErrors[attempts.length - 1]
+			if (error !== undefined) throw error
+			return result
+		},
+	)
+
+	return {
+		client: { $transaction: transaction } as unknown as PrismaClient,
+		attempts,
+		options,
+		record(operation: string) {
+			if (!activeAttempt) {
+				throw new Error('Transaction operation recorded outside an attempt.')
+			}
+			activeAttempt.push(operation)
+		},
+		useTransactionClientFactory(value: () => Prisma.TransactionClient) {
+			createTransactionClient = value
+		},
+	}
+}
+
+function appliedPreviewTransaction(
+	record: (operation: string) => void,
+	summary = 'Already applied.',
+) {
+	return {
+		$executeRaw: vi.fn(async () => {
+			record('mutex')
+			return 1
+		}),
+		trackingCommandPreview: {
+			findFirst: vi.fn(async () => {
+				record('preview')
+				return {
+					status: 'applied',
+					operations: JSON.stringify({ summary, operations: [] }),
+				}
+			}),
+		},
+	} as unknown as Prisma.TransactionClient
+}
+
+test('apply retries a P2034 transaction with the owner mutex first each time', async () => {
+	const conflict = transactionConflict()
+	const harness = createTransactionHarness([conflict])
+	harness.useTransactionClientFactory(() =>
+		appliedPreviewTransaction(operation => harness.record(operation)),
+	)
+
+	await expect(
+		applyTrackingCommandPreview(harness.client, {
+			ownerId: 'retry-owner',
+			previewId: 'retry-preview',
+		}),
+	).resolves.toEqual({
+		summary: 'Already applied.',
+		operations: [],
+		alreadyApplied: true,
+	})
+	expect(harness.attempts).toEqual([
+		['mutex', 'preview'],
+		['mutex', 'preview'],
+	])
+	expect(harness.options).toEqual([
+		{ isolationLevel: 'Serializable' },
+		{ isolationLevel: 'Serializable' },
+	])
+})
+
+test('undo retries the complete Serializable transaction after P2034', async () => {
+	const now = new Date('2026-07-29T08:00:00.000Z')
+	const conflict = transactionConflict()
+	const harness = createTransactionHarness([conflict])
+	const record = (operation: string) => harness.record(operation)
+	const snapshot = {
+		operations: [],
+		states: [],
+		favorites: [],
+		collectionItems: [],
+		entries: [],
+	}
+	harness.useTransactionClientFactory(
+		() =>
+			({
+				$executeRaw: vi.fn(async () => {
+					record('mutex')
+					return 1
+				}),
+				trackingCommandPreview: {
+					findFirst: vi.fn(async () => {
+						record('preview')
+						return {
+							id: 'undo-preview',
+							journal: JSON.stringify({ before: snapshot, after: snapshot }),
+							appliedAt: now,
+							operations: JSON.stringify({
+								summary: 'Undo applied command.',
+								operations: [],
+							}),
+						}
+					}),
+					update: vi.fn(async () => ({ id: 'undo-preview' })),
+				},
+				trackingState: { findMany: vi.fn(async () => []) },
+				userFavorite: {
+					findMany: vi.fn(async () => []),
+					deleteMany: vi.fn(async () => ({ count: 0 })),
+				},
+				mediaCollectionItem: { findMany: vi.fn(async () => []) },
+				entry: {
+					findMany: vi.fn(async () => []),
+					deleteMany: vi.fn(async () => ({ count: 0 })),
+				},
+			}) as unknown as Prisma.TransactionClient,
+	)
+
+	await expect(
+		undoTrackingCommandPreview(harness.client, {
+			ownerId: 'retry-owner',
+			previewId: 'undo-preview',
+			now,
+		}),
+	).resolves.toEqual({ summary: 'Undo applied command.' })
+	expect(harness.attempts).toHaveLength(2)
+	expect(harness.attempts.map(attempt => attempt.slice(0, 2))).toEqual([
+		['mutex', 'preview'],
+		['mutex', 'preview'],
+	])
+	expect(harness.options).toEqual([
+		{ isolationLevel: 'Serializable' },
+		{ isolationLevel: 'Serializable' },
+	])
+})
+
+test('Serializable retries stop after three P2034 attempts', async () => {
+	const conflict = transactionConflict()
+	const harness = createTransactionHarness([conflict, conflict, conflict])
+	harness.useTransactionClientFactory(() =>
+		appliedPreviewTransaction(operation => harness.record(operation)),
+	)
+
+	await expect(
+		applyTrackingCommandPreview(harness.client, {
+			ownerId: 'bounded-owner',
+			previewId: 'bounded-preview',
+		}),
+	).rejects.toBe(conflict)
+	expect(harness.attempts).toHaveLength(3)
+	expect(harness.attempts.every(attempt => attempt[0] === 'mutex')).toBe(true)
+})
+
+test('Serializable transactions do not retry non-P2034 failures', async () => {
+	const failure = new Error('domain failure')
+	const harness = createTransactionHarness([failure])
+	harness.useTransactionClientFactory(() =>
+		appliedPreviewTransaction(operation => harness.record(operation)),
+	)
+
+	await expect(
+		applyTrackingCommandPreview(harness.client, {
+			ownerId: 'single-owner',
+			previewId: 'single-preview',
+		}),
+	).rejects.toBe(failure)
+	expect(harness.attempts).toEqual([['mutex', 'preview']])
+})
 
 test('builds a local preview and requires explicit application', async () => {
 	vi.stubEnv('OPENAI_API_KEY', 'test-key')

--- a/app/utils/tracking-command.server.ts
+++ b/app/utils/tracking-command.server.ts
@@ -20,10 +20,12 @@ import {
 	prismaSearchFilter,
 } from './prisma-search.server.ts'
 import { setMediaTrackingStatus } from './tracking-status.server.ts'
+import { serializeUserLibraryMutation } from './watchlist-limits.ts'
 
 const MAX_OPERATIONS = 10
 const PREVIEW_EXPIRY_MS = 20 * 60 * 1_000
 const PROMPT_VERSION = 'tracking-command-v1'
+const SERIALIZABLE_TRANSACTION_MAX_ATTEMPTS = 3
 
 const TrackingOperationFieldsSchema = z
 	.object({
@@ -557,12 +559,55 @@ function parsedResolvedPlan(value: string) {
 	return ResolvedPlanSchema.parse(JSON.parse(value) as unknown)
 }
 
+function isRetryableSerializableTransactionError(error: unknown) {
+	return (
+		error !== null &&
+		typeof error === 'object' &&
+		'code' in error &&
+		error.code === 'P2034'
+	)
+}
+
+async function withSerializableLibraryMutation<Result>(
+	prisma: PrismaClient,
+	ownerId: string,
+	mutation: (tx: Prisma.TransactionClient) => Promise<Result>,
+) {
+	for (
+		let attempt = 1;
+		attempt <= SERIALIZABLE_TRANSACTION_MAX_ATTEMPTS;
+		attempt += 1
+	) {
+		try {
+			return await prisma.$transaction(
+				async tx => {
+					// Every retry preserves the global per-owner mutation lock order.
+					await serializeUserLibraryMutation(tx, ownerId)
+					return mutation(tx)
+				},
+				{ isolationLevel: 'Serializable' },
+			)
+		} catch (error) {
+			if (
+				attempt === SERIALIZABLE_TRANSACTION_MAX_ATTEMPTS ||
+				!isRetryableSerializableTransactionError(error)
+			) {
+				throw error
+			}
+		}
+	}
+
+	throw new Error('Serializable library mutation exhausted its retry bound.')
+}
+
 export async function applyTrackingCommandPreview(
 	prisma: PrismaClient,
 	input: { ownerId: string; previewId: string; now?: Date },
 ) {
 	const now = input.now ?? new Date()
-	return await prisma.$transaction(
+	return await withSerializableLibraryMutation(
+		prisma,
+		input.ownerId,
 		async tx => {
 			const preview = await tx.trackingCommandPreview.findFirst({
 				where: {
@@ -767,7 +812,6 @@ export async function applyTrackingCommandPreview(
 				alreadyApplied: false,
 			}
 		},
-		{ isolationLevel: 'Serializable' },
 	)
 }
 
@@ -834,7 +878,9 @@ export async function undoTrackingCommandPreview(
 	input: { ownerId: string; previewId: string; now?: Date },
 ) {
 	const now = input.now ?? new Date()
-	return await prisma.$transaction(
+	return await withSerializableLibraryMutation(
+		prisma,
+		input.ownerId,
 		async tx => {
 			const preview = await tx.trackingCommandPreview.findFirst({
 				where: {
@@ -990,7 +1036,6 @@ export async function undoTrackingCommandPreview(
 			})
 			return { summary: parsedResolvedPlan(preview.operations).summary }
 		},
-		{ isolationLevel: 'Serializable' },
 	)
 }
 

--- a/app/utils/tracking-state.server.ts
+++ b/app/utils/tracking-state.server.ts
@@ -7,6 +7,7 @@ import {
 	trackingStateFromEntry,
 	type TrackingEntryLike,
 } from './tracking-state.ts'
+import { serializeUserLibraryMutation } from './watchlist-limits.ts'
 
 export type TrackingStateWriteMode = 'none' | 'status' | 'all'
 
@@ -23,6 +24,9 @@ export async function ensureTrackingStateForEntry(
 		recordActivity?: boolean
 	},
 ) {
+	if (input.recordActivity) {
+		await serializeUserLibraryMutation(tx, input.ownerId)
+	}
 	const existingState = await tx.trackingState.findUnique({
 		where: {
 			ownerId_mediaId: {

--- a/app/utils/tracking-state.test.ts
+++ b/app/utils/tracking-state.test.ts
@@ -132,3 +132,40 @@ test('treats malformed history and zero scores as empty state', () => {
 		sourceUpdatedAt: 0,
 	})
 })
+
+test('does not coerce non-scalar legacy values into epoch dates', () => {
+	const snapshot = trackingStateFromEntry(
+		{
+			history: JSON.stringify({
+				added: {},
+				started: [],
+				finished: false,
+				lastUpdated: '0',
+			}),
+		},
+		{ status: 'watching', mediaKind: 'anime' },
+	)
+
+	expect(snapshot.startedAt).toBeNull()
+	expect(snapshot.completedAt).toBeNull()
+	expect(snapshot.sourceUpdatedAt).toBe(0)
+})
+
+test('accepts an already bounded history object without reparsing JSON', () => {
+	const history = {
+		started: '2026-01-02T00:00:00.000Z',
+		progress: {
+			3: { finishDate: ['2026-01-03T00:00:00.000Z'] },
+		},
+	}
+	const fromObject = trackingStateFromEntry(
+		{ history, length: '3 / 12 eps' },
+		{ status: 'watching', mediaKind: 'anime' },
+	)
+	const fromJson = trackingStateFromEntry(
+		{ history: JSON.stringify(history), length: '3 / 12 eps' },
+		{ status: 'watching', mediaKind: 'anime' },
+	)
+
+	expect(fromObject).toEqual(fromJson)
+})

--- a/app/utils/tracking-state.ts
+++ b/app/utils/tracking-state.ts
@@ -1,3 +1,5 @@
+import { profileHistoryTimestamp } from './profile-history-bounds.ts'
+
 export type TrackingProgressSnapshot = {
 	unit: string
 	current: number
@@ -36,6 +38,8 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function parseHistory(value: unknown): Record<string, unknown> {
+	const record = asRecord(value)
+	if (record) return record
 	if (typeof value !== 'string' || !value || value === 'null') return {}
 	try {
 		return asRecord(JSON.parse(value)) ?? {}
@@ -45,11 +49,8 @@ function parseHistory(value: unknown): Record<string, unknown> {
 }
 
 function dateFromUnknown(value: unknown): Date | null {
-	if (value === null || value === undefined || value === '' || value === 0) {
-		return null
-	}
-	const date = new Date(value as string | number | Date)
-	return Number.isNaN(date.getTime()) ? null : date
+	const timestamp = profileHistoryTimestamp(value)
+	return timestamp === null ? null : new Date(timestamp)
 }
 
 function dateMs(value: unknown) {

--- a/app/utils/tracking-status.server.ts
+++ b/app/utils/tracking-status.server.ts
@@ -10,6 +10,7 @@ import {
 	trackingStateFromEntry,
 	type TrackingEntryLike,
 } from './tracking-state.ts'
+import { serializeUserLibraryMutation } from './watchlist-limits.ts'
 
 const catalogEntrySelect = {
 	id: true,
@@ -116,6 +117,7 @@ export async function setMediaTrackingStatus(
 		recordActivity?: boolean
 	},
 ) {
+	await serializeUserLibraryMutation(tx, input.ownerId)
 	const media = await tx.media.findUnique({
 		where: { id: input.mediaId },
 		select: {

--- a/app/utils/watchlist-limits.test.ts
+++ b/app/utils/watchlist-limits.test.ts
@@ -1,0 +1,47 @@
+import { type Prisma } from '@prisma/client'
+import { expect, test, vi } from 'vitest'
+import { serializeUserLibraryMutation } from './watchlist-limits.ts'
+
+function transactionWith(execute: () => Promise<number>) {
+	return {
+		$executeRaw: vi.fn(execute),
+	} as unknown as Pick<Prisma.TransactionClient, '$executeRaw'>
+}
+
+test('acquires each owner mutex only once per transaction', async () => {
+	let release = () => {}
+	const held = new Promise<number>(resolve => {
+		release = () => resolve(1)
+	})
+	const tx = transactionWith(() => held)
+
+	const first = serializeUserLibraryMutation(tx, 'owner-a')
+	const duplicate = serializeUserLibraryMutation(tx, 'owner-a')
+	expect(tx.$executeRaw).toHaveBeenCalledTimes(1)
+
+	release()
+	await Promise.all([first, duplicate])
+	await serializeUserLibraryMutation(tx, 'owner-a')
+	expect(tx.$executeRaw).toHaveBeenCalledTimes(1)
+
+	await serializeUserLibraryMutation(tx, 'owner-b')
+	expect(tx.$executeRaw).toHaveBeenCalledTimes(2)
+})
+
+test('a failed acquisition can be retried in the same transaction', async () => {
+	const failure = new Error('lock failed')
+	const tx = transactionWith(
+		vi
+			.fn<() => Promise<number>>()
+			.mockRejectedValueOnce(failure)
+			.mockResolvedValueOnce(1),
+	)
+
+	await expect(serializeUserLibraryMutation(tx, 'retry-owner')).rejects.toBe(
+		failure,
+	)
+	await expect(
+		serializeUserLibraryMutation(tx, 'retry-owner'),
+	).resolves.toBeUndefined()
+	expect(tx.$executeRaw).toHaveBeenCalledTimes(2)
+})

--- a/app/utils/watchlist-limits.ts
+++ b/app/utils/watchlist-limits.ts
@@ -1,0 +1,97 @@
+import { type Prisma } from '@prisma/client'
+
+export const MAX_WATCHLISTS_PER_USER = 100
+export const MAX_WATCHLISTS_PER_TYPE = 50
+/** Maximum number of watchlists a profile query ever needs to consider. */
+export const PROFILE_WATCHLIST_LIMIT = MAX_WATCHLISTS_PER_USER
+
+const libraryMutexes = new WeakMap<object, Map<string, Promise<void>>>()
+
+export class WatchlistLimitError extends Error {
+	readonly status = 409
+
+	constructor(
+		message: string,
+		public readonly limit: 'total' | 'type',
+	) {
+		super(message)
+		this.name = 'WatchlistLimitError'
+	}
+}
+
+/**
+ * Serialize library mutations whose visibility/activity provenance must agree
+ * at commit. The non-key no-op keeps the member timestamp unchanged while
+ * providing one cross-database transaction lock.
+ */
+export async function serializeUserLibraryMutation(
+	tx: Pick<Prisma.TransactionClient, '$executeRaw'>,
+	ownerId: string,
+) {
+	let transactionMutexes = libraryMutexes.get(tx)
+	if (!transactionMutexes) {
+		transactionMutexes = new Map()
+		libraryMutexes.set(tx, transactionMutexes)
+	}
+	let acquisition = transactionMutexes.get(ownerId)
+	if (!acquisition) {
+		acquisition = (async () => {
+			await tx.$executeRaw`
+				UPDATE "User"
+				SET "updatedAt" = "updatedAt"
+				WHERE "id" = ${ownerId}
+			`
+		})()
+		transactionMutexes.set(ownerId, acquisition)
+	}
+	try {
+		await acquisition
+	} catch (error) {
+		if (transactionMutexes.get(ownerId) === acquisition) {
+			transactionMutexes.delete(ownerId)
+		}
+		throw error
+	}
+}
+
+/** Serialize all list reuse/create decisions for one member. */
+export async function serializeWatchlistCreation(
+	tx: Pick<Prisma.TransactionClient, '$executeRaw'>,
+	ownerId: string,
+) {
+	await serializeUserLibraryMutation(tx, ownerId)
+}
+
+/**
+ * Checks watchlist capacity inside the same transaction that creates the list.
+ * Callers must reuse an existing destination before invoking this guard.
+ */
+export async function assertWatchlistCreationAllowed(
+	tx: Pick<Prisma.TransactionClient, 'watchlist' | '$executeRaw'>,
+	input: { ownerId: string; typeId: string },
+) {
+	// A harmless row update provides one cross-database, per-owner transaction
+	// lock. Concurrent normal creations and imports therefore cannot both pass
+	// the count checks at the same boundary.
+	await serializeWatchlistCreation(tx, input.ownerId)
+
+	const [totalCount, typeCount] = await Promise.all([
+		tx.watchlist.count({ where: { ownerId: input.ownerId } }),
+		tx.watchlist.count({
+			where: { ownerId: input.ownerId, typeId: input.typeId },
+		}),
+	])
+
+	if (totalCount >= MAX_WATCHLISTS_PER_USER) {
+		throw new WatchlistLimitError(
+			`You can have up to ${MAX_WATCHLISTS_PER_USER} watchlists. Delete one before creating another.`,
+			'total',
+		)
+	}
+	if (typeCount >= MAX_WATCHLISTS_PER_TYPE) {
+		throw new WatchlistLimitError(
+			`You can have up to ${MAX_WATCHLISTS_PER_TYPE} watchlists for each media type. Delete one before creating another.`,
+			'type',
+		)
+	}
+}

--- a/package.json
+++ b/package.json
@@ -100,8 +100,8 @@
     "validate:release:build": "npm run build && npm run bundle:check",
     "validate:release:browser": "cross-env CI=true PORT=4122 playwright test --project=chromium",
     "validate:release:browser:portable": "cross-env CI=true PORT=4122 playwright test --project=chromium --ignore-snapshots",
-    "validate:release:postgres": "npm run prisma:generate:postgres && npm run db:migrate:postgres && npm run db:verify:postgres && npm run db:smoke:postgres && npm run db:loadtest:postgres -- --commit --count 2000 --cleanup-after",
-    "validate:scale:postgres": "npm run prisma:generate:postgres && npm run db:migrate:postgres && npm run db:verify:postgres && npm run db:smoke:postgres && npm run db:loadtest:postgres -- --commit --count 100000 --member-count 1000 --tracking-per-member 100 --activity-per-member 20 --require-trigram-indexes --require-calendar-indexes --require-community-indexes --cleanup-after"
+    "validate:release:postgres": "npm run prisma:generate:postgres && npm run db:migrate:postgres && npm run db:verify:postgres && npm run db:smoke:postgres && npm run db:loadtest:postgres -- --commit --count 2000 --member-count 20 --tracking-per-member 100 --activity-per-member 20 --cleanup-after",
+    "validate:scale:postgres": "npm run prisma:generate:postgres && npm run db:migrate:postgres && npm run db:verify:postgres && npm run db:smoke:postgres && npm run db:loadtest:postgres -- --commit --count 100000 --member-count 1000 --tracking-per-member 100 --activity-per-member 20 --require-trigram-indexes --require-calendar-indexes --require-community-indexes --require-profile-indexes --cleanup-after"
   },
   "eslintIgnore": [
     "/node_modules",

--- a/prisma/migrations/20260729000900_verify_activity_visibility_provenance/migration.sql
+++ b/prisma/migrations/20260729000900_verify_activity_visibility_provenance/migration.sql
@@ -1,0 +1,6 @@
+-- Historical ActivityEvent rows cannot always be attributed to a watchlist:
+-- older rows used mutable labels and a previous migration could only guess when
+-- duplicate labels existed. Keep those rows owner-visible, but require all new
+-- public activity to opt into immutable, public-at-creation eligibility.
+ALTER TABLE "ActivityEvent"
+ADD COLUMN "publicEligible" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20260729001000_bound_profile_queries/migration.sql
+++ b/prisma/migrations/20260729001000_bound_profile_queries/migration.sql
@@ -1,0 +1,24 @@
+-- Bound profile analytics keyset scans and the four newest-first activity
+-- sources with deterministic id tie-breaks.
+CREATE INDEX "Entry_watchlistId_id_idx" ON "Entry"("watchlistId", "id");
+
+CREATE INDEX "ActivityEvent_actorId_createdAt_id_idx"
+ON "ActivityEvent"("actorId", "createdAt", "id");
+CREATE INDEX "ActivityEvent_actorId_isPublic_publicEligible_createdAt_id_idx"
+ON "ActivityEvent"("actorId", "isPublic", "publicEligible", "createdAt", "id");
+CREATE INDEX "ActivityEvent_isPublic_publicEligible_createdAt_id_idx"
+ON "ActivityEvent"("isPublic", "publicEligible", "createdAt", "id");
+
+CREATE INDEX "Review_authorId_moderationStatus_createdAt_id_idx"
+ON "Review"("authorId", "moderationStatus", "createdAt", "id");
+
+CREATE INDEX "DiaryEntry_ownerId_createdAt_id_idx"
+ON "DiaryEntry"("ownerId", "createdAt", "id");
+CREATE INDEX "DiaryEntry_ownerId_loggedOn_createdAt_id_idx"
+ON "DiaryEntry"("ownerId", "loggedOn", "createdAt", "id");
+
+-- Keep every prior access path available until all replacements exist.
+DROP INDEX "Entry_watchlistId_idx";
+DROP INDEX "ActivityEvent_actorId_createdAt_idx";
+DROP INDEX "Review_authorId_createdAt_idx";
+DROP INDEX "DiaryEntry_ownerId_loggedOn_idx";

--- a/prisma/postgresql/migrations/20260729000900_verify_activity_visibility_provenance/migration.sql
+++ b/prisma/postgresql/migrations/20260729000900_verify_activity_visibility_provenance/migration.sql
@@ -1,0 +1,6 @@
+-- Historical ActivityEvent rows cannot always be attributed to a watchlist:
+-- older rows used mutable labels and a previous migration could only guess when
+-- duplicate labels existed. Keep those rows owner-visible, but require all new
+-- public activity to opt into immutable, public-at-creation eligibility.
+ALTER TABLE "ActivityEvent"
+ADD COLUMN "publicEligible" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/postgresql/migrations/20260729001000_bound_profile_queries/migration.sql
+++ b/prisma/postgresql/migrations/20260729001000_bound_profile_queries/migration.sql
@@ -1,0 +1,9 @@
+-- Bound profile analytics keyset scans and the four newest-first activity
+-- sources with deterministic id tie-breaks.
+-- Each PostgreSQL migration in this series contains exactly one statement:
+-- Prisma otherwise wraps multi-statement migrations in a transaction, which
+-- PostgreSQL forbids for CONCURRENTLY.
+-- Bare CREATE is intentional: a failed concurrent build can leave an invalid
+-- index, which must fail loudly and be removed before the migration is retried.
+CREATE INDEX CONCURRENTLY "Entry_watchlistId_id_idx"
+ON "Entry"("watchlistId", "id");

--- a/prisma/postgresql/migrations/20260729001100_bound_profile_activity_actor_create/migration.sql
+++ b/prisma/postgresql/migrations/20260729001100_bound_profile_activity_actor_create/migration.sql
@@ -1,0 +1,3 @@
+-- Keep this as one statement so Prisma deploy does not wrap CONCURRENTLY.
+CREATE INDEX CONCURRENTLY "ActivityEvent_actorId_createdAt_id_idx"
+ON "ActivityEvent"("actorId", "createdAt", "id");

--- a/prisma/postgresql/migrations/20260729001200_bound_profile_activity_public_create/migration.sql
+++ b/prisma/postgresql/migrations/20260729001200_bound_profile_activity_public_create/migration.sql
@@ -1,0 +1,3 @@
+-- Keep this as one statement so Prisma deploy does not wrap CONCURRENTLY.
+CREATE INDEX CONCURRENTLY "ActivityEvent_actorId_isPublic_publicEligible_createdAt_id_idx"
+ON "ActivityEvent"("actorId", "isPublic", "publicEligible", "createdAt", "id");

--- a/prisma/postgresql/migrations/20260729001300_bound_profile_review_create/migration.sql
+++ b/prisma/postgresql/migrations/20260729001300_bound_profile_review_create/migration.sql
@@ -1,0 +1,3 @@
+-- Keep this as one statement so Prisma deploy does not wrap CONCURRENTLY.
+CREATE INDEX CONCURRENTLY "Review_authorId_moderationStatus_createdAt_id_idx"
+ON "Review"("authorId", "moderationStatus", "createdAt", "id");

--- a/prisma/postgresql/migrations/20260729001400_bound_profile_diary_created_create/migration.sql
+++ b/prisma/postgresql/migrations/20260729001400_bound_profile_diary_created_create/migration.sql
@@ -1,0 +1,3 @@
+-- Keep this as one statement so Prisma deploy does not wrap CONCURRENTLY.
+CREATE INDEX CONCURRENTLY "DiaryEntry_ownerId_createdAt_id_idx"
+ON "DiaryEntry"("ownerId", "createdAt", "id");

--- a/prisma/postgresql/migrations/20260729001500_bound_profile_diary_logged_create/migration.sql
+++ b/prisma/postgresql/migrations/20260729001500_bound_profile_diary_logged_create/migration.sql
@@ -1,0 +1,3 @@
+-- Keep this as one statement so Prisma deploy does not wrap CONCURRENTLY.
+CREATE INDEX CONCURRENTLY "DiaryEntry_ownerId_loggedOn_createdAt_id_idx"
+ON "DiaryEntry"("ownerId", "loggedOn", "createdAt", "id");

--- a/prisma/postgresql/migrations/20260729001600_bound_profile_entry_drop/migration.sql
+++ b/prisma/postgresql/migrations/20260729001600_bound_profile_entry_drop/migration.sql
@@ -1,0 +1,2 @@
+-- Every replacement exists before this nonblocking retirement series begins.
+DROP INDEX CONCURRENTLY IF EXISTS "Entry_watchlistId_idx";

--- a/prisma/postgresql/migrations/20260729001700_bound_profile_activity_drop/migration.sql
+++ b/prisma/postgresql/migrations/20260729001700_bound_profile_activity_drop/migration.sql
@@ -1,0 +1,2 @@
+-- Keep this as one statement so Prisma deploy does not wrap CONCURRENTLY.
+DROP INDEX CONCURRENTLY IF EXISTS "ActivityEvent_actorId_createdAt_idx";

--- a/prisma/postgresql/migrations/20260729001800_bound_profile_review_drop/migration.sql
+++ b/prisma/postgresql/migrations/20260729001800_bound_profile_review_drop/migration.sql
@@ -1,0 +1,2 @@
+-- Keep this as one statement so Prisma deploy does not wrap CONCURRENTLY.
+DROP INDEX CONCURRENTLY IF EXISTS "Review_authorId_createdAt_idx";

--- a/prisma/postgresql/migrations/20260729001900_bound_profile_diary_drop/migration.sql
+++ b/prisma/postgresql/migrations/20260729001900_bound_profile_diary_drop/migration.sql
@@ -1,0 +1,2 @@
+-- Keep this as one statement so Prisma deploy does not wrap CONCURRENTLY.
+DROP INDEX CONCURRENTLY IF EXISTS "DiaryEntry_ownerId_loggedOn_idx";

--- a/prisma/postgresql/migrations/20260729002000_activity_public_eligible_create/migration.sql
+++ b/prisma/postgresql/migrations/20260729002000_activity_public_eligible_create/migration.sql
@@ -1,0 +1,3 @@
+-- Keep this as one statement so Prisma deploy does not wrap CONCURRENTLY.
+CREATE INDEX CONCURRENTLY "ActivityEvent_isPublic_publicEligible_createdAt_id_idx"
+ON "ActivityEvent"("isPublic", "publicEligible", "createdAt", "id");

--- a/prisma/postgresql/schema.prisma
+++ b/prisma/postgresql/schema.prisma
@@ -616,7 +616,7 @@ model Entry {
   malScore      Decimal? // anime, manga
 
   // non-unique foreign key
-  @@index([watchlistId])
+  @@index([watchlistId, id])
   @@index([mediaId])
   @@index([trackingStateId])
 }
@@ -842,6 +842,8 @@ model ActivityEvent {
   progressPrevious    Int?
   progressTotal       Int?
   isPublic            Boolean  @default(true)
+  /// True only when immutable provenance was valid and the event was public-safe at creation.
+  publicEligible      Boolean  @default(false)
   createdAt           DateTime @default(now())
 
   actor                     User           @relation(fields: [actorId], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -855,11 +857,13 @@ model ActivityEvent {
   previousStatusWatchlist   Watchlist?     @relation("ActivityEventPreviousStatusWatchlist", fields: [previousStatusWatchlistId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   previousStatusWatchlistId String?
 
-  @@index([actorId, createdAt])
+  @@index([actorId, createdAt, id])
+  @@index([actorId, isPublic, publicEligible, createdAt, id])
   @@index([mediaId, createdAt])
   @@index([trackingStateId])
   @@index([statusWatchlistId])
   @@index([previousStatusWatchlistId])
+  @@index([isPublic, publicEligible, createdAt, id])
   @@index([isPublic, createdAt])
   @@index([type, createdAt])
 }
@@ -887,7 +891,7 @@ model Review {
   notifications Notification[]
 
   @@unique([authorId, mediaId])
-  @@index([authorId, createdAt])
+  @@index([authorId, moderationStatus, createdAt, id])
   @@index([mediaId, createdAt])
   @@index([moderationStatus, createdAt])
 }
@@ -1005,7 +1009,8 @@ model DiaryEntry {
   media   Media  @relation(fields: [mediaId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   mediaId String
 
-  @@index([ownerId, loggedOn])
+  @@index([ownerId, createdAt, id])
+  @@index([ownerId, loggedOn, createdAt, id])
   @@index([mediaId, loggedOn])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -611,7 +611,7 @@ model Entry {
   malScore      Decimal? // anime, manga
 
   // non-unique foreign key
-  @@index([watchlistId])
+  @@index([watchlistId, id])
   @@index([mediaId])
   @@index([trackingStateId])
 }
@@ -837,6 +837,8 @@ model ActivityEvent {
   progressPrevious    Int?
   progressTotal       Int?
   isPublic            Boolean  @default(true)
+  /// True only when immutable provenance was valid and the event was public-safe at creation.
+  publicEligible      Boolean  @default(false)
   createdAt           DateTime @default(now())
 
   actor                     User           @relation(fields: [actorId], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -850,11 +852,13 @@ model ActivityEvent {
   previousStatusWatchlist   Watchlist?     @relation("ActivityEventPreviousStatusWatchlist", fields: [previousStatusWatchlistId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   previousStatusWatchlistId String?
 
-  @@index([actorId, createdAt])
+  @@index([actorId, createdAt, id])
+  @@index([actorId, isPublic, publicEligible, createdAt, id])
   @@index([mediaId, createdAt])
   @@index([trackingStateId])
   @@index([statusWatchlistId])
   @@index([previousStatusWatchlistId])
+  @@index([isPublic, publicEligible, createdAt, id])
   @@index([isPublic, createdAt])
   @@index([type, createdAt])
 }
@@ -882,7 +886,7 @@ model Review {
   notifications Notification[]
 
   @@unique([authorId, mediaId])
-  @@index([authorId, createdAt])
+  @@index([authorId, moderationStatus, createdAt, id])
   @@index([mediaId, createdAt])
   @@index([moderationStatus, createdAt])
 }
@@ -1000,7 +1004,8 @@ model DiaryEntry {
   media   Media  @relation(fields: [mediaId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   mediaId String
 
-  @@index([ownerId, loggedOn])
+  @@index([ownerId, createdAt, id])
+  @@index([ownerId, loggedOn, createdAt, id])
   @@index([mediaId, loggedOn])
 }
 

--- a/scripts/load-test-postgres-catalog.mjs
+++ b/scripts/load-test-postgres-catalog.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import 'dotenv/config'
+import { spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -7,9 +8,11 @@ import { performance } from 'node:perf_hooks'
 import { PrismaClient } from '@prisma/client'
 import {
 	assertRequiredQueryIndexes,
+	assertRequiredQueryRows,
 	assertSafeLoadDatabaseUrl,
 	bytesLabel,
 	calendarLoadWindow,
+	representativeProfileEntryShape,
 	representativeLoadShape,
 	summarizeDatabasePressure,
 	summarizeExplain,
@@ -20,6 +23,8 @@ const args = process.argv.slice(2)
 const prefix = 'load-catalog-'
 const syntheticBroadDescriptionNeedle = 'Shared synthetic load description'
 const syntheticDescriptionLead = `${syntheticBroadDescriptionNeedle} for indexed discovery.`
+const syntheticRareDescriptionRow = 73_003
+const syntheticRareDescriptionNeedle = `rare-nebula-token-${syntheticRareDescriptionRow}`
 const requiredTrigramIndexesByQuery = {
 	'canonical-title': 'Media_title_trgm_idx',
 	'tracking-exact-title': 'Media_title_trgm_idx',
@@ -30,6 +35,58 @@ const requiredCalendarIndexesByQuery = {
 	'calendar-media-range': 'Media_nextReleaseAt_idx',
 	'calendar-occurrence-range': 'ReleaseOccurrence_releaseAt_status_idx',
 	'calendar-public-tracker-counts': 'TrackingState_mediaId_idx',
+}
+const requiredProfileIndexesByQuery = {
+	'profile-entry-page': 'Entry_watchlistId_id_idx',
+	'profile-activity-owner': 'ActivityEvent_actorId_createdAt_id_idx',
+	'profile-activity-public':
+		'ActivityEvent_actorId_isPublic_publicEligible_createdAt_id_idx',
+	'profile-review-page': 'Review_authorId_moderationStatus_createdAt_id_idx',
+	'profile-diary-activity': 'DiaryEntry_ownerId_createdAt_id_idx',
+	'profile-diary-page': 'DiaryEntry_ownerId_loggedOn_createdAt_id_idx',
+}
+const requiredProfileRowsByQuery = {
+	'profile-entry-page': 500,
+	'profile-activity-owner': 100,
+	'profile-activity-public': 100,
+	'profile-review-page': 100,
+	'profile-diary-activity': 100,
+	'profile-diary-page': 100,
+}
+const profileActivityPublicRelationsSql = `LEFT JOIN "Watchlist" AS status_watchlist
+   ON status_watchlist.id = activity."statusWatchlistId"
+ LEFT JOIN "Watchlist" AS previous_status_watchlist
+   ON previous_status_watchlist.id = activity."previousStatusWatchlistId"`
+const profileActivityPublicPredicateSql = `activity."isPublic" = true
+ AND activity."publicEligible" = true
+ AND (
+   (
+     activity."statusWatchlistId" IS NULL
+     AND activity."statusLabel" IS NULL
+   )
+   OR (
+     status_watchlist."ownerId" = $1
+     AND status_watchlist."isPublic" = true
+   )
+ )
+ AND (
+   (
+     activity."previousStatusWatchlistId" IS NULL
+     AND activity."previousStatusLabel" IS NULL
+   )
+   OR (
+     previous_status_watchlist."ownerId" = $1
+     AND previous_status_watchlist."isPublic" = true
+   )
+ )`
+const profileFixtureTargets = {
+	reviewRowsPerMember: 10,
+	diaryRowsPerMember: 10,
+	activityRows: 120,
+	reviewRows: 120,
+	hiddenReviewRows: 600,
+	diaryRows: 2_000,
+	unsafePublicActivityRows: 1,
 }
 const communityCandidateLimit = 1_000
 const communityCandidateChunkSize = 400
@@ -82,6 +139,7 @@ Options:
   --require-trigram-indexes Fail if measured text searches avoid trigram indexes
   --require-calendar-indexes Fail if bounded calendar queries avoid their indexes
   --require-community-indexes Fail if chunked community aggregates avoid their index
+  --require-profile-indexes Fail if bounded profile queries avoid their indexes
   --help                    Show this help
 
 DATABASE_URL must use PostgreSQL and its database name must contain a clearly
@@ -131,6 +189,7 @@ function assertKnownArguments() {
 		'--require-trigram-indexes',
 		'--require-calendar-indexes',
 		'--require-community-indexes',
+		'--require-profile-indexes',
 		'--help',
 	])
 	for (let index = 0; index < args.length; index++) {
@@ -178,6 +237,68 @@ function kindSql(series = 'n') {
 		ELSE 'manga' END`
 }
 
+function profileFixtureMemberNumber(memberCount) {
+	if (!memberCount) return null
+	let memberNumber = Math.max(1, Math.floor(memberCount / 2))
+	if (memberNumber % 7 === 0) {
+		memberNumber =
+			memberNumber < memberCount ? memberNumber + 1 : memberNumber - 1
+	}
+	return Math.max(1, memberNumber)
+}
+
+function representativeProfileFixture(shape, mediaCount) {
+	const memberNumber = profileFixtureMemberNumber(shape.memberCount)
+	const reviewRowsPerMember = Math.min(
+		profileFixtureTargets.reviewRowsPerMember,
+		mediaCount,
+	)
+	const diaryRowsPerMember = profileFixtureTargets.diaryRowsPerMember
+	const reviewRows = Math.min(
+		profileFixtureTargets.reviewRows,
+		Math.max(0, mediaCount - reviewRowsPerMember),
+	)
+	const hiddenReviewRows = Math.min(
+		profileFixtureTargets.hiddenReviewRows,
+		Math.max(0, mediaCount - reviewRowsPerMember - reviewRows),
+	)
+	if (memberNumber === null) {
+		return {
+			memberNumber: null,
+			memberId: null,
+			watchlistId: null,
+			reviewRowsPerMember,
+			diaryRowsPerMember,
+			expectedEntries: 0,
+			entryRows: 0,
+			activityRows: 0,
+			reviewRows: 0,
+			hiddenReviewRows: 0,
+			diaryRows: 0,
+			unsafePublicActivityRows: 0,
+		}
+	}
+	const entryShape = representativeProfileEntryShape({
+		mediaCount,
+		trackedEntries: shape.trackingPerMember,
+	})
+
+	return {
+		memberNumber,
+		memberId: `${prefix}member-${memberNumber}`,
+		watchlistId: `${prefix}watchlist-${memberNumber}-liveaction`,
+		reviewRowsPerMember,
+		diaryRowsPerMember,
+		expectedEntries: entryShape.expectedEntries,
+		entryRows: entryShape.fixtureEntryRows,
+		activityRows: profileFixtureTargets.activityRows,
+		reviewRows,
+		hiddenReviewRows,
+		diaryRows: profileFixtureTargets.diaryRows,
+		unsafePublicActivityRows: profileFixtureTargets.unsafePublicActivityRows,
+	}
+}
+
 async function databaseMetrics(prisma) {
 	const rows = await prisma.$queryRaw`
 		SELECT
@@ -189,7 +310,9 @@ async function databaseMetrics(prisma) {
 			pg_total_relation_size('"ReleaseOccurrence"')::bigint AS "releaseOccurrenceBytes",
 			pg_total_relation_size('"TrackingState"')::bigint AS "trackingBytes",
 			pg_total_relation_size('"Entry"')::bigint AS "entryBytes",
-			pg_total_relation_size('"ActivityEvent"')::bigint AS "activityBytes"
+			pg_total_relation_size('"ActivityEvent"')::bigint AS "activityBytes",
+			pg_total_relation_size('"Review"')::bigint AS "reviewBytes",
+			pg_total_relation_size('"DiaryEntry"')::bigint AS "diaryBytes"
 	`
 	const row = rows[0]
 	return Object.fromEntries(
@@ -251,7 +374,7 @@ async function insertBatch(prisma, start, end, scheduleAnchor) {
 				ELSE NULL END,
 			$3::text || ' Record ' || n || '. ' ||
 				repeat('Cast, setting, themes, and release metadata vary across this representative catalog record. ', (n % 4) + 1) ||
-				CASE n % 997 WHEN 0 THEN 'rare-nebula-token' ELSE '' END,
+				CASE WHEN n = $5::int THEN $6::text ELSE '' END,
 			CASE n % 5 WHEN 0 THEN 'Drama, Mystery' WHEN 1 THEN 'Action, Fantasy'
 				WHEN 2 THEN 'Comedy' WHEN 3 THEN 'Science Fiction' ELSE 'Romance' END,
 			CASE WHEN ${kind} IN ('movie', 'tv') THEN 'en' ELSE 'ja' END,
@@ -273,6 +396,8 @@ async function insertBatch(prisma, start, end, scheduleAnchor) {
 		end,
 		syntheticDescriptionLead,
 		scheduleAnchor,
+		syntheticRareDescriptionRow,
+		syntheticRareDescriptionNeedle,
 	)
 	await prisma.$executeRawUnsafe(
 		`INSERT INTO "MediaExternalId" (
@@ -425,6 +550,7 @@ async function insertRepresentativeMemberBatch(
 	shape,
 	mediaCount,
 ) {
+	const profileFixture = representativeProfileFixture(shape, mediaCount)
 	await prisma.$executeRawUnsafe(
 		`INSERT INTO "User" (
 			"id", "email", "username", "name", "bio", "createdAt", "updatedAt", "lastActiveAt"
@@ -557,15 +683,17 @@ async function insertRepresentativeMemberBatch(
 			)
 			INSERT INTO "ActivityEvent" (
 				"id", "type", "status", "statusLabel", "score", "isPublic",
-				"createdAt", "actorId", "mediaId", "trackingStateId",
+				"publicEligible", "createdAt", "actorId", "mediaId", "trackingStateId",
 				"statusWatchlistId"
 			)
 			SELECT
 				'${prefix}activity-' || member_number || '-' || slot,
 				CASE WHEN slot % 4 = 0 THEN 'completed' ELSE 'status' END,
 				tracking.status,
-				CASE WHEN media.kind = 'manga' THEN 'Reading' ELSE 'Watching' END,
+				CASE WHEN tracking."statusWatchlistId" IS NULL THEN NULL
+					WHEN media.kind = 'manga' THEN 'Reading' ELSE 'Watching' END,
 				tracking.score,
+				COALESCE(watchlist."isPublic", true),
 				COALESCE(watchlist."isPublic", true),
 				CURRENT_TIMESTAMP - ((slot % 365) || ' days')::interval,
 				tracking."ownerId",
@@ -583,6 +711,277 @@ async function insertRepresentativeMemberBatch(
 			shape.activityPerMember,
 		)
 	}
+	await prisma.$executeRawUnsafe(
+		`INSERT INTO "Review" (
+			"id", "body", "containsSpoilers", "rating", "createdAt", "updatedAt",
+			"moderationStatus", "authorId", "mediaId"
+		)
+		SELECT
+			'${prefix}review-' || member_number || '-' || review_slot,
+			'Representative profile review ' || member_number || '-' || review_slot,
+			(review_slot % 9) = 0,
+			((review_slot % 10) + 1)::numeric,
+			CURRENT_TIMESTAMP - (
+				((member_number + review_slot) % 90) || ' days'
+			)::interval,
+			CURRENT_TIMESTAMP,
+			'visible',
+			'${prefix}member-' || member_number,
+			'${prefix}media-' || (
+				1 + mod(
+					((member_number - 1)::bigint * $3::bigint) + review_slot - 1,
+					$4::bigint
+				)
+			)
+		FROM generate_series($1::int, $2::int) AS member_number
+		CROSS JOIN generate_series(1, $5::int) AS review_slot
+		ON CONFLICT DO NOTHING`,
+		start,
+		end,
+		shape.trackingPerMember,
+		mediaCount,
+		profileFixture.reviewRowsPerMember,
+	)
+	await prisma.$executeRawUnsafe(
+		`INSERT INTO "DiaryEntry" (
+			"id", "loggedOn", "isRepeat", "rating", "createdAt", "updatedAt",
+			"ownerId", "mediaId"
+		)
+		SELECT
+			'${prefix}diary-' || member_number || '-' || diary_slot,
+			CURRENT_TIMESTAMP - (
+				((member_number + diary_slot) % 120) || ' days'
+			)::interval,
+			(diary_slot % 5) = 0,
+			((diary_slot % 10) + 1)::numeric,
+			CURRENT_TIMESTAMP - (
+				((member_number + diary_slot) % 90) || ' days'
+			)::interval,
+			CURRENT_TIMESTAMP,
+			'${prefix}member-' || member_number,
+			'${prefix}media-' || (
+				1 + mod(
+					((member_number - 1)::bigint * $3::bigint) + diary_slot - 1,
+					$4::bigint
+				)
+			)
+		FROM generate_series($1::int, $2::int) AS member_number
+		CROSS JOIN generate_series(1, $5::int) AS diary_slot
+		ON CONFLICT DO NOTHING`,
+		start,
+		end,
+		shape.trackingPerMember,
+		mediaCount,
+		profileFixture.diaryRowsPerMember,
+	)
+}
+
+async function insertRepresentativeProfileFixture(prisma, shape, mediaCount) {
+	const fixture = representativeProfileFixture(shape, mediaCount)
+	if (fixture.memberNumber === null) return
+
+	await prisma.$executeRawUnsafe(
+		`WITH live_action_media AS (
+			SELECT
+				media.id,
+				media.thumbnail,
+				media.title,
+				media.type,
+				media."releaseStart",
+				media.genres,
+				ROW_NUMBER() OVER (ORDER BY media_number)::int AS media_slot,
+				COUNT(*) OVER()::int AS media_count
+			FROM generate_series(1, $3::int) AS media_number
+			JOIN "Media" AS media
+				ON media.id = '${prefix}media-' || media_number
+			WHERE media.kind IN ('movie', 'tv')
+		), assignments AS (
+			SELECT
+				slot,
+				1 + mod(
+					slot - 1,
+					(SELECT MAX(media_count) FROM live_action_media)
+				) AS media_slot
+			FROM generate_series(1, $2::int) AS slot
+		)
+		INSERT INTO "Entry" (
+			"id", "watchlistId", "mediaId", "position", "thumbnail", "title",
+			"type", "releaseStart", "history", "genres", "story", "character",
+			"presentation", "sound", "performance", "enjoyment", "averaged",
+			"personal", "airYear", "length", "tmdbScore"
+		)
+		SELECT
+			'${prefix}entry-heavy-' || $1::int || '-' || assignments.slot,
+			'${prefix}watchlist-' || $1::int || '-liveaction',
+			media.id,
+			10000 + assignments.slot,
+			media.thumbnail,
+			media.title,
+			media.type,
+			media."releaseStart",
+			json_build_object(
+				'Added',
+				to_char(
+					(CURRENT_TIMESTAMP - (assignments.slot || ' minutes')::interval)
+						AT TIME ZONE 'UTC',
+					'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+				)
+			)::text,
+			media.genres,
+			8,
+			8,
+			8,
+			8,
+			8,
+			8,
+			8,
+			8,
+			EXTRACT(YEAR FROM media."releaseStart")::int::text,
+			'120 min',
+			7.5
+		FROM assignments
+		JOIN live_action_media AS media USING (media_slot)
+		ON CONFLICT DO NOTHING`,
+		fixture.memberNumber,
+		fixture.entryRows,
+		mediaCount,
+	)
+
+	await prisma.$executeRawUnsafe(
+		`WITH activity_rows AS (
+			SELECT
+				slot,
+				1 + mod(slot - 1, $3::int) AS tracking_slot
+			FROM generate_series(1, $2::int) AS slot
+		)
+		INSERT INTO "ActivityEvent" (
+			"id", "type", "status", "statusLabel", "previousStatus",
+			"previousStatusLabel", "score", "previousScore", "progressUnit",
+			"progressCurrent", "progressPrevious", "progressTotal", "isPublic",
+			"publicEligible",
+			"createdAt", "actorId", "mediaId", "trackingStateId",
+			"statusWatchlistId", "previousStatusWatchlistId"
+		)
+		SELECT
+			'${prefix}activity-heavy-' || $1::int || '-' || activity_rows.slot,
+			CASE WHEN activity_rows.slot % 4 = 0 THEN 'completed' ELSE 'progress' END,
+			tracking.status,
+			CASE WHEN tracking."statusWatchlistId" IS NULL THEN NULL
+				WHEN media.kind = 'manga' THEN 'Reading' ELSE 'Watching' END,
+			CASE WHEN tracking."statusWatchlistId" IS NULL
+				THEN NULL ELSE 'planning' END,
+			CASE WHEN tracking."statusWatchlistId" IS NULL
+				THEN NULL ELSE 'Planning' END,
+			tracking.score,
+			NULL,
+			CASE WHEN media.kind = 'manga' THEN 'chapter' ELSE 'episode' END,
+			activity_rows.slot,
+			activity_rows.slot - 1,
+			CASE WHEN media.kind = 'manga' THEN 200 ELSE 24 END,
+			COALESCE(watchlist."isPublic", true),
+			COALESCE(watchlist."isPublic", true),
+			CURRENT_TIMESTAMP - (activity_rows.slot || ' minutes')::interval,
+			tracking."ownerId",
+			tracking."mediaId",
+			tracking.id,
+			tracking."statusWatchlistId",
+			tracking."statusWatchlistId"
+		FROM activity_rows
+		JOIN "TrackingState" AS tracking
+			ON tracking.id = '${prefix}tracking-' || $1::int || '-' ||
+				activity_rows.tracking_slot
+		JOIN "Media" AS media ON media.id = tracking."mediaId"
+		LEFT JOIN "Watchlist" AS watchlist
+			ON watchlist.id = tracking."statusWatchlistId"
+		ON CONFLICT DO NOTHING`,
+		fixture.memberNumber,
+		fixture.activityRows,
+		shape.trackingPerMember,
+	)
+
+	await prisma.$executeRawUnsafe(
+		`INSERT INTO "ActivityEvent" (
+			"id", "type", "statusLabel", "isPublic", "publicEligible",
+			"createdAt", "actorId", "mediaId"
+		)
+		SELECT
+			'${prefix}activity-unsafe-' || $1::int,
+			'status',
+			'Legacy list without immutable provenance',
+			true,
+			false,
+			CURRENT_TIMESTAMP + INTERVAL '1 minute',
+			'${prefix}member-' || $1::int,
+			'${prefix}media-1'
+		WHERE $2::int > 0
+		ON CONFLICT DO NOTHING`,
+		fixture.memberNumber,
+		fixture.unsafePublicActivityRows,
+	)
+
+	await prisma.$executeRawUnsafe(
+		`WITH review_rows AS (
+			SELECT
+				slot,
+				1 + mod(
+					(($1::int - 1)::bigint * $3::bigint) +
+						$5::bigint + slot - 1,
+					$4::bigint
+				)::int AS media_number
+			FROM generate_series(1, $2::int) AS slot
+		)
+		INSERT INTO "Review" (
+			"id", "body", "containsSpoilers", "rating", "createdAt", "updatedAt",
+			"moderationStatus", "authorId", "mediaId"
+		)
+		SELECT
+			'${prefix}review-heavy-' || $1::int || '-' || review_rows.slot,
+			'Representative profile review ' || $1::int || '-' || review_rows.slot,
+			(review_rows.slot % 9) = 0,
+			((review_rows.slot % 10) + 1)::numeric,
+			CURRENT_TIMESTAMP - (review_rows.slot || ' hours')::interval,
+			CURRENT_TIMESTAMP,
+			CASE WHEN review_rows.slot <= $6::int THEN 'visible' ELSE 'hidden' END,
+			'${prefix}member-' || $1::int,
+			'${prefix}media-' || review_rows.media_number
+		FROM review_rows
+		ON CONFLICT DO NOTHING`,
+		fixture.memberNumber,
+		fixture.reviewRows + fixture.hiddenReviewRows,
+		shape.trackingPerMember,
+		mediaCount,
+		fixture.reviewRowsPerMember,
+		fixture.reviewRows,
+	)
+
+	await prisma.$executeRawUnsafe(
+		`WITH diary_rows AS (
+			SELECT
+				slot,
+				1 + mod(slot - 1, $3::int) AS media_number
+			FROM generate_series(1, $2::int) AS slot
+		)
+		INSERT INTO "DiaryEntry" (
+			"id", "loggedOn", "isRepeat", "rating", "createdAt", "updatedAt",
+			"ownerId", "mediaId"
+		)
+		SELECT
+			'${prefix}diary-heavy-' || $1::int || '-' || diary_rows.slot,
+			CURRENT_TIMESTAMP - (
+				(1 + mod(diary_rows.slot * 37, 5000)) || ' days'
+			)::interval,
+			(diary_rows.slot % 5) = 0,
+			((diary_rows.slot % 10) + 1)::numeric,
+			CURRENT_TIMESTAMP - (diary_rows.slot || ' minutes')::interval,
+			CURRENT_TIMESTAMP,
+			'${prefix}member-' || $1::int,
+			'${prefix}media-' || diary_rows.media_number
+		FROM diary_rows
+		ON CONFLICT DO NOTHING`,
+		fixture.memberNumber,
+		fixture.diaryRows,
+		mediaCount,
+	)
 }
 
 async function insertRepresentativeMembers(prisma, shape, mediaCount) {
@@ -597,6 +996,7 @@ async function insertRepresentativeMembers(prisma, shape, mediaCount) {
 		await insertRepresentativeMemberBatch(prisma, start, end, shape, mediaCount)
 		console.log(`Loaded representative members ${end}/${shape.memberCount}`)
 	}
+	await insertRepresentativeProfileFixture(prisma, shape, mediaCount)
 }
 
 async function representativeCounts(prisma) {
@@ -620,7 +1020,17 @@ async function representativeCounts(prisma) {
 			(SELECT COUNT(*)::int FROM "TrackingState"
 			 WHERE id LIKE '${prefix}tracking-%' AND "statusWatchlistId" IS NULL) AS "nullListTrackingRows",
 			(SELECT COUNT(*)::int FROM "Entry" WHERE id LIKE '${prefix}entry-%') AS "entryRows",
-			(SELECT COUNT(*)::int FROM "ActivityEvent" WHERE id LIKE '${prefix}activity-%') AS "activityRows"`,
+			(SELECT COUNT(*)::int FROM "ActivityEvent" WHERE id LIKE '${prefix}activity-%') AS "activityRows",
+			(SELECT COUNT(*)::int FROM "Review" WHERE id LIKE '${prefix}review-%') AS "reviewRows",
+			(SELECT COUNT(*)::int FROM "DiaryEntry" WHERE id LIKE '${prefix}diary-%') AS "diaryRows",
+			(SELECT COUNT(*)::int FROM "Entry"
+			 WHERE id LIKE '${prefix}entry-heavy-%') AS "heavyEntryRows",
+			(SELECT COUNT(*)::int FROM "ActivityEvent"
+			 WHERE id LIKE '${prefix}activity-heavy-%') AS "heavyActivityRows",
+			(SELECT COUNT(*)::int FROM "Review"
+			 WHERE id LIKE '${prefix}review-heavy-%') AS "heavyReviewRows",
+			(SELECT COUNT(*)::int FROM "DiaryEntry"
+			 WHERE id LIKE '${prefix}diary-heavy-%') AS "heavyDiaryRows"`,
 	)
 	return Object.fromEntries(
 		Object.entries(rows[0]).map(([key, value]) => [key, Number(value)]),
@@ -787,7 +1197,7 @@ async function queryMetrics(prisma, count, shape, scheduleAnchor) {
 		[
 			'rare-description',
 			'SELECT id FROM "Media" WHERE description ILIKE $1 LIMIT 24',
-			['%rare-nebula-token%'],
+			[`%${syntheticRareDescriptionNeedle}%`],
 		],
 		[
 			'broad-description',
@@ -839,12 +1249,9 @@ async function queryMetrics(prisma, count, shape, scheduleAnchor) {
 		queries.push(await explain(prisma, ...definition))
 	}
 	if (!shape.memberCount) return queries
-	let memberNumber = Math.max(1, Math.floor(shape.memberCount / 2))
-	if (memberNumber % 7 === 0) {
-		memberNumber =
-			memberNumber < shape.memberCount ? memberNumber + 1 : memberNumber - 1
-	}
-	const memberId = `${prefix}member-${Math.max(1, memberNumber)}`
+	const profileFixture = representativeProfileFixture(shape, count)
+	const memberId = profileFixture.memberId
+	const publicWatchlistId = profileFixture.watchlistId
 	const publicTrackerCandidateIds = [
 		...Array.from(
 			{ length: Math.min(200, count) },
@@ -858,19 +1265,75 @@ async function queryMetrics(prisma, count, shape, scheduleAnchor) {
 	queries.push(
 		await explain(
 			prisma,
-			'profile-entries',
-			`SELECT entry.id FROM "Entry" AS entry
-			 JOIN "Watchlist" AS watchlist ON watchlist.id = entry."watchlistId"
-			 WHERE watchlist."ownerId" = $1
-			 ORDER BY entry.position LIMIT 500`,
+			'profile-entry-page',
+			`SELECT
+				id, "watchlistId", "mediaId", "trackingStateId", type,
+				"releaseStart", history, genres, story, character, presentation,
+				sound, performance, enjoyment, averaged, personal, "airYear",
+				"startSeason", "startYear", length, chapters, volumes,
+				"tmdbScore", "malScore"
+			 FROM "Entry"
+			 WHERE "watchlistId" = $1 AND id > $2
+			 ORDER BY id LIMIT 500`,
+			[publicWatchlistId, ''],
+		),
+		await explain(
+			prisma,
+			'profile-activity-owner',
+			`SELECT
+				id, type, status, "statusLabel", "previousStatus",
+				"previousStatusLabel", score, "previousScore", "progressUnit",
+				"progressCurrent", "progressPrevious", "progressTotal",
+				"createdAt", "mediaId"
+			 FROM "ActivityEvent"
+			 WHERE "actorId" = $1
+			 ORDER BY "createdAt" DESC, id DESC LIMIT 100`,
 			[memberId],
 		),
 		await explain(
 			prisma,
-			'profile-activity',
-			`SELECT id FROM "ActivityEvent"
-			 WHERE "actorId" = $1 AND "isPublic" = true
-			 ORDER BY "createdAt" DESC LIMIT 100`,
+			'profile-activity-public',
+			`SELECT
+				activity.id, activity.type, activity.status,
+				activity."statusLabel", activity."previousStatus",
+				activity."previousStatusLabel", activity.score,
+				activity."previousScore", activity."progressUnit",
+				activity."progressCurrent", activity."progressPrevious",
+				activity."progressTotal", activity."createdAt", activity."mediaId"
+			 FROM "ActivityEvent" AS activity
+			 ${profileActivityPublicRelationsSql}
+			 WHERE activity."actorId" = $1
+			   AND ${profileActivityPublicPredicateSql}
+			 ORDER BY activity."createdAt" DESC, activity.id DESC LIMIT 100`,
+			[memberId],
+		),
+		await explain(
+			prisma,
+			'profile-review-page',
+			`SELECT
+				id, body, "containsSpoilers", rating, "createdAt", "updatedAt",
+				"mediaId"
+			 FROM "Review"
+			 WHERE "authorId" = $1 AND "moderationStatus" = 'visible'
+			 ORDER BY "createdAt" DESC, id DESC LIMIT 100`,
+			[memberId],
+		),
+		await explain(
+			prisma,
+			'profile-diary-activity',
+			`SELECT id, "isRepeat", "createdAt", "mediaId"
+			 FROM "DiaryEntry"
+			 WHERE "ownerId" = $1
+			 ORDER BY "createdAt" DESC, id DESC LIMIT 100`,
+			[memberId],
+		),
+		await explain(
+			prisma,
+			'profile-diary-page',
+			`SELECT id, "loggedOn", "isRepeat", rating, "createdAt", "mediaId"
+			 FROM "DiaryEntry"
+			 WHERE "ownerId" = $1
+			 ORDER BY "loggedOn" DESC, "createdAt" DESC, id DESC LIMIT 100`,
 			[memberId],
 		),
 		await explain(
@@ -928,6 +1391,63 @@ function wait(milliseconds) {
 	return new Promise(resolve => setTimeout(resolve, milliseconds))
 }
 
+async function runProfileLoaderSmoke({
+	username,
+	expectedEntries,
+	expectedActivity,
+	unsafeActivityId,
+	reportPath,
+}) {
+	const smokeReportPath = `${reportPath}.profile-loaders.json`
+	if (fs.existsSync(smokeReportPath)) fs.unlinkSync(smokeReportPath)
+	const smokeScript = path.resolve('scripts/smoke-profile-loaders-postgres.ts')
+	const childArgs = [
+		'--import',
+		'tsx',
+		smokeScript,
+		'--username',
+		username,
+		'--expected-entries',
+		String(expectedEntries),
+		'--expected-activity',
+		String(expectedActivity),
+		'--unsafe-activity-id',
+		unsafeActivityId,
+		'--report',
+		smokeReportPath,
+	]
+	await new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, childArgs, {
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				NODE_ENV: 'test',
+				SESSION_SECRET:
+					process.env.SESSION_SECRET ?? 'postgres-profile-smoke-only',
+			},
+			stdio: 'inherit',
+		})
+		child.once('error', reject)
+		child.once('exit', (code, signal) => {
+			if (code === 0) {
+				resolve()
+				return
+			}
+			reject(
+				new Error(
+					`Profile loader smoke failed (${signal ? `signal ${signal}` : `exit ${code}`})`,
+				),
+			)
+		})
+	})
+	if (!fs.existsSync(smokeReportPath)) {
+		throw new Error('Profile loader smoke did not write its report')
+	}
+	const report = readJson(smokeReportPath, 'Profile loader smoke report')
+	fs.unlinkSync(smokeReportPath)
+	return report
+}
+
 async function concurrentMetrics(
 	prisma,
 	count,
@@ -972,8 +1492,10 @@ async function concurrentMetrics(
 				prisma.$queryRawUnsafe(
 					`SELECT activity.id, activity."createdAt"
 					 FROM "ActivityEvent" AS activity
-					 WHERE activity."actorId" = $1 AND activity."isPublic" = true
-					 ORDER BY activity."createdAt" DESC LIMIT 100`,
+					 ${profileActivityPublicRelationsSql}
+					 WHERE activity."actorId" = $1
+					   AND ${profileActivityPublicPredicateSql}
+					 ORDER BY activity."createdAt" DESC, activity.id DESC LIMIT 100`,
 					`${prefix}member-${memberNumber}`,
 				),
 			)
@@ -1098,12 +1620,14 @@ async function main() {
 		trackingPerMember,
 		activityPerMember,
 	})
+	const profileFixture = representativeProfileFixture(shape, count)
 	const commit = args.includes('--commit')
 	const resume = args.includes('--resume')
 	const cleanupAfter = args.includes('--cleanup-after')
 	const requireTrigramIndexes = args.includes('--require-trigram-indexes')
 	const requireCalendarIndexes = args.includes('--require-calendar-indexes')
 	const requireCommunityIndexes = args.includes('--require-community-indexes')
+	const requireProfileIndexes = args.includes('--require-profile-indexes')
 	if (requireCalendarIndexes && !shape.memberCount) {
 		throw new Error(
 			'--require-calendar-indexes requires --member-count so the bounded tracker aggregation is measured',
@@ -1112,6 +1636,24 @@ async function main() {
 	if (requireCommunityIndexes && !shape.memberCount) {
 		throw new Error(
 			'--require-community-indexes requires --member-count so community aggregates are measured',
+		)
+	}
+	if (requireProfileIndexes && !shape.memberCount) {
+		throw new Error(
+			'--require-profile-indexes requires --member-count so profile queries are measured',
+		)
+	}
+	if (
+		requireProfileIndexes &&
+		(profileFixture.entryRows <= 500 ||
+			profileFixture.activityRows + shape.activityPerMember <= 100 ||
+			profileFixture.reviewRows + profileFixture.reviewRowsPerMember <= 100 ||
+			profileFixture.hiddenReviewRows <
+				profileFixtureTargets.hiddenReviewRows ||
+			profileFixture.diaryRows + profileFixture.diaryRowsPerMember <= 100)
+	) {
+		throw new Error(
+			'--require-profile-indexes requires enough media for the representative profile fixture to exceed every bounded page',
 		)
 	}
 	const target = assertSafeLoadDatabaseUrl(process.env.DATABASE_URL)
@@ -1136,6 +1678,11 @@ async function main() {
 	console.log(
 		`Representative members: ${shape.memberCount}; tracking rows: ${shape.trackingRows}; activity rows: ${shape.activityRows}`,
 	)
+	if (profileFixture.memberId) {
+		console.log(
+			`Profile fixture: ${profileFixture.memberId}; +${profileFixture.entryRows} list entries, +${profileFixture.activityRows} valid activity events, +${profileFixture.unsafePublicActivityRows} provenance-negative event, +${profileFixture.reviewRows} visible reviews, +${profileFixture.hiddenReviewRows} hidden review fixtures, +${profileFixture.diaryRows} diary rows`,
+		)
+	}
 	console.log(
 		`Mode: ${commit ? (resume ? 'COMMIT/RESUME' : 'COMMIT') : 'DRY-RUN'}`,
 	)
@@ -1251,8 +1798,23 @@ async function main() {
 			publicListTrackingRows: shape.publicListTrackingRows,
 			privateListTrackingRows: shape.privateListTrackingRows,
 			nullListTrackingRows: shape.nullListTrackingRows,
-			entryRows: shape.entryRows,
-			activityRows: shape.activityRows,
+			entryRows: shape.entryRows + profileFixture.entryRows,
+			activityRows:
+				shape.activityRows +
+				profileFixture.activityRows +
+				profileFixture.unsafePublicActivityRows,
+			reviewRows:
+				shape.memberCount * profileFixture.reviewRowsPerMember +
+				profileFixture.reviewRows +
+				profileFixture.hiddenReviewRows,
+			diaryRows:
+				shape.memberCount * profileFixture.diaryRowsPerMember +
+				profileFixture.diaryRows,
+			heavyEntryRows: profileFixture.entryRows,
+			heavyActivityRows: profileFixture.activityRows,
+			heavyReviewRows:
+				profileFixture.reviewRows + profileFixture.hiddenReviewRows,
+			heavyDiaryRows: profileFixture.diaryRows,
 		})) {
 			if (representative[field] !== expected) {
 				throw new Error(
@@ -1277,6 +1839,8 @@ async function main() {
 			await prisma.$executeRawUnsafe('ANALYZE "TrackingState"')
 			await prisma.$executeRawUnsafe('ANALYZE "Entry"')
 			await prisma.$executeRawUnsafe('ANALYZE "ActivityEvent"')
+			await prisma.$executeRawUnsafe('ANALYZE "Review"')
+			await prisma.$executeRawUnsafe('ANALYZE "DiaryEntry"')
 		}
 		const communityAggregates = shape.memberCount
 			? await communityAggregateMetrics(prisma, count)
@@ -1293,6 +1857,15 @@ async function main() {
 			shape,
 			checkpoint.startedAt,
 		)
+		const profileLoaderSmoke = profileFixture.memberNumber
+			? await runProfileLoaderSmoke({
+					username: `load_catalog_member_${profileFixture.memberNumber}`,
+					expectedEntries: profileFixture.expectedEntries,
+					expectedActivity: 100,
+					unsafeActivityId: `${prefix}activity-unsafe-${profileFixture.memberNumber}`,
+					reportPath,
+				})
+			: null
 		const concurrency = await concurrentMetrics(
 			prisma,
 			count,
@@ -1326,6 +1899,20 @@ async function main() {
 				communityQueryIndexAssertionError = error
 			}
 		}
+		let profileQueryIndexAssertionError
+		let profileQueryRowAssertionError
+		if (shape.memberCount) {
+			try {
+				assertRequiredQueryIndexes(queries, requiredProfileIndexesByQuery)
+			} catch (error) {
+				profileQueryIndexAssertionError = error
+			}
+			try {
+				assertRequiredQueryRows(queries, requiredProfileRowsByQuery)
+			} catch (error) {
+				profileQueryRowAssertionError = error
+			}
+		}
 		const missingQueryIndexes =
 			queryIndexAssertionError?.missingRequirements ?? []
 		const missingIndexes = [
@@ -1343,6 +1930,13 @@ async function main() {
 		const missingCommunityIndexes = [
 			...new Set(
 				missingCommunityQueryIndexes.map(({ requiredIndex }) => requiredIndex),
+			),
+		]
+		const missingProfileQueryIndexes =
+			profileQueryIndexAssertionError?.missingRequirements ?? []
+		const missingProfileIndexes = [
+			...new Set(
+				missingProfileQueryIndexes.map(({ requiredIndex }) => requiredIndex),
 			),
 		]
 		const insertedRows = loaded - checkpoint.initialRows
@@ -1365,8 +1959,10 @@ async function main() {
 				...representative,
 				trackingPerMember: shape.trackingPerMember,
 				activityPerMember: shape.activityPerMember,
+				profileFixture,
 			},
 			communityAggregates,
+			profileLoaderSmoke,
 			recovery: {
 				checkpointSha256,
 				interruptedAt: checkpoint.interruptedAt ?? null,
@@ -1386,6 +1982,9 @@ async function main() {
 			missingCalendarQueryIndexes,
 			missingCommunityIndexes,
 			missingCommunityQueryIndexes,
+			missingProfileIndexes,
+			missingProfileQueryIndexes,
+			profileQueryRowFailures: profileQueryRowAssertionError?.rowFailures ?? [],
 		}
 		writePrivateJson(reportPath, report)
 		console.log(
@@ -1404,9 +2003,16 @@ async function main() {
 				`Community aggregates: ${communityAggregates.candidateCount} candidates in ${communityAggregates.chunks.length} chunks; groups=${communityAggregates.total.groups}; trackers=${communityAggregates.total.trackers}; ratings=${communityAggregates.total.ratings}; weighted mean=${communityAggregates.total.weightedMean ?? 'none'}.`,
 			)
 		}
+		if (profileLoaderSmoke) {
+			console.log(
+				`Real profile loaders: overview=${profileLoaderSmoke.overview.wallMs}ms/${profileLoaderSmoke.overview.bytes}B, stats=${profileLoaderSmoke.stats.wallMs}ms/${profileLoaderSmoke.stats.bytes}B, activity=${profileLoaderSmoke.activity.wallMs}ms/${profileLoaderSmoke.activity.bytes}B.`,
+			)
+		}
 		console.log(`Report written: ${reportPath}`)
 		if (cleanupAfter) {
 			const cleaned = await cleanup(prisma)
+			report.cleanup = cleaned
+			writePrivateJson(reportPath, report)
 			console.log(
 				`Cleanup removed ${cleaned.deletedMedia} media and ${cleaned.deletedMembers} member rows in ${cleaned.wallMs}ms.`,
 			)
@@ -1424,6 +2030,10 @@ async function main() {
 			...(requireCommunityIndexes && communityQueryIndexAssertionError
 				? [communityQueryIndexAssertionError]
 				: []),
+			...(requireProfileIndexes && profileQueryIndexAssertionError
+				? [profileQueryIndexAssertionError]
+				: []),
+			...(profileQueryRowAssertionError ? [profileQueryRowAssertionError] : []),
 		]
 		if (validationErrors.length === 1) {
 			throw validationErrors[0]

--- a/scripts/postgres-load-utils.mjs
+++ b/scripts/postgres-load-utils.mjs
@@ -114,6 +114,53 @@ export function assertRequiredQueryIndexes(queryPlans, requirements) {
 	throw failure
 }
 
+export function assertRequiredQueryRows(queryPlans, requirements) {
+	if (!Array.isArray(queryPlans)) {
+		throw new Error('Query plans must be an array')
+	}
+	if (
+		!requirements ||
+		typeof requirements !== 'object' ||
+		Array.isArray(requirements)
+	) {
+		throw new Error('Query row requirements must be an object')
+	}
+
+	const failures = []
+	for (const [queryName, requiredRows] of Object.entries(requirements)) {
+		if (!queryName || !Number.isSafeInteger(requiredRows) || requiredRows < 1) {
+			throw new Error(
+				'Query row requirements must map names to positive integer minimums',
+			)
+		}
+		const measurements = queryPlans.filter(plan => plan?.name === queryName)
+		const invalidMeasurements = measurements.filter(
+			plan =>
+				!Number.isFinite(plan.actualRows) || plan.actualRows < requiredRows,
+		)
+		if (measurements.length && !invalidMeasurements.length) continue
+		failures.push({
+			queryName,
+			requiredRows,
+			measurementCount: measurements.length,
+			invalidMeasurementCount: invalidMeasurements.length,
+			observedRows: measurements.map(plan => plan.actualRows),
+		})
+	}
+
+	if (!failures.length) return
+	const error = new Error(
+		`Required PostgreSQL queries returned too few rows: ${failures
+			.map(
+				failure =>
+					`${failure.queryName} >= ${failure.requiredRows} (observed ${failure.observedRows.join(', ') || 'unmeasured'})`,
+			)
+			.join('; ')}`,
+	)
+	error.rowFailures = failures
+	throw error
+}
+
 export function bytesLabel(value) {
 	const bytes = Number(value)
 	if (!Number.isFinite(bytes) || bytes < 0) return 'unknown'
@@ -191,6 +238,24 @@ export function representativeLoadShape({
 		feedRows: Math.floor(mediaCount / 100),
 		nextReleaseRows: Math.floor(mediaCount / 20),
 		releaseOccurrenceRows: Math.floor(mediaCount / 25),
+	}
+}
+
+export function representativeProfileEntryShape({
+	mediaCount,
+	trackedEntries,
+}) {
+	boundedInteger('mediaCount', mediaCount, { minimum: 1, maximum: 2_000_000 })
+	boundedInteger('trackedEntries', trackedEntries, { maximum: 100_000 })
+	const expectedEntries = Math.min(mediaCount, 100_000)
+	if (trackedEntries > expectedEntries) {
+		throw new Error(
+			'trackedEntries may not exceed the representative profile target',
+		)
+	}
+	return {
+		expectedEntries,
+		fixtureEntryRows: expectedEntries - trackedEntries,
 	}
 }
 

--- a/scripts/postgres-load-utils.test.mjs
+++ b/scripts/postgres-load-utils.test.mjs
@@ -1,9 +1,11 @@
 import { expect, test } from 'vitest'
 import {
 	assertRequiredQueryIndexes,
+	assertRequiredQueryRows,
 	assertSafeLoadDatabaseUrl,
 	bytesLabel,
 	calendarLoadWindow,
+	representativeProfileEntryShape,
 	representativeLoadShape,
 	summarizeDatabasePressure,
 	summarizeExplain,
@@ -164,6 +166,53 @@ test('rejects an unmeasured required query and a partial duplicate measurement',
 	).toThrow(/1\/2 measurements missing.*alternate-title/s)
 })
 
+test('requires every representative query plan to return meaningful rows', () => {
+	expect(() =>
+		assertRequiredQueryRows(
+			[
+				{ name: 'profile-entry-page', actualRows: 500 },
+				{ name: 'profile-activity-public', actualRows: 100 },
+			],
+			{
+				'profile-entry-page': 500,
+				'profile-activity-public': 100,
+			},
+		),
+	).not.toThrow()
+
+	let failure
+	try {
+		assertRequiredQueryRows(
+			[
+				{ name: 'profile-entry-page', actualRows: 0 },
+				{ name: 'profile-entry-page', actualRows: 500 },
+			],
+			{
+				'profile-entry-page': 500,
+				'profile-activity-public': 100,
+			},
+		)
+	} catch (error) {
+		failure = error
+	}
+
+	expect(failure).toBeInstanceOf(Error)
+	expect(failure.message).toMatch(
+		/profile-entry-page >= 500.*profile-activity-public >= 100/,
+	)
+	expect(failure.rowFailures).toEqual([
+		expect.objectContaining({
+			queryName: 'profile-entry-page',
+			invalidMeasurementCount: 1,
+			observedRows: [0, 500],
+		}),
+		expect.objectContaining({
+			queryName: 'profile-activity-public',
+			measurementCount: 0,
+		}),
+	])
+})
+
 test('derives a bounded representative catalog and member load shape', () => {
 	expect(
 		representativeLoadShape({
@@ -209,6 +258,45 @@ test('derives a bounded representative catalog and member load shape', () => {
 			releaseOccurrenceRows: 0,
 		}),
 	)
+})
+
+test.each([
+	{
+		mediaCount: 2_000,
+		trackedEntries: 100,
+		expected: { expectedEntries: 2_000, fixtureEntryRows: 1_900 },
+	},
+	{
+		mediaCount: 100_000,
+		trackedEntries: 100,
+		expected: { expectedEntries: 100_000, fixtureEntryRows: 99_900 },
+	},
+	{
+		mediaCount: 150_000,
+		trackedEntries: 100,
+		expected: { expectedEntries: 100_000, fixtureEntryRows: 99_900 },
+	},
+	{
+		mediaCount: 80,
+		trackedEntries: 80,
+		expected: { expectedEntries: 80, fixtureEntryRows: 0 },
+	},
+])(
+	'derives a $expected.expectedEntries-entry real profile fixture',
+	({ mediaCount, trackedEntries, expected }) => {
+		expect(
+			representativeProfileEntryShape({ mediaCount, trackedEntries }),
+		).toEqual(expected)
+	},
+)
+
+test('rejects a representative profile with more tracked rows than its target', () => {
+	expect(() =>
+		representativeProfileEntryShape({
+			mediaCount: 80,
+			trackedEntries: 81,
+		}),
+	).toThrow('trackedEntries may not exceed')
 })
 
 test('requires each bounded calendar query to use its assigned index', () => {

--- a/scripts/smoke-profile-loaders-postgres.ts
+++ b/scripts/smoke-profile-loaders-postgres.ts
@@ -1,0 +1,1112 @@
+#!/usr/bin/env -S npx tsx
+import 'dotenv/config'
+import fs from 'node:fs'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { type PrismaClient } from '@prisma/client'
+import { type updateEntryCellCommand } from '#app/routes/lists+/.fetch+/update-cell.$request.ts'
+import { type action as mediaDetailAction } from '#app/routes/media+/$mediaId.tsx'
+import {
+	type getTrackingActivityState,
+	type recordTrackingActivityDiff,
+} from '#app/utils/activity.server.ts'
+import { type applyLibraryImportBatch } from '#app/utils/library-import-commit.server.ts'
+import { type syncWatchlistActivityVisibility } from '#app/utils/lists/visibility.server.ts'
+import { type setMediaTrackingStatus } from '#app/utils/tracking-status.server.ts'
+import { type serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
+import { assertSafeLoadDatabaseUrl } from './postgres-load-utils.mjs'
+
+type ActivityWriter = {
+	getTrackingActivityState: typeof getTrackingActivityState
+	recordTrackingActivityDiff: typeof recordTrackingActivityDiff
+}
+
+type VisibilityWriter = {
+	syncWatchlistActivityVisibility: typeof syncWatchlistActivityVisibility
+}
+
+type TrackingStatusWriter = {
+	setMediaTrackingStatus: typeof setMediaTrackingStatus
+}
+
+type LibraryMutex = {
+	serializeUserLibraryMutation: typeof serializeUserLibraryMutation
+}
+
+type EntryCellWriter = {
+	updateEntryCellCommand: typeof updateEntryCellCommand
+}
+
+const args = process.argv.slice(2)
+const knownArguments = new Set([
+	'--username',
+	'--expected-entries',
+	'--expected-activity',
+	'--unsafe-activity-id',
+	'--report',
+])
+
+function valueFor(flag: string) {
+	const index = args.indexOf(flag)
+	if (index < 0) throw new Error(`${flag} is required`)
+	const value = args[index + 1]
+	if (!value || value.startsWith('--')) {
+		throw new Error(`${flag} requires a value`)
+	}
+	return value
+}
+
+function positiveInteger(flag: string) {
+	const value = Number(valueFor(flag))
+	if (!Number.isSafeInteger(value) || value < 1) {
+		throw new Error(`${flag} must be a positive integer`)
+	}
+	return value
+}
+
+function assertKnownArguments() {
+	for (let index = 0; index < args.length; index += 2) {
+		const flag = args[index]
+		if (!flag || !knownArguments.has(flag)) {
+			throw new Error(`Unknown argument: ${flag ?? '(missing)'}`)
+		}
+		if (!args[index + 1] || args[index + 1]!.startsWith('--')) {
+			throw new Error(`${flag} requires a value`)
+		}
+	}
+}
+
+function writePrivateJson(filename: string, value: unknown) {
+	fs.mkdirSync(path.dirname(filename), { recursive: true })
+	const partial = `${filename}.partial`
+	fs.writeFileSync(partial, `${JSON.stringify(value, null, 2)}\n`, {
+		mode: 0o600,
+	})
+	fs.renameSync(partial, filename)
+	fs.chmodSync(filename, 0o600)
+}
+
+function compactJson(value: unknown, label: string, byteLimit: number) {
+	const encoded = JSON.stringify(value)
+	const bytes = Buffer.byteLength(encoded)
+	if (bytes > byteLimit) {
+		throw new Error(
+			`${label} loader payload exceeded ${byteLimit} bytes: ${bytes}`,
+		)
+	}
+	const forbiddenKeys = new Set([
+		'entries',
+		'history',
+		'rawEntries',
+		'typedEntries',
+		'watchLists',
+		'watchlists',
+	])
+	const stack = [value]
+	while (stack.length) {
+		const current = stack.pop()
+		if (!current || typeof current !== 'object') continue
+		if (Array.isArray(current)) {
+			stack.push(...current)
+			continue
+		}
+		for (const [key, child] of Object.entries(current)) {
+			if (forbiddenKeys.has(key)) {
+				throw new Error(`${label} loader exposed forbidden raw field ${key}`)
+			}
+			stack.push(child)
+		}
+	}
+	return bytes
+}
+
+async function measured<T>(operation: () => Promise<T>) {
+	const started = performance.now()
+	const value = await operation()
+	const wallMs = Number((performance.now() - started).toFixed(3))
+	if (!Number.isFinite(wallMs) || wallMs < 0 || wallMs >= 20_000) {
+		throw new Error(
+			`Profile loader timing was invalid or exceeded 20s: ${wallMs}`,
+		)
+	}
+	return { value, wallMs }
+}
+
+async function importConcurrencyRegression(
+	prisma: PrismaClient,
+	applyLibraryImport: typeof applyLibraryImportBatch,
+) {
+	const suffix = `${Date.now()}-${process.pid}`
+	const ownerId = `profile-smoke-import-owner-${suffix}`
+	const mediaIds = [
+		`profile-smoke-import-media-${suffix}-1`,
+		`profile-smoke-import-media-${suffix}-2`,
+	]
+	const started = performance.now()
+	try {
+		await prisma.user.create({
+			data: {
+				id: ownerId,
+				email: `profile-smoke-import-${suffix}@synthetic.invalid`,
+				username: `profile_smoke_import_${suffix.replaceAll('-', '_')}`,
+			},
+		})
+		const animeType = await prisma.listType.findUniqueOrThrow({
+			where: { name: 'anime' },
+			select: { id: true },
+		})
+		await prisma.media.createMany({
+			data: mediaIds.map((id, index) => ({
+				id,
+				kind: 'anime',
+				title: `Profile import concurrency fixture ${index + 1}`,
+			})),
+		})
+		const batches = await Promise.all(
+			mediaIds.map((mediaId, index) =>
+				prisma.libraryImportBatch.create({
+					data: {
+						ownerId,
+						provider: 'myanimelist',
+						fileName: `concurrency-${index + 1}.xml`,
+						itemCount: 1,
+						matchedCount: 1,
+						ambiguousCount: 0,
+						unmatchedCount: 0,
+						conflictCount: 0,
+						items: {
+							create: {
+								sourceKey: `mal:anime:concurrency:${suffix}:${index + 1}`,
+								mediaId,
+								resolution: 'add',
+								matchState: 'matched',
+								matchMethod: 'exact-title',
+								payload: JSON.stringify({
+									sourceKey: `mal:anime:concurrency:${suffix}:${index + 1}`,
+									provider: 'myanimelist',
+									mediaKind: 'anime',
+									title: `Profile import concurrency fixture ${index + 1}`,
+									externalId: null,
+									status: 'completed',
+									score: 8,
+									progress: { episodes: 12 },
+									repeatCount: 0,
+									startedAt: null,
+									completedAt: null,
+								}),
+							},
+						},
+					},
+					select: { id: true },
+				}),
+			),
+		)
+
+		const results = await Promise.all(
+			batches.map(batch =>
+				prisma.$transaction(
+					tx =>
+						applyLibraryImport(tx, {
+							ownerId,
+							batchId: batch.id,
+						}),
+					{ maxWait: 10_000, timeout: 30_000 },
+				),
+			),
+		)
+		const [destinationLists, states, entries] = await Promise.all([
+			prisma.watchlist.findMany({
+				where: { ownerId, typeId: animeType.id, name: 'completed' },
+				select: { id: true },
+			}),
+			prisma.trackingState.findMany({
+				where: { ownerId, mediaId: { in: mediaIds } },
+				select: { statusWatchlistId: true },
+			}),
+			prisma.entry.count({
+				where: { watchlist: { ownerId }, mediaId: { in: mediaIds } },
+			}),
+		])
+		if (
+			results.some(result => result.appliedCount !== 1) ||
+			destinationLists.length !== 1 ||
+			states.length !== 2 ||
+			states.some(
+				state => state.statusWatchlistId !== destinationLists[0]?.id,
+			) ||
+			entries !== 2
+		) {
+			throw new Error(
+				'Concurrent imports did not reuse exactly one serialized status list',
+			)
+		}
+		return {
+			concurrentImports: results.length,
+			destinationLists: destinationLists.length,
+			trackingStates: states.length,
+			entries,
+			wallMs: Number((performance.now() - started).toFixed(3)),
+		}
+	} finally {
+		await prisma.user.deleteMany({ where: { id: ownerId } })
+		await prisma.media.deleteMany({ where: { id: { in: mediaIds } } })
+	}
+}
+
+async function scoreStatusMutexOrderRegression(
+	prisma: PrismaClient,
+	action: typeof mediaDetailAction,
+	trackingStatus: TrackingStatusWriter,
+	mutex: LibraryMutex,
+) {
+	const suffix = `${Date.now()}-${process.pid}`
+	const ownerId = `profile-smoke-order-owner-${suffix}`
+	const mediaId = `profile-smoke-order-media-${suffix}`
+	let releaseStatus = () => {}
+	const pendingOperations: Promise<unknown>[] = []
+	try {
+		const owner = await prisma.user.create({
+			data: {
+				id: ownerId,
+				email: `profile-smoke-order-${suffix}@synthetic.invalid`,
+				username: `profile_smoke_order_${suffix.replaceAll('-', '_')}`,
+				lastActiveAt: new Date(),
+			},
+		})
+		const liveActionType = await prisma.listType.findUniqueOrThrow({
+			where: { name: 'liveaction' },
+			select: { id: true },
+		})
+		const [source, destination] = await Promise.all([
+			prisma.watchlist.create({
+				data: {
+					ownerId,
+					typeId: liveActionType.id,
+					name: 'watching',
+					header: 'Watching',
+					position: 1,
+					isPublic: true,
+				},
+			}),
+			prisma.watchlist.create({
+				data: {
+					ownerId,
+					typeId: liveActionType.id,
+					name: 'completed',
+					header: 'Completed',
+					position: 2,
+					isPublic: true,
+				},
+			}),
+		])
+		await prisma.media.create({
+			data: { id: mediaId, kind: 'movie', title: 'Mutex order fixture' },
+		})
+		const state = await prisma.trackingState.create({
+			data: {
+				ownerId,
+				mediaId,
+				status: source.name,
+				statusWatchlistId: source.id,
+				score: 6,
+			},
+		})
+		await prisma.entry.create({
+			data: {
+				watchlistId: source.id,
+				mediaId,
+				trackingStateId: state.id,
+				position: 1,
+				title: 'Mutex order fixture',
+				type: 'Movie',
+				personal: 6,
+			},
+		})
+		const session = await prisma.session.create({
+			data: {
+				userId: owner.id,
+				expirationDate: new Date(Date.now() + 60_000),
+			},
+		})
+		const { authSessionStorage } = await import('#app/utils/session.server.ts')
+		const cookieSession = await authSessionStorage.getSession()
+		cookieSession.set('sessionId', session.id)
+		const cookie = (
+			await authSessionStorage.commitSession(cookieSession)
+		).split(';')[0]!
+
+		let signalStatusLocked = () => {}
+		const statusLocked = new Promise<void>(resolve => {
+			signalStatusLocked = resolve
+		})
+		const holdStatus = new Promise<void>(resolve => {
+			releaseStatus = resolve
+		})
+		const statusTransaction = prisma.$transaction(
+			async tx => {
+				await mutex.serializeUserLibraryMutation(tx, ownerId)
+				signalStatusLocked()
+				await holdStatus
+				await trackingStatus.setMediaTrackingStatus(tx, {
+					ownerId,
+					mediaId,
+					watchlistId: destination.id,
+				})
+			},
+			{ maxWait: 10_000, timeout: 30_000 },
+		)
+		pendingOperations.push(statusTransaction)
+		await statusLocked
+
+		const scoreResult = action({
+			request: new Request(
+				`https://profile-smoke.invalid/media/${encodeURIComponent(mediaId)}`,
+				{
+					method: 'POST',
+					headers: {
+						cookie,
+						'content-type': 'application/x-www-form-urlencoded',
+					},
+					body: new URLSearchParams({ intent: 'score', score: '9' }),
+				},
+			),
+			params: { mediaId },
+		} as unknown as Parameters<typeof action>[0]).then(
+			value => ({ value, error: null }),
+			error => ({ value: null, error }),
+		)
+		pendingOperations.push(scoreResult)
+
+		await new Promise(resolve => setTimeout(resolve, 200))
+		const trackingRowWasFree = await prisma
+			.$transaction(async tx => {
+				await tx.$queryRaw`
+					SELECT "id"
+					FROM "TrackingState"
+					WHERE "id" = ${state.id}
+					FOR UPDATE NOWAIT
+				`
+			})
+			.then(
+				() => true,
+				() => false,
+			)
+		if (!trackingRowWasFree) {
+			throw new Error(
+				'Score update locked TrackingState before acquiring the user mutex',
+			)
+		}
+
+		releaseStatus()
+		const [statusUpdate, scoreUpdate] = await Promise.all([
+			statusTransaction,
+			scoreResult,
+		])
+		void statusUpdate
+		if (scoreUpdate.error) throw scoreUpdate.error
+		const saved = await prisma.trackingState.findUniqueOrThrow({
+			where: { id: state.id },
+			select: { statusWatchlistId: true, score: true },
+		})
+		if (
+			saved.statusWatchlistId !== destination.id ||
+			Number(saved.score) !== 9
+		) {
+			throw new Error(
+				'Serialized status and score updates did not both commit correctly',
+			)
+		}
+		return {
+			trackingRowFreeWhileScoreWaited: trackingRowWasFree,
+			statusAndScoreCommitted: true,
+		}
+	} finally {
+		releaseStatus()
+		await Promise.allSettled(pendingOperations)
+		await prisma.user.deleteMany({ where: { id: ownerId } })
+		await prisma.media.deleteMany({ where: { id: mediaId } })
+	}
+}
+
+async function cellHistoryMutexRegression(
+	prisma: PrismaClient,
+	cellWriter: EntryCellWriter,
+	mutex: LibraryMutex,
+) {
+	const suffix = `${Date.now()}-${process.pid}`
+	const ownerId = `profile-smoke-cell-owner-${suffix}`
+	const listTypeId = `profile-smoke-cell-type-${suffix}`
+	const entryId = `profile-smoke-cell-entry-${suffix}`
+	let releaseWriter = () => {}
+	const pendingOperations: Promise<unknown>[] = []
+	try {
+		await prisma.user.create({
+			data: {
+				id: ownerId,
+				email: `profile-smoke-cell-${suffix}@synthetic.invalid`,
+				username: `profile_smoke_cell_${suffix.replaceAll('-', '_')}`,
+			},
+		})
+		await prisma.listType.create({
+			data: {
+				id: listTypeId,
+				name: `profile-smoke-cell-${suffix}`,
+				header: 'Cell history regression',
+				columns: JSON.stringify({ title: 'string' }),
+				mediaType: JSON.stringify(['movie']),
+				completionType: JSON.stringify({ past: 'watched' }),
+			},
+		})
+		const watchlist = await prisma.watchlist.create({
+			data: {
+				ownerId,
+				typeId: listTypeId,
+				name: 'watching',
+				header: 'Watching',
+				position: 1,
+			},
+		})
+		await prisma.entry.create({
+			data: {
+				id: entryId,
+				watchlistId: watchlist.id,
+				position: 1,
+				title: 'Before',
+				history: JSON.stringify({ added: 1, progress: { episode: 1 } }),
+			},
+		})
+
+		let signalWriterLocked = () => {}
+		const writerLocked = new Promise<void>(resolve => {
+			signalWriterLocked = resolve
+		})
+		const holdWriter = new Promise<void>(resolve => {
+			releaseWriter = resolve
+		})
+		const historyWriter = prisma.$transaction(
+			async tx => {
+				await mutex.serializeUserLibraryMutation(tx, ownerId)
+				await tx.entry.update({
+					where: { id: entryId },
+					data: {
+						history: JSON.stringify({
+							added: 1,
+							progress: { episode: 7 },
+							concurrentMarker: 'preserve-me',
+						}),
+					},
+				})
+				signalWriterLocked()
+				await holdWriter
+			},
+			{ maxWait: 10_000, timeout: 30_000 },
+		)
+		pendingOperations.push(historyWriter)
+		await writerLocked
+
+		const cellUpdate = cellWriter.updateEntryCellCommand(ownerId, {
+			entryId,
+			columnId: 'title',
+			value: 'After',
+		})
+		pendingOperations.push(cellUpdate)
+		await new Promise(resolve => setTimeout(resolve, 200))
+		releaseWriter()
+		await Promise.all([historyWriter, cellUpdate])
+
+		const saved = await prisma.entry.findUniqueOrThrow({
+			where: { id: entryId },
+			select: { title: true, history: true },
+		})
+		const history = JSON.parse(saved.history ?? '') as {
+			progress?: { episode?: number }
+			concurrentMarker?: string
+		}
+		if (
+			saved.title !== 'After' ||
+			history.progress?.episode !== 7 ||
+			history.concurrentMarker !== 'preserve-me'
+		) {
+			throw new Error(
+				'Cell update overwrote history committed while it waited for the user mutex',
+			)
+		}
+		return {
+			concurrentHistoryPreserved: true,
+			titleCommitted: true,
+		}
+	} finally {
+		releaseWriter()
+		await Promise.allSettled(pendingOperations)
+		await prisma.user.deleteMany({ where: { id: ownerId } })
+		await prisma.listType.deleteMany({ where: { id: listTypeId } })
+	}
+}
+
+async function activityMultiOperationConcurrencyRegression(
+	prisma: PrismaClient,
+	activity: ActivityWriter,
+) {
+	const suffix = `${Date.now()}-${process.pid}`
+	const ownerId = `profile-smoke-multi-owner-${suffix}`
+	const mediaIds = [
+		`profile-smoke-multi-media-a-${suffix}`,
+		`profile-smoke-multi-media-b-${suffix}`,
+	]
+	let releaseFirst = () => {}
+	try {
+		await prisma.user.create({
+			data: {
+				id: ownerId,
+				email: `profile-smoke-multi-${suffix}@synthetic.invalid`,
+				username: `profile_smoke_multi_${suffix.replaceAll('-', '_')}`,
+			},
+		})
+		const liveActionType = await prisma.listType.findUniqueOrThrow({
+			where: { name: 'liveaction' },
+			select: { id: true },
+		})
+		const watchlists = await Promise.all([
+			prisma.watchlist.create({
+				data: {
+					ownerId,
+					typeId: liveActionType.id,
+					name: 'watching-a',
+					header: 'Watching A',
+					position: 1,
+					isPublic: true,
+				},
+			}),
+			prisma.watchlist.create({
+				data: {
+					ownerId,
+					typeId: liveActionType.id,
+					name: 'watching-b',
+					header: 'Watching B',
+					position: 2,
+					isPublic: true,
+				},
+			}),
+		])
+		await prisma.media.createMany({
+			data: mediaIds.map((id, index) => ({
+				id,
+				kind: 'movie',
+				title: `Multi-operation activity ${index + 1}`,
+			})),
+		})
+		await prisma.trackingState.createMany({
+			data: mediaIds.map((mediaId, index) => ({
+				ownerId,
+				mediaId,
+				status: watchlists[index]!.name,
+				statusWatchlistId: watchlists[index]!.id,
+				score: 8 + index,
+			})),
+		})
+
+		const record = async (
+			tx: Parameters<typeof activity.recordTrackingActivityDiff>[0],
+			mediaId: string,
+		) => {
+			const after = await activity.getTrackingActivityState(
+				tx,
+				ownerId,
+				mediaId,
+			)
+			if (!after) throw new Error('Multi-operation tracking state is missing')
+			await activity.recordTrackingActivityDiff(tx, {
+				actorId: ownerId,
+				mediaId,
+				before: { ...after, score: null },
+				after,
+			})
+		}
+
+		let signalFirstRecorded = () => {}
+		const firstRecorded = new Promise<void>(resolve => {
+			signalFirstRecorded = resolve
+		})
+		const holdFirst = new Promise<void>(resolve => {
+			releaseFirst = resolve
+		})
+		const descending = prisma.$transaction(
+			async tx => {
+				await record(tx, mediaIds[1]!)
+				signalFirstRecorded()
+				await holdFirst
+				await record(tx, mediaIds[0]!)
+			},
+			{ maxWait: 10_000, timeout: 30_000 },
+		)
+		await firstRecorded
+
+		let signalAttempted = () => {}
+		let signalFirstRecordedAscending = () => {}
+		const attempted = new Promise<void>(resolve => {
+			signalAttempted = resolve
+		})
+		const firstRecordedAscending = new Promise<void>(resolve => {
+			signalFirstRecordedAscending = resolve
+		})
+		const ascending = prisma.$transaction(
+			async tx => {
+				signalAttempted()
+				await record(tx, mediaIds[0]!)
+				signalFirstRecordedAscending()
+				await record(tx, mediaIds[1]!)
+			},
+			{ maxWait: 10_000, timeout: 30_000 },
+		)
+		await attempted
+		const bypassedActorLock = await Promise.race([
+			firstRecordedAscending.then(() => true),
+			new Promise<false>(resolve => setTimeout(() => resolve(false), 200)),
+		])
+		releaseFirst()
+		await Promise.all([descending, ascending])
+		if (bypassedActorLock) {
+			throw new Error(
+				'Opposite-order activity transactions bypassed the actor mutex',
+			)
+		}
+		const eventCount = await prisma.activityEvent.count({
+			where: { actorId: ownerId, mediaId: { in: mediaIds }, type: 'score' },
+		})
+		if (eventCount !== 4) {
+			throw new Error(
+				`Opposite-order activity transactions stored ${eventCount} events; expected 4`,
+			)
+		}
+		return { secondTransactionBlocked: true, eventCount }
+	} finally {
+		releaseFirst()
+		await prisma.user.deleteMany({ where: { id: ownerId } })
+		await prisma.media.deleteMany({ where: { id: { in: mediaIds } } })
+	}
+}
+
+async function activityVisibilityConcurrencyRegression(
+	prisma: PrismaClient,
+	activity: ActivityWriter,
+	visibility: VisibilityWriter,
+) {
+	const suffix = `${Date.now()}-${process.pid}`
+	const ownerId = `profile-smoke-activity-owner-${suffix}`
+	const mediaId = `profile-smoke-activity-media-${suffix}`
+	let releaseActivity = () => {}
+	try {
+		await prisma.user.create({
+			data: {
+				id: ownerId,
+				email: `profile-smoke-activity-${suffix}@synthetic.invalid`,
+				username: `profile_smoke_activity_${suffix.replaceAll('-', '_')}`,
+			},
+		})
+		const liveActionType = await prisma.listType.findUniqueOrThrow({
+			where: { name: 'liveaction' },
+			select: { id: true },
+		})
+		const watchlist = await prisma.watchlist.create({
+			data: {
+				ownerId,
+				typeId: liveActionType.id,
+				name: 'watching',
+				header: 'Watching',
+				position: 1,
+				isPublic: true,
+			},
+		})
+		await prisma.media.create({
+			data: { id: mediaId, kind: 'movie', title: 'Visibility race fixture' },
+		})
+		await prisma.trackingState.create({
+			data: {
+				ownerId,
+				mediaId,
+				status: 'watching',
+				statusWatchlistId: watchlist.id,
+				score: 8,
+			},
+		})
+
+		let signalInserted = () => {}
+		const inserted = new Promise<void>(resolve => {
+			signalInserted = resolve
+		})
+		const holdActivity = new Promise<void>(resolve => {
+			releaseActivity = resolve
+		})
+		const activityTransaction = prisma.$transaction(
+			async tx => {
+				const after = await activity.getTrackingActivityState(
+					tx,
+					ownerId,
+					mediaId,
+				)
+				if (!after) throw new Error('Visibility race tracking state is missing')
+				await activity.recordTrackingActivityDiff(tx, {
+					actorId: ownerId,
+					mediaId,
+					before: { ...after, score: null },
+					after,
+				})
+				signalInserted()
+				await holdActivity
+			},
+			{ maxWait: 10_000, timeout: 30_000 },
+		)
+		await inserted
+
+		let signalAttempted = () => {}
+		let signalSynchronized = () => {}
+		const attempted = new Promise<void>(resolve => {
+			signalAttempted = resolve
+		})
+		const synchronized = new Promise<void>(resolve => {
+			signalSynchronized = resolve
+		})
+		const visibilityTransaction = prisma.$transaction(
+			async tx => {
+				signalAttempted()
+				const updated = await tx.watchlist.update({
+					where: { id: watchlist.id },
+					data: { isPublic: false },
+				})
+				await visibility.syncWatchlistActivityVisibility(tx, updated)
+				signalSynchronized()
+			},
+			{ maxWait: 10_000, timeout: 30_000 },
+		)
+		await attempted
+		const settingsPassedWhileActivityWasUncommitted = await Promise.race([
+			synchronized.then(() => true),
+			new Promise<false>(resolve => setTimeout(() => resolve(false), 200)),
+		])
+		releaseActivity()
+		await Promise.all([activityTransaction, visibilityTransaction])
+		if (settingsPassedWhileActivityWasUncommitted) {
+			throw new Error(
+				'Watchlist visibility update bypassed the activity provenance lock',
+			)
+		}
+
+		const event = await prisma.activityEvent.findFirstOrThrow({
+			where: { actorId: ownerId, mediaId, type: 'score' },
+			select: { isPublic: true, publicEligible: true, statusLabel: true },
+		})
+		if (
+			event.isPublic ||
+			!event.publicEligible ||
+			event.statusLabel !== watchlist.header
+		) {
+			throw new Error(
+				'Concurrent privatization did not hide the committed activity event',
+			)
+		}
+		return {
+			settingsBlockedOnActivityLock: true,
+			eventPublicAfterPrivatization: event.isPublic,
+			eventRemainsEligibleForItsOriginalPublicContext: event.publicEligible,
+		}
+	} finally {
+		releaseActivity()
+		await prisma.user.deleteMany({ where: { id: ownerId } })
+		await prisma.media.deleteMany({ where: { id: mediaId } })
+	}
+}
+
+async function activityDeletionConcurrencyRegression(
+	prisma: PrismaClient,
+	activity: ActivityWriter,
+	visibility: VisibilityWriter,
+) {
+	const suffix = `${Date.now()}-${process.pid}`
+	const ownerId = `profile-smoke-delete-owner-${suffix}`
+	const mediaId = `profile-smoke-delete-media-${suffix}`
+	let releaseActivity = () => {}
+	try {
+		await prisma.user.create({
+			data: {
+				id: ownerId,
+				email: `profile-smoke-delete-${suffix}@synthetic.invalid`,
+				username: `profile_smoke_delete_${suffix.replaceAll('-', '_')}`,
+			},
+		})
+		const liveActionType = await prisma.listType.findUniqueOrThrow({
+			where: { name: 'liveaction' },
+			select: { id: true },
+		})
+		const watchlist = await prisma.watchlist.create({
+			data: {
+				ownerId,
+				typeId: liveActionType.id,
+				name: 'watching',
+				header: 'Watching',
+				position: 1,
+				isPublic: true,
+			},
+		})
+		await prisma.media.create({
+			data: { id: mediaId, kind: 'movie', title: 'Deletion race fixture' },
+		})
+		await prisma.trackingState.create({
+			data: {
+				ownerId,
+				mediaId,
+				status: 'watching',
+				statusWatchlistId: watchlist.id,
+				score: 7,
+			},
+		})
+
+		let signalInserted = () => {}
+		const inserted = new Promise<void>(resolve => {
+			signalInserted = resolve
+		})
+		const holdActivity = new Promise<void>(resolve => {
+			releaseActivity = resolve
+		})
+		const activityTransaction = prisma.$transaction(
+			async tx => {
+				const after = await activity.getTrackingActivityState(
+					tx,
+					ownerId,
+					mediaId,
+				)
+				if (!after) throw new Error('Deletion race tracking state is missing')
+				await activity.recordTrackingActivityDiff(tx, {
+					actorId: ownerId,
+					mediaId,
+					before: { ...after, score: null },
+					after,
+				})
+				signalInserted()
+				await holdActivity
+			},
+			{ maxWait: 10_000, timeout: 30_000 },
+		)
+		await inserted
+
+		let signalAttempted = () => {}
+		let signalDeleted = () => {}
+		const attempted = new Promise<void>(resolve => {
+			signalAttempted = resolve
+		})
+		const deleted = new Promise<void>(resolve => {
+			signalDeleted = resolve
+		})
+		const deletionTransaction = prisma.$transaction(
+			async tx => {
+				signalAttempted()
+				await visibility.syncWatchlistActivityVisibility(tx, {
+					...watchlist,
+					isPublic: false,
+				})
+				await tx.watchlist.delete({ where: { id: watchlist.id } })
+				signalDeleted()
+			},
+			{ maxWait: 10_000, timeout: 30_000 },
+		)
+		await attempted
+		const deletedBeforeActivityCommitted = await Promise.race([
+			deleted.then(() => true),
+			new Promise<false>(resolve => setTimeout(() => resolve(false), 200)),
+		])
+		releaseActivity()
+		await Promise.all([activityTransaction, deletionTransaction])
+		if (deletedBeforeActivityCommitted) {
+			throw new Error('Watchlist deletion bypassed the activity actor mutex')
+		}
+
+		const event = await prisma.activityEvent.findFirstOrThrow({
+			where: { actorId: ownerId, mediaId, type: 'score' },
+			select: {
+				isPublic: true,
+				publicEligible: true,
+				statusLabel: true,
+				statusWatchlistId: true,
+			},
+		})
+		if (
+			event.isPublic ||
+			!event.publicEligible ||
+			event.statusWatchlistId !== null ||
+			event.statusLabel !== watchlist.header
+		) {
+			throw new Error(
+				'Concurrent deletion did not quarantine activity before clearing its relation',
+			)
+		}
+		return {
+			deletionBlockedOnActorMutex: true,
+			eventPublicAfterDeletion: event.isPublic,
+			relationClearedAfterQuarantine: event.statusWatchlistId === null,
+		}
+	} finally {
+		releaseActivity()
+		await prisma.user.deleteMany({ where: { id: ownerId } })
+		await prisma.media.deleteMany({ where: { id: mediaId } })
+	}
+}
+
+async function main() {
+	assertKnownArguments()
+	assertSafeLoadDatabaseUrl(process.env.DATABASE_URL)
+	process.env.SESSION_SECRET ??= 'postgres-profile-smoke-only'
+
+	const username = valueFor('--username')
+	const expectedEntries = positiveInteger('--expected-entries')
+	const expectedActivity = positiveInteger('--expected-activity')
+	const unsafeActivityId = valueFor('--unsafe-activity-id')
+	const reportPath = path.resolve(valueFor('--report'))
+	const [
+		{ prisma },
+		profileData,
+		imports,
+		activityWriter,
+		visibility,
+		mediaRoute,
+		cellWriter,
+		trackingStatus,
+		libraryMutex,
+	] = await Promise.all([
+		import('#app/utils/db.server.ts'),
+		import('#app/utils/profile-data.server.ts'),
+		import('#app/utils/library-import-commit.server.ts'),
+		import('#app/utils/activity.server.ts'),
+		import('#app/utils/lists/visibility.server.ts'),
+		import('#app/routes/media+/$mediaId.tsx'),
+		import('#app/routes/lists+/.fetch+/update-cell.$request.ts'),
+		import('#app/utils/tracking-status.server.ts'),
+		import('#app/utils/watchlist-limits.ts'),
+	])
+
+	try {
+		const request = new Request(
+			`https://profile-smoke.invalid/users/${encodeURIComponent(username)}`,
+		)
+		const overview = await measured(() =>
+			profileData.loadProfileOverview(request, username),
+		)
+		const stats = await measured(() =>
+			profileData.loadProfileStats(request, username),
+		)
+		const activity = await measured(() =>
+			profileData.loadProfileActivity(request, username),
+		)
+
+		if (overview.value.diagnostic.processed !== expectedEntries) {
+			throw new Error(
+				`Overview processed ${overview.value.diagnostic.processed} entries; expected ${expectedEntries}`,
+			)
+		}
+		if (stats.value.diagnostic.processed !== expectedEntries) {
+			throw new Error(
+				`Stats processed ${stats.value.diagnostic.processed} entries; expected ${expectedEntries}`,
+			)
+		}
+		if (
+			overview.value.diagnostic.truncated ||
+			stats.value.diagnostic.truncated
+		) {
+			throw new Error(
+				'Profile analytics unexpectedly truncated the representative fixture',
+			)
+		}
+		const countedStatsEntries = Object.values(
+			stats.value.listTypeCounts,
+		).reduce((sum, count) => sum + count, 0)
+		if (countedStatsEntries !== expectedEntries) {
+			throw new Error(
+				`Stats counted ${countedStatsEntries} entries; expected ${expectedEntries}`,
+			)
+		}
+		if (activity.value.activityEvents.length !== expectedActivity) {
+			throw new Error(
+				`Activity returned ${activity.value.activityEvents.length} rows; expected ${expectedActivity}`,
+			)
+		}
+		if (
+			activity.value.activityEvents.some(
+				event => event.id === `tracking:${unsafeActivityId}`,
+			)
+		) {
+			throw new Error(
+				'Public activity exposed an event without immutable list provenance',
+			)
+		}
+		if (!activity.value.activityLimited) {
+			throw new Error('Activity did not report its bounded source truncation')
+		}
+
+		const report = {
+			version: 1,
+			measuredAt: new Date().toISOString(),
+			expectedEntries,
+			expectedActivity,
+			overview: {
+				wallMs: overview.wallMs,
+				bytes: compactJson(overview.value, 'Overview', 128 * 1024),
+				processed: overview.value.diagnostic.processed,
+				truncated: overview.value.diagnostic.truncated,
+			},
+			stats: {
+				wallMs: stats.wallMs,
+				bytes: compactJson(stats.value, 'Stats', 256 * 1024),
+				processed: stats.value.diagnostic.processed,
+				truncated: stats.value.diagnostic.truncated,
+				countedEntries: countedStatsEntries,
+			},
+			activity: {
+				wallMs: activity.wallMs,
+				bytes: compactJson(activity.value, 'Activity', 64 * 1024),
+				returned: activity.value.activityEvents.length,
+				limited: activity.value.activityLimited,
+				unsafeProvenanceEventVisible: false,
+			},
+			importConcurrency: await importConcurrencyRegression(
+				prisma,
+				imports.applyLibraryImportBatch,
+			),
+			scoreStatusMutexOrder: await scoreStatusMutexOrderRegression(
+				prisma,
+				mediaRoute.action,
+				trackingStatus,
+				libraryMutex,
+			),
+			cellHistoryMutex: await cellHistoryMutexRegression(
+				prisma,
+				cellWriter,
+				libraryMutex,
+			),
+			activityMultiOperationConcurrency:
+				await activityMultiOperationConcurrencyRegression(
+					prisma,
+					activityWriter,
+				),
+			activityVisibilityConcurrency:
+				await activityVisibilityConcurrencyRegression(
+					prisma,
+					activityWriter,
+					visibility,
+				),
+			activityDeletionConcurrency: await activityDeletionConcurrencyRegression(
+				prisma,
+				activityWriter,
+				visibility,
+			),
+		}
+		writePrivateJson(reportPath, report)
+		console.log(
+			`Profile loader smoke passed: ${expectedEntries} entries, ${expectedActivity} activity rows, ${report.activity.bytes}B activity payload.`,
+		)
+	} finally {
+		await prisma.$disconnect()
+	}
+}
+
+main().catch(error => {
+	console.error(error)
+	process.exitCode = 1
+})

--- a/scripts/smoke-profile-loaders-postgres.ts
+++ b/scripts/smoke-profile-loaders-postgres.ts
@@ -11,7 +11,7 @@ import {
 	type recordTrackingActivityDiff,
 } from '#app/utils/activity.server.ts'
 import { type applyLibraryImportBatch } from '#app/utils/library-import-commit.server.ts'
-import { type syncWatchlistActivityVisibility } from '#app/utils/lists/visibility.server.ts'
+import { type syncWatchlistActivityVisibility } from '#app/utils/lists/activity-visibility.server.ts'
 import { type setMediaTrackingStatus } from '#app/utils/tracking-status.server.ts'
 import { type serializeUserLibraryMutation } from '#app/utils/watchlist-limits.ts'
 import { assertSafeLoadDatabaseUrl } from './postgres-load-utils.mjs'
@@ -975,7 +975,7 @@ async function main() {
 		import('#app/utils/profile-data.server.ts'),
 		import('#app/utils/library-import-commit.server.ts'),
 		import('#app/utils/activity.server.ts'),
-		import('#app/utils/lists/visibility.server.ts'),
+		import('#app/utils/lists/activity-visibility.server.ts'),
 		import('#app/routes/media+/$mediaId.tsx'),
 		import('#app/routes/lists+/.fetch+/update-cell.$request.ts'),
 		import('#app/utils/tracking-status.server.ts'),

--- a/tests/e2e/home-feed.test.ts
+++ b/tests/e2e/home-feed.test.ts
@@ -128,7 +128,7 @@ test('home shows a unified activity feed from followed members', async ({
 				actorId: followed.id,
 				mediaId: media.id,
 				status: 'completed',
-				statusLabel: 'Completed',
+				publicEligible: true,
 			},
 		}),
 		prisma.review.create({

--- a/tests/e2e/profile-performance.test.ts
+++ b/tests/e2e/profile-performance.test.ts
@@ -23,10 +23,14 @@ test('profile tabs load their own data without reloading the heavy shell', async
 		position: index + 1,
 		title: `Profile browser history ${index + 1}`,
 		type: 'TV',
+		startSeason: `Winter ${2020 + (index % 6)}`,
+		genres: 'Action, Drama',
 		length: `${(index % 24) + 1} / 24 eps`,
 		personal: (index % 10) + 1,
+		malScore: (index % 10) + 1,
 		history: JSON.stringify({
 			added: Date.UTC(2025, 0, 1) + index,
+			finished: Date.UTC(2024 + (index % 2), 0, 1) + index,
 			lastUpdated: Date.UTC(2025, 0, 1) + index,
 		}),
 		description: 'Large provider description. '.repeat(100),
@@ -58,6 +62,65 @@ test('profile tabs load their own data without reloading the heavy shell', async
 	await expect(page.getByRole('heading', { name: 'Collections' })).toBeVisible()
 	await page.getByRole('link', { name: 'Stats', exact: true }).click()
 	await expect(page.getByRole('heading', { name: 'Stats' })).toBeVisible()
+	const mediaFilter = page.getByRole('group', {
+		name: 'Filter statistics by media type',
+	})
+	await expect(
+		mediaFilter.getByRole('button', { name: 'Anime', exact: true }),
+	).toHaveAttribute('aria-pressed', 'true')
+	const chartView = page.getByLabel('Chart view', { exact: true })
+	for (const chart of [
+		{
+			value: 'watchlist',
+			heading: 'Watchlist Overview',
+			label: 'Watchlist status distribution',
+		},
+		{
+			value: 'listTypeDistribution',
+			heading: 'List Type Distribution',
+			label: 'List type distribution',
+		},
+		{
+			value: 'score',
+			heading: 'Score Distribution',
+			label: 'Score distribution',
+		},
+		{
+			value: 'objectiveScores',
+			heading: 'Personal vs Public Scores',
+			label: 'Personal score distribution by MAL score',
+		},
+		{
+			value: 'release',
+			heading: 'Release Date Distribution',
+			label: 'Release year distribution',
+		},
+		{
+			value: 'watched',
+			heading: 'Watch Date Distribution',
+			label: 'Completion year distribution',
+		},
+		{
+			value: 'genreChords',
+			heading: 'Genre Overlap',
+			label: 'Genre overlap',
+		},
+		{
+			value: 'type',
+			heading: 'Media Type Distribution',
+			label: 'Media type distribution',
+		},
+	]) {
+		await chartView.selectOption(chart.value)
+		await expect(
+			page.getByRole('heading', { name: chart.heading, exact: true }),
+		).toBeVisible()
+		await expect(
+			page
+				.locator('.user-landing-chart-stage')
+				.getByRole('img', { name: chart.label, exact: true }),
+		).toBeVisible()
+	}
 	await page.getByRole('link', { name: 'Social', exact: true }).click()
 	await expect(page.getByRole('heading', { name: 'Guestbook' })).toBeVisible()
 


### PR DESCRIPTION
## Summary
- bound profile overview, statistics, completion history, and activity loaders with compact DTOs and hard work ceilings
- close activity visibility provenance gaps and serialize concurrent library mutations without losing user state
- add responsive, accessible profile analytics plus SQLite/PostgreSQL migrations and a 100,000-entry PostgreSQL load harness
- isolate activity-visibility data writes from request/session initialization so database and background jobs remain credential-free

## Validation
- `npm run static`
- 169 test files / 941 tests with coverage
- production build and bundle budgets
- 98 Chromium end-to-end scenarios
- clean SQLite migration replay (49 migrations)
- PostgreSQL migration/drift/smoke gates
- credential-free PostgreSQL 16 release gate with `SESSION_SECRET` absent
- 100,000-entry PostgreSQL loader and query-plan run with required indexes used
- independent final code and CI-correction reviews: no blocker or important findings