### PR TITLE
Cache hot public surface fragments

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -196,6 +196,7 @@ export async function loader({ request, url }: LoaderFunctionArgs) {
 		},
 		{
 			headers: combineHeaders(
+				{ 'Cache-Control': 'private, no-store' },
 				{ 'Server-Timing': timings.toString() },
 				toastHeaders,
 			),
@@ -205,6 +206,7 @@ export async function loader({ request, url }: LoaderFunctionArgs) {
 
 export const headers: HeadersFunction = ({ actionHeaders, loaderHeaders }) => {
 	return combineHeaders(
+		{ 'Cache-Control': 'private, no-store' },
 		{ 'Server-Timing': loaderHeaders.get('Server-Timing') ?? '' },
 		loaderHeaders.has('Set-Cookie')
 			? { 'Set-Cookie': loaderHeaders.get('Set-Cookie') ?? '' }

--- a/app/routes/admin+/operations.route.test.ts
+++ b/app/routes/admin+/operations.route.test.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { expect, test } from 'vitest'
 import { getSessionExpirationDate } from '#app/utils/auth.server.ts'
+import { createSafeCacheReporter } from '#app/utils/cache.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { BASE_URL, getSessionCookieHeader } from '#tests/utils.ts'
 import { action, loader } from './operations.tsx'
@@ -99,6 +100,16 @@ test('keeps runtime telemetry private to unauthorized members', async () => {
 })
 
 test('returns private runtime and database readiness to site operators', async () => {
+	const privateEventPayload = 'member-private-cache-input'
+	const report = createSafeCacheReporter('anonymous-home-summary')({} as never)
+	report({
+		name: 'getCachedValueEmpty',
+		key: privateEventPayload,
+	} as never)
+	report({
+		name: 'getFreshValueStart',
+		key: privateEventPayload,
+	} as never)
 	const operator = await createUser('site-operator')
 	const response = await loader(await requestFor(operator.id))
 	expect(response.init?.headers).toEqual(
@@ -112,7 +123,16 @@ test('returns private runtime and database readiness to site operators', async (
 				requests: expect.any(Object),
 				process: expect.objectContaining({ node: expect.any(String) }),
 			}),
+			cacheOperations: {
+				'anonymous-home-summary': expect.objectContaining({
+					miss: 1,
+					refresh: 1,
+				}),
+			},
 		}),
+	)
+	expect(JSON.stringify(response.data.cacheOperations)).not.toContain(
+		privateEventPayload,
 	)
 })
 

--- a/app/routes/admin+/operations.tsx
+++ b/app/routes/admin+/operations.tsx
@@ -18,6 +18,7 @@ import {
 	getAiGatewayOperationsTelemetry,
 	isAiCapabilityConfigured,
 } from '#app/utils/ai-gateway.server.ts'
+import { getCacheOperationsSnapshot } from '#app/utils/cache.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { getRuntimeOperationsSnapshot } from '#app/utils/operations-observability.server.ts'
 import { requireUserWithPermission } from '#app/utils/permissions.server.ts'
@@ -131,6 +132,7 @@ export async function loader({ request, url }: LoaderFunctionArgs) {
 			},
 			incidents,
 			ai,
+			cacheOperations: getCacheOperationsSnapshot(),
 		},
 		{ headers: { 'Cache-Control': 'private, no-store' } },
 	)
@@ -446,6 +448,64 @@ export default function OperationsAdminRoute() {
 						</tbody>
 					</table>
 				</div>
+			</VeudPanel>
+
+			<VeudPanel aria-labelledby="cache-operations-heading">
+				<div>
+					<h2
+						id="cache-operations-heading"
+						className="text-xl font-black text-veud-yellow"
+					>
+						Cache operation counters
+					</h2>
+					<p className="mt-1 text-sm text-veud-copy">
+						Aggregate process totals by static cache family.
+					</p>
+				</div>
+				{Object.entries(snapshot.cacheOperations).length ? (
+					<div className="mt-4 overflow-x-auto">
+						<table className="w-full min-w-[660px] text-left text-sm">
+							<thead className="text-xs uppercase tracking-wide text-veud-mint">
+								<tr>
+									{[
+										'Cache family',
+										'Hit',
+										'Miss',
+										'Refresh',
+										'Refresh error',
+										'Write error',
+										'Invalid',
+									].map(label => (
+										<th key={label} className="px-3 py-2">
+											{label}
+										</th>
+									))}
+								</tr>
+							</thead>
+							<tbody className="divide-y divide-veud-border/60">
+								{Object.entries(snapshot.cacheOperations).map(
+									([namespace, counts]) => (
+										<tr key={namespace}>
+											<td className="px-3 py-2 font-black text-veud-cream">
+												{namespace.replaceAll('-', ' ')}
+											</td>
+											<td className="px-3 py-2">{counts.hit}</td>
+											<td className="px-3 py-2">{counts.miss}</td>
+											<td className="px-3 py-2">{counts.refresh}</td>
+											<td className="px-3 py-2">{counts['refresh-error']}</td>
+											<td className="px-3 py-2">{counts['write-error']}</td>
+											<td className="px-3 py-2">{counts.invalid}</td>
+										</tr>
+									),
+								)}
+							</tbody>
+						</table>
+					</div>
+				) : (
+					<p className="mt-4 rounded-xl border border-dashed border-veud-border p-5 text-sm text-veud-mint">
+						No cache activity has been recorded since this server started.
+					</p>
+				)}
 			</VeudPanel>
 
 			<VeudPanel aria-labelledby="recent-errors-heading">

--- a/app/routes/discover.route.test.ts
+++ b/app/routes/discover.route.test.ts
@@ -12,7 +12,10 @@ vi.mock('#app/utils/discovery.server.ts', async importOriginal => {
 	const actual = (await importOriginal()) as typeof discoveryServer
 	return {
 		...actual,
+		getDiscoveryFacets: vi.fn(actual.getDiscoveryFacets),
+		getDiscoveryGenres: vi.fn(actual.getDiscoveryGenres),
 		getDiscoveryResults: vi.fn(actual.getDiscoveryResults),
+		getDiscoveryStatuses: vi.fn(actual.getDiscoveryStatuses),
 	}
 })
 
@@ -49,7 +52,12 @@ async function cookieFor(userId: string) {
 
 test('anonymous discovery loads filters and falls back from personalized ranking', async () => {
 	await prisma.media.create({
-		data: { kind: 'movie', title: 'Anonymous Discovery', genres: 'Drama' },
+		data: {
+			kind: 'movie',
+			title: 'Anonymous Discovery',
+			genres: 'Drama',
+			releaseStatus: 'Released',
+		},
 	})
 
 	const result = await loader({
@@ -75,6 +83,11 @@ test('anonymous discovery loads filters and falls back from personalized ranking
 		expect.objectContaining({ title: 'Anonymous Discovery' }),
 	])
 	expect(result.data.genres).toEqual(['Drama'])
+	expect(result.data.statuses).toEqual(['Released'])
+	expect(discoveryServer.getDiscoveryFacets).toHaveBeenCalledOnce()
+	expect(discoveryServer.getDiscoveryGenres).not.toHaveBeenCalled()
+	expect(discoveryServer.getDiscoveryStatuses).not.toHaveBeenCalled()
+	expect(result.data).not.toHaveProperty('truncated')
 })
 
 test('signed-in discovery returns unseen recommendation graph results', async () => {

--- a/app/routes/discover.tsx
+++ b/app/routes/discover.tsx
@@ -31,11 +31,10 @@ import { isAiCapabilityConfigured } from '#app/utils/ai-gateway.server.ts'
 import { getUserId, requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import {
-	getDiscoveryGenres,
+	getDiscoveryFacets,
 	getDiscoveryResults,
 	getDiscoveryResultsForMediaIds,
 	getDiscoveryResultsForPlan,
-	getDiscoveryStatuses,
 	parseDiscoveryQuery,
 	type DiscoveryQuery,
 	type DiscoveryResults,
@@ -350,8 +349,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 			? getRecommendationGraph(viewerId)
 			: Promise.resolve(null)
 	const memoryQueryTooShort = filters.mode === 'memory' && filters.q.length < 3
-	const genresPromise = getDiscoveryGenres()
-	const statusesPromise = getDiscoveryStatuses()
+	const facetsPromise = getDiscoveryFacets()
 	const watchlistsPromise = viewerId
 		? prisma.watchlist.findMany({
 				where: { ownerId: viewerId },
@@ -388,8 +386,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 				: null
 	const [
 		discovery,
-		genres,
-		statuses,
+		facets,
 		watchlists,
 		recommendationGraph,
 		previousNaturalResults,
@@ -414,8 +411,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 							preferredGenres: [],
 						} satisfies DiscoveryResults)
 					: getDiscoveryResults(filters, viewerId),
-		genresPromise,
-		statusesPromise,
+		facetsPromise,
 		watchlistsPromise,
 		recommendationGraphPromise,
 		previousNaturalPlan
@@ -449,8 +445,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 			viewerId && isAiCapabilityConfigured('natural-language-discovery'),
 		),
 		imageSearchAvailable: isAiCapabilityConfigured('image-tip-of-tongue'),
-		genres,
-		statuses,
+		genres: facets.genres,
+		statuses: facets.statuses,
 		watchlists,
 		recommendationGraph,
 		isSignedIn: Boolean(viewerId),

--- a/app/routes/settings+/profile.connections.tsx
+++ b/app/routes/settings+/profile.connections.tsx
@@ -91,9 +91,20 @@ export async function loader({ request, url }: LoaderFunctionArgs) {
 	)
 }
 
-export const headers: HeadersFunction = ({ actionHeaders, loaderHeaders }) => {
+export const headers: HeadersFunction = ({
+	actionHeaders,
+	loaderHeaders,
+	parentHeaders,
+}) => {
+	const serverTiming = [
+		parentHeaders.get('Server-Timing'),
+		loaderHeaders.get('Server-Timing'),
+	]
+		.filter(Boolean)
+		.join(',')
 	return combineHeaders(
-		{ 'Server-Timing': loaderHeaders.get('Server-Timing') ?? '' },
+		{ 'Cache-Control': 'private, no-store' },
+		serverTiming ? { 'Server-Timing': serverTiming } : null,
 		actionHeaders.has('Set-Cookie')
 			? { 'Set-Cookie': actionHeaders.get('Set-Cookie') ?? '' }
 			: null,
@@ -202,7 +213,7 @@ function Connection({
 									status={
 										deleteFetcher.state !== 'idle'
 											? 'pending'
-											: deleteFetcher.data?.status ?? 'idle'
+											: (deleteFetcher.data?.status ?? 'idle')
 									}
 								>
 									<Icon name="cross-1" />

--- a/app/single-fetch-headers.test.ts
+++ b/app/single-fetch-headers.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, test } from 'vitest'
-import { headers as rootHeaders } from './root.tsx'
+import { headers as rootHeaders, loader as rootLoader } from './root.tsx'
 import { headers as connectionHeaders } from './routes/settings+/profile.connections.tsx'
+import { profileHeaders } from './utils/profile-headers.ts'
 
 const parentHeaders = new Headers()
 
 describe('Single Fetch headers', () => {
+	test('the root loader marks its account-aware data private and non-cacheable', async () => {
+		const url = new URL('https://veud.example/')
+		const response = await rootLoader({
+			request: new Request(url),
+			url,
+			params: {},
+		} as unknown as Parameters<typeof rootLoader>[0])
+
+		expect(new Headers(response.init?.headers).get('Cache-Control')).toBe(
+			'private, no-store',
+		)
+	})
+
 	test('the root preserves loader and action cookies without overriding the stream content type', () => {
 		const headers = new Headers(
 			rootHeaders({
@@ -23,12 +37,40 @@ describe('Single Fetch headers', () => {
 		)
 
 		expect(headers.get('Content-Type')).toBeNull()
+		expect(headers.get('Cache-Control')).toBe('private, no-store')
 		expect(headers.get('Server-Timing')).toBe('root_loader;dur=1')
 		expect(headers.get('Set-Cookie')).toContain('toast=; Path=/')
 		expect(headers.get('Set-Cookie')).toContain('theme=dark; Path=/')
 	})
 
+	test('the root overrides cacheable child metadata at the document boundary', () => {
+		const headers = new Headers(
+			rootHeaders({
+				actionHeaders: new Headers({
+					'Cache-Control': 'public, max-age=3600',
+				}),
+				errorHeaders: undefined,
+				loaderHeaders: new Headers({
+					'Cache-Control': 'public, s-maxage=3600',
+				}),
+				parentHeaders,
+			}),
+		)
+
+		expect(headers.get('Cache-Control')).toBe('private, no-store')
+	})
+
 	test('the connections route preserves its action toast cookie', () => {
+		const rootDocumentHeaders = new Headers(
+			rootHeaders({
+				actionHeaders: new Headers(),
+				errorHeaders: undefined,
+				loaderHeaders: new Headers({
+					'Server-Timing': 'root_loader;dur=1',
+				}),
+				parentHeaders,
+			}),
+		)
 		const headers = new Headers(
 			connectionHeaders({
 				actionHeaders: new Headers({
@@ -40,12 +82,53 @@ describe('Single Fetch headers', () => {
 					'Content-Type': 'application/json',
 					'Server-Timing': 'connections;dur=1',
 				}),
-				parentHeaders,
+				parentHeaders: rootDocumentHeaders,
 			}),
 		)
 
 		expect(headers.get('Content-Type')).toBeNull()
-		expect(headers.get('Server-Timing')).toBe('connections;dur=1')
+		expect(headers.get('Cache-Control')).toBe('private, no-store')
+		expect(headers.get('Server-Timing')).toBe(
+			'root_loader;dur=1,connections;dur=1',
+		)
 		expect(headers.get('Set-Cookie')).toBe('toast=deleted; Path=/')
+	})
+
+	test('nested profile header composition preserves the root no-store policy', () => {
+		const rootDocumentHeaders = new Headers(
+			rootHeaders({
+				actionHeaders: new Headers(),
+				errorHeaders: undefined,
+				loaderHeaders: new Headers({
+					'Server-Timing': 'root_loader;dur=1',
+				}),
+				parentHeaders,
+			}),
+		)
+		const profileShellHeaders = new Headers(
+			profileHeaders({
+				actionHeaders: new Headers(),
+				errorHeaders: undefined,
+				loaderHeaders: new Headers({
+					'Server-Timing': 'profile_shell;dur=2',
+				}),
+				parentHeaders: rootDocumentHeaders,
+			}),
+		)
+		const profileTabHeaders = new Headers(
+			profileHeaders({
+				actionHeaders: new Headers(),
+				errorHeaders: undefined,
+				loaderHeaders: new Headers({
+					'Server-Timing': 'profile_tab;dur=3',
+				}),
+				parentHeaders: profileShellHeaders,
+			}),
+		)
+
+		expect(profileTabHeaders.get('Cache-Control')).toBe('private, no-store')
+		expect(profileTabHeaders.get('Server-Timing')).toBe(
+			'root_loader;dur=1,profile_shell;dur=2,profile_tab;dur=3',
+		)
 	})
 })

--- a/app/utils/anonymous-home.server.test.ts
+++ b/app/utils/anonymous-home.server.test.ts
@@ -1,0 +1,203 @@
+import { faker } from '@faker-js/faker'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+	ANONYMOUS_HOME_SUMMARY_TTL_MS,
+	getAnonymousHomeProof,
+	getAnonymousHomeSummary,
+} from './anonymous-home.server.ts'
+import { prisma } from './db.server.ts'
+import { createPublicSurfaceCacheRuntimeForTest } from './public-surface-cache.server.ts'
+
+afterEach(() => {
+	vi.useRealTimers()
+	vi.restoreAllMocks()
+})
+
+async function createUser(
+	prefix: string,
+	{ accountStatus = 'active' }: { accountStatus?: string } = {},
+) {
+	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
+	return prisma.user.create({
+		data: {
+			email: `${prefix}_${suffix}@example.com`,
+			username: `${prefix}_${suffix}`,
+			accountStatus,
+		},
+	})
+}
+
+describe('anonymous home summary cache', () => {
+	test('uses a bounded public aggregate cache while activity remains fresh', async () => {
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+		const mediaCount = vi.spyOn(prisma.media, 'count')
+		const mediaGroupBy = vi.spyOn(prisma.media, 'groupBy')
+		const reviewCount = vi.spyOn(prisma.review, 'count')
+		const collectionCount = vi.spyOn(prisma.mediaCollection, 'count')
+		const activityFindMany = vi.spyOn(prisma.activityEvent, 'findMany')
+		const reviewFindMany = vi.spyOn(prisma.review, 'findMany')
+		const collectionFindMany = vi.spyOn(prisma.mediaCollection, 'findMany')
+
+		const first = await getAnonymousHomeProof({ cacheRuntime: runtime })
+		const author = await createUser('anonymous_cache')
+		const media = await prisma.media.create({
+			data: { kind: 'movie', title: 'Fresh anonymous activity' },
+		})
+		const review = await prisma.review.create({
+			data: {
+				authorId: author.id,
+				mediaId: media.id,
+				body: 'This review should appear without refreshing the summary.',
+			},
+		})
+		const second = await getAnonymousHomeProof({ cacheRuntime: runtime })
+
+		expect(first).toMatchObject({
+			catalogTotal: 0,
+			reviewTotal: 0,
+			publicCollectionTotal: 0,
+			kinds: [],
+			activity: [],
+		})
+		expect(second).toMatchObject({
+			catalogTotal: 0,
+			reviewTotal: 0,
+			publicCollectionTotal: 0,
+			kinds: [],
+		})
+		expect(second.activity.map(item => item.id)).toContain(
+			`review:${review.id}`,
+		)
+
+		expect(mediaCount).toHaveBeenCalledOnce()
+		expect(mediaGroupBy).toHaveBeenCalledOnce()
+		expect(reviewCount).toHaveBeenCalledOnce()
+		expect(collectionCount).toHaveBeenCalledOnce()
+		expect(activityFindMany).toHaveBeenCalledTimes(2)
+		expect(reviewFindMany).toHaveBeenCalledTimes(2)
+		expect(collectionFindMany).toHaveBeenCalledTimes(2)
+	})
+
+	test('expires aggregate values at the TTL and returns detached frozen data', async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2026-07-29T12:00:00.000Z'))
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+
+		const initial = await getAnonymousHomeSummary({ runtime })
+		await prisma.media.create({
+			data: { kind: 'anime', title: 'New catalog title' },
+		})
+		const warm = await getAnonymousHomeSummary({ runtime })
+
+		expect(initial).toEqual({
+			catalogTotal: 0,
+			reviewTotal: 0,
+			publicCollectionTotal: 0,
+			kinds: [],
+		})
+		expect(warm).toEqual(initial)
+		expect(warm).not.toBe(initial)
+		expect(Object.isFrozen(warm)).toBe(true)
+		expect(Object.isFrozen(warm.kinds)).toBe(true)
+
+		vi.advanceTimersByTime(ANONYMOUS_HOME_SUMMARY_TTL_MS + 1)
+		const refreshed = await getAnonymousHomeSummary({ runtime })
+		expect(refreshed).toMatchObject({
+			catalogTotal: 1,
+			kinds: [{ kind: 'anime', count: 1 }],
+		})
+	})
+
+	test('keeps identities out of the cached summary and applies moderation immediately', async () => {
+		const [active, suspended] = await Promise.all([
+			createUser('anonymous_visible'),
+			createUser('anonymous_suspended', { accountStatus: 'suspended' }),
+		])
+		const [visibleMedia, unclassifiedMedia] = await Promise.all([
+			prisma.media.create({
+				data: { kind: 'manga', title: 'Visible proof title' },
+			}),
+			prisma.media.create({
+				data: { kind: 'podcast', title: 'Unclassified catalog title' },
+			}),
+		])
+		const [visibleReview] = await Promise.all([
+			prisma.review.create({
+				data: {
+					authorId: active.id,
+					mediaId: visibleMedia.id,
+					body: 'A visible review.',
+				},
+			}),
+			prisma.review.create({
+				data: {
+					authorId: suspended.id,
+					mediaId: unclassifiedMedia.id,
+					body: 'A review from a suspended member.',
+				},
+			}),
+			prisma.mediaCollection.create({
+				data: {
+					ownerId: active.id,
+					title: 'Visible collection',
+				},
+			}),
+			prisma.mediaCollection.create({
+				data: {
+					ownerId: active.id,
+					title: 'Private collection',
+					isPublic: false,
+				},
+			}),
+			prisma.mediaCollection.create({
+				data: {
+					ownerId: suspended.id,
+					title: 'Suspended collection',
+				},
+			}),
+		])
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+
+		const first = await getAnonymousHomeProof({ cacheRuntime: runtime })
+		const serializedSummary = JSON.stringify({
+			catalogTotal: first.catalogTotal,
+			reviewTotal: first.reviewTotal,
+			publicCollectionTotal: first.publicCollectionTotal,
+			kinds: first.kinds,
+		})
+		expect(first).toMatchObject({
+			catalogTotal: 2,
+			reviewTotal: 1,
+			publicCollectionTotal: 1,
+			kinds: [{ kind: 'manga', count: 1 }],
+		})
+		expect(first.activity.map(item => item.id)).toContain(
+			`review:${visibleReview.id}`,
+		)
+		expect(serializedSummary).not.toContain(active.username)
+		expect(serializedSummary).not.toContain(visibleMedia.title)
+
+		await prisma.user.update({
+			where: { id: active.id },
+			data: { accountStatus: 'suspended' },
+		})
+		const second = await getAnonymousHomeProof({ cacheRuntime: runtime })
+
+		// Aggregate counts intentionally use the short TTL as their consistency
+		// boundary, while identity-bearing activity is always re-evaluated.
+		expect(second.reviewTotal).toBe(1)
+		expect(second.publicCollectionTotal).toBe(1)
+		expect(second.activity.map(item => item.id)).not.toContain(
+			`review:${visibleReview.id}`,
+		)
+	})
+
+	test('bypasses public caches by default in the unit-test runtime', async () => {
+		const mediaCount = vi.spyOn(prisma.media, 'count')
+
+		await getAnonymousHomeSummary()
+		await getAnonymousHomeSummary()
+
+		expect(mediaCount).toHaveBeenCalledTimes(2)
+	})
+})

--- a/app/utils/anonymous-home.server.ts
+++ b/app/utils/anonymous-home.server.ts
@@ -1,6 +1,51 @@
+import { z } from 'zod'
 import { activityEventLabel } from './activity.ts'
 import { prisma } from './db.server.ts'
 import { publicActivityEventWhere } from './lists/visibility.ts'
+import {
+	getPublicSurfaceFragment,
+	type PublicSurfaceCacheRuntime,
+} from './public-surface-cache.server.ts'
+
+export const ANONYMOUS_HOME_SUMMARY_TTL_MS = 5 * 60 * 1_000
+const ANONYMOUS_HOME_SUMMARY_KEY_VERSION = 1
+const anonymousHomeKinds = ['anime', 'manga', 'movie', 'tv'] as const
+
+const safeCountSchema = z.number().int().min(0).max(Number.MAX_SAFE_INTEGER)
+const anonymousHomeSummarySchema = z
+	.object({
+		catalogTotal: safeCountSchema,
+		reviewTotal: safeCountSchema,
+		publicCollectionTotal: safeCountSchema,
+		kinds: z
+			.array(
+				z
+					.object({
+						kind: z.enum(anonymousHomeKinds),
+						count: safeCountSchema,
+					})
+					.strict(),
+			)
+			.max(anonymousHomeKinds.length),
+	})
+	.strict()
+	.superRefine((summary, context) => {
+		const kinds = summary.kinds.map(item => item.kind)
+		const expected = [...new Set(kinds)].sort((left, right) =>
+			left.localeCompare(right, 'en-US'),
+		)
+		if (
+			expected.length !== kinds.length ||
+			expected.some((kind, index) => kind !== kinds[index])
+		) {
+			context.addIssue({
+				code: 'custom',
+				message: 'Anonymous home kinds must be unique and sorted.',
+			})
+		}
+	})
+
+export type AnonymousHomeSummary = z.infer<typeof anonymousHomeSummarySchema>
 
 export type AnonymousHomeActivity = {
 	id: string
@@ -16,105 +61,137 @@ export type AnonymousHomeActivity = {
 	}
 }
 
-export type AnonymousHomeProof = {
-	catalogTotal: number
-	reviewTotal: number
-	publicCollectionTotal: number
-	kinds: Array<{ kind: string; count: number }>
+export type AnonymousHomeProof = AnonymousHomeSummary & {
 	activity: AnonymousHomeActivity[]
 }
 
-export async function getAnonymousHomeProof(): Promise<AnonymousHomeProof> {
-	const [
+function parseAnonymousHomeSummary(value: unknown) {
+	return anonymousHomeSummarySchema.parse(value)
+}
+
+async function loadAnonymousHomeSummary(): Promise<AnonymousHomeSummary> {
+	const [catalogTotal, reviewTotal, publicCollectionTotal, kinds] =
+		await Promise.all([
+			prisma.media.count(),
+			prisma.review.count({
+				where: {
+					moderationStatus: 'visible',
+					author: { is: { accountStatus: 'active' } },
+				},
+			}),
+			prisma.mediaCollection.count({
+				where: {
+					isPublic: true,
+					moderationStatus: 'visible',
+					owner: { is: { accountStatus: 'active' } },
+				},
+			}),
+			prisma.media.groupBy({
+				by: ['kind'],
+				where: { kind: { in: [...anonymousHomeKinds] } },
+				_count: { _all: true },
+				orderBy: { kind: 'asc' },
+			}),
+		])
+
+	return parseAnonymousHomeSummary({
 		catalogTotal,
 		reviewTotal,
 		publicCollectionTotal,
-		kinds,
-		trackingRows,
-		reviewRows,
-		collectionRows,
-	] = await Promise.all([
-		prisma.media.count(),
-		prisma.review.count({
-			where: {
-				moderationStatus: 'visible',
-				author: { is: { accountStatus: 'active' } },
-			},
-		}),
-		prisma.mediaCollection.count({
-			where: {
-				isPublic: true,
-				moderationStatus: 'visible',
-				owner: { is: { accountStatus: 'active' } },
-			},
-		}),
-		prisma.media.groupBy({
-			by: ['kind'],
-			_count: { _all: true },
-			orderBy: { kind: 'asc' },
-		}),
-		prisma.activityEvent.findMany({
-			where: {
-				actor: { is: { accountStatus: 'active' } },
-				AND: [publicActivityEventWhere],
-			},
-			orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-			take: 8,
-			select: {
-				id: true,
-				type: true,
-				status: true,
-				statusLabel: true,
-				previousStatus: true,
-				previousStatusLabel: true,
-				score: true,
-				previousScore: true,
-				progressUnit: true,
-				progressCurrent: true,
-				progressPrevious: true,
-				progressTotal: true,
-				createdAt: true,
-				actor: { select: { username: true } },
-				media: {
-					select: { id: true, kind: true, title: true, thumbnail: true },
+		kinds: kinds.map(row => ({
+			kind: row.kind,
+			count: row._count._all,
+		})),
+	})
+}
+
+export function getAnonymousHomeSummary({
+	runtime,
+}: {
+	runtime?: PublicSurfaceCacheRuntime
+} = {}) {
+	return getPublicSurfaceFragment({
+		namespace: 'anonymous-home-summary',
+		keyVersion: ANONYMOUS_HOME_SUMMARY_KEY_VERSION,
+		keyPayload: { fragment: 'aggregate-summary' },
+		ttl: ANONYMOUS_HOME_SUMMARY_TTL_MS,
+		parse: parseAnonymousHomeSummary,
+		getFreshValue: loadAnonymousHomeSummary,
+		runtime,
+	})
+}
+
+export async function getAnonymousHomeProof({
+	cacheRuntime,
+}: {
+	cacheRuntime?: PublicSurfaceCacheRuntime
+} = {}): Promise<AnonymousHomeProof> {
+	const [summary, trackingRows, reviewRows, collectionRows] = await Promise.all(
+		[
+			getAnonymousHomeSummary({ runtime: cacheRuntime }),
+			prisma.activityEvent.findMany({
+				where: {
+					actor: { is: { accountStatus: 'active' } },
+					AND: [publicActivityEventWhere],
 				},
-			},
-		}),
-		prisma.review.findMany({
-			where: {
-				moderationStatus: 'visible',
-				author: { is: { accountStatus: 'active' } },
-			},
-			orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-			take: 8,
-			select: {
-				id: true,
-				createdAt: true,
-				author: { select: { username: true } },
-				media: { select: { id: true, title: true, thumbnail: true } },
-			},
-		}),
-		prisma.mediaCollection.findMany({
-			where: {
-				isPublic: true,
-				moderationStatus: 'visible',
-				owner: { is: { accountStatus: 'active' } },
-			},
-			orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-			take: 8,
-			select: {
-				id: true,
-				title: true,
-				createdAt: true,
-				owner: { select: { username: true } },
-				items: {
-					orderBy: [{ position: 'asc' }, { id: 'asc' }],
-					take: 1,
-					select: { media: { select: { thumbnail: true } } },
+				orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+				take: 8,
+				select: {
+					id: true,
+					type: true,
+					status: true,
+					statusLabel: true,
+					previousStatus: true,
+					previousStatusLabel: true,
+					score: true,
+					previousScore: true,
+					progressUnit: true,
+					progressCurrent: true,
+					progressPrevious: true,
+					progressTotal: true,
+					createdAt: true,
+					actor: { select: { username: true } },
+					media: {
+						select: { id: true, kind: true, title: true, thumbnail: true },
+					},
 				},
-			},
-		}),
-	])
+			}),
+			prisma.review.findMany({
+				where: {
+					moderationStatus: 'visible',
+					author: { is: { accountStatus: 'active' } },
+				},
+				orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+				take: 8,
+				select: {
+					id: true,
+					createdAt: true,
+					author: { select: { username: true } },
+					media: { select: { id: true, title: true, thumbnail: true } },
+				},
+			}),
+			prisma.mediaCollection.findMany({
+				where: {
+					isPublic: true,
+					moderationStatus: 'visible',
+					owner: { is: { accountStatus: 'active' } },
+				},
+				orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+				take: 8,
+				select: {
+					id: true,
+					title: true,
+					createdAt: true,
+					owner: { select: { username: true } },
+					items: {
+						orderBy: [{ position: 'asc' }, { id: 'asc' }],
+						take: 1,
+						select: { media: { select: { thumbnail: true } } },
+					},
+				},
+			}),
+		],
+	)
 
 	const activity: AnonymousHomeActivity[] = [
 		...trackingRows.map(row => ({
@@ -166,13 +243,7 @@ export async function getAnonymousHomeProof(): Promise<AnonymousHomeProof> {
 		.slice(0, 5)
 
 	return {
-		catalogTotal,
-		reviewTotal,
-		publicCollectionTotal,
-		kinds: kinds.map(row => ({
-			kind: row.kind,
-			count: row._count._all,
-		})),
+		...summary,
 		activity,
 	}
 }

--- a/app/utils/cache.server.test.ts
+++ b/app/utils/cache.server.test.ts
@@ -12,6 +12,7 @@ import {
 } from './cache-key.server.ts'
 import {
 	cache,
+	cacheMetricNamespaces,
 	cachifiedSafely,
 	createCacheResourceCloser,
 	createMemoryCache,
@@ -600,6 +601,19 @@ describe('bounded in-memory cache', () => {
 })
 
 describe('privacy-safe cache reporting', () => {
+	test('accepts only registered static metric families', () => {
+		expect(cacheMetricNamespaces).toEqual([
+			'anonymous-home-summary',
+			'discovery-facets',
+			'home-trending-plan',
+			'ranked-discovery',
+			'recommendation-graph',
+		])
+		for (const namespace of cacheMetricNamespaces) {
+			expect(() => createSafeCacheReporter(namespace)).not.toThrow()
+		}
+	})
+
 	test('records aggregate event classes without retaining event payloads', () => {
 		const privateText = 'viewer-123 secret query'
 		const report = createSafeCacheReporter('ranked-discovery')({} as never)

--- a/app/utils/cache.server.ts
+++ b/app/utils/cache.server.ts
@@ -666,6 +666,9 @@ export type CacheOperationsSnapshot = Readonly<
 >
 
 export const cacheMetricNamespaces = [
+	'anonymous-home-summary',
+	'discovery-facets',
+	'home-trending-plan',
 	'ranked-discovery',
 	'recommendation-graph',
 ] as const

--- a/app/utils/discovery.server.test.ts
+++ b/app/utils/discovery.server.test.ts
@@ -3,14 +3,30 @@ import { expect, test, vi } from 'vitest'
 import { getCacheOperationsSnapshot } from './cache.server.ts'
 import { prisma } from './db.server.ts'
 import {
+	DISCOVERY_FACETS_CACHE_MAX_BYTES,
+	DISCOVERY_FACETS_CACHE_TTL_MS,
+	DISCOVERY_GENRE_LIMIT,
+	DISCOVERY_GENRE_MAX_BYTES,
+	DISCOVERY_GENRE_MAX_CODE_UNITS,
+	DISCOVERY_GENRE_SOURCE_LIMIT,
+	DISCOVERY_GENRE_SOURCE_MAX_CODE_UNITS,
+	DISCOVERY_STATUS_LIMIT,
+	DISCOVERY_STATUS_MAX_BYTES,
+	DISCOVERY_STATUS_MAX_CODE_UNITS,
+	DISCOVERY_STATUS_SOURCE_LIMIT,
+	DISCOVERY_STATUS_SOURCE_MAX_CODE_UNITS,
+	getDiscoveryFacets,
 	getDiscoveryGenres,
 	getDiscoveryResults,
 	getDiscoveryResultsForMediaIds,
 	getDiscoveryResultsForPlan,
 	getDiscoveryStatuses,
+	normalizeDiscoveryFacetSources,
+	parseDiscoveryFacets,
 	parseDiscoveryQuery,
 } from './discovery.server.ts'
 import { type NaturalLanguageDiscoveryPlan } from './natural-language-discovery.ts'
+import { createPublicSurfaceCacheRuntimeForTest } from './public-surface-cache.server.ts'
 
 async function createUser(prefix: string) {
 	const suffix = faker.string.alphanumeric({ length: 10 }).toLowerCase()
@@ -64,6 +80,241 @@ test('discovery query parsing bounds input and replaces invalid options', () => 
 		sort: 'popular',
 		page: 1,
 	})
+})
+
+test('discovery facets normalize, deduplicate, and sort with deterministic en-US semantics', () => {
+	const rows = {
+		genreRows: [
+			{ value: ' drama, Comedy, Action ' },
+			{ value: 'DRAMA, comedy' },
+			{ value: 'Drama' },
+		],
+		statusRows: [
+			{ value: 'released' },
+			{ value: 'RELEASED' },
+			{ value: 'Released' },
+			{ value: 'Ended' },
+		],
+	}
+
+	const first = normalizeDiscoveryFacetSources(rows)
+	const reversed = normalizeDiscoveryFacetSources({
+		genreRows: [...rows.genreRows].reverse(),
+		statusRows: [...rows.statusRows].reverse(),
+	})
+
+	expect(first).toEqual({
+		genres: ['Action', 'Comedy', 'Drama'],
+		statuses: ['Ended', 'Released'],
+		truncated: { genres: false, statuses: false },
+	})
+	expect(reversed).toEqual(first)
+})
+
+test('discovery facets enforce source, value, cardinality, and payload bounds', () => {
+	const genreRows = Array.from(
+		{ length: DISCOVERY_GENRE_SOURCE_LIMIT + 1 },
+		(_, index) => ({
+			value:
+				index === DISCOVERY_GENRE_SOURCE_LIMIT
+					? 'AAA sentinel must not be consumed'
+					: `Genre ${String(index).padStart(4, '0')}`,
+		}),
+	)
+	const statusRows = Array.from(
+		{ length: DISCOVERY_STATUS_SOURCE_LIMIT + 1 },
+		(_, index) => ({
+			value:
+				index === DISCOVERY_STATUS_SOURCE_LIMIT
+					? 'AAA sentinel must not be consumed'
+					: `Status ${String(index).padStart(3, '0')}`,
+		}),
+	)
+
+	const facets = normalizeDiscoveryFacetSources({ genreRows, statusRows })
+
+	expect(facets.genres).toHaveLength(DISCOVERY_GENRE_LIMIT)
+	expect(facets.statuses).toHaveLength(DISCOVERY_STATUS_LIMIT)
+	expect(facets.truncated).toEqual({ genres: true, statuses: true })
+	expect(facets.genres).not.toContain('AAA sentinel must not be consumed')
+	expect(facets.statuses).not.toContain('AAA sentinel must not be consumed')
+	for (const genre of facets.genres) {
+		expect(genre.length).toBeLessThanOrEqual(DISCOVERY_GENRE_MAX_CODE_UNITS)
+		expect(Buffer.byteLength(genre, 'utf8')).toBeLessThanOrEqual(
+			DISCOVERY_GENRE_MAX_BYTES,
+		)
+	}
+	for (const status of facets.statuses) {
+		expect(status.length).toBeLessThanOrEqual(DISCOVERY_STATUS_MAX_CODE_UNITS)
+		expect(Buffer.byteLength(status, 'utf8')).toBeLessThanOrEqual(
+			DISCOVERY_STATUS_MAX_BYTES,
+		)
+	}
+	expect(Buffer.byteLength(JSON.stringify(facets), 'utf8')).toBeLessThan(
+		DISCOVERY_FACETS_CACHE_MAX_BYTES,
+	)
+})
+
+test('maximum-cardinality discovery facets stay materially below the cache ceiling', () => {
+	const facets = normalizeDiscoveryFacetSources({
+		genreRows: Array.from({ length: DISCOVERY_GENRE_LIMIT }, (_, index) => ({
+			value: `${String(index).padStart(3, '0')}-${'界'.repeat(76)}`,
+		})),
+		statusRows: Array.from({ length: DISCOVERY_STATUS_LIMIT }, (_, index) => ({
+			value: `S${String(index).padStart(3, '0')}-${'界'.repeat(55)}`,
+		})),
+	})
+	const payloadBytes = Buffer.byteLength(JSON.stringify(facets), 'utf8')
+
+	expect(facets.genres).toHaveLength(DISCOVERY_GENRE_LIMIT)
+	expect(facets.statuses).toHaveLength(DISCOVERY_STATUS_LIMIT)
+	expect(payloadBytes).toBeGreaterThan(40 * 1_024)
+	expect(payloadBytes).toBeLessThan(DISCOVERY_FACETS_CACHE_MAX_BYTES)
+	expect(() => parseDiscoveryFacets(facets)).not.toThrow()
+})
+
+test('discovery facets discard blank, malformed, oversized, and hostile values', () => {
+	const facets = normalizeDiscoveryFacetSources({
+		genreRows: [
+			{ value: '   ' },
+			{ value: 'Safe Genre' },
+			{ value: `Safe Genre, ${'g'.repeat(81)}` },
+			{ value: 'Bad\u0000Genre' },
+			{ value: 'x'.repeat(1_000_000) },
+			{ value: null },
+			{ value: 42 },
+		],
+		statusRows: [
+			{ value: '' },
+			{ value: 'Released' },
+			{ value: 'Bad\nStatus' },
+			{ value: 's'.repeat(61) },
+			{ value: 'x'.repeat(1_000_000) },
+			{ value: undefined },
+		],
+	})
+
+	expect(facets).toEqual({
+		genres: ['Safe Genre'],
+		statuses: ['Released'],
+		truncated: { genres: false, statuses: false },
+	})
+	expect(() =>
+		parseDiscoveryFacets({
+			...facets,
+			genres: ['Drama', 'drama'],
+		}),
+	).toThrow(/case-insensitively unique/)
+	expect(() =>
+		parseDiscoveryFacets({
+			...facets,
+			statuses: ['Released', 'Ended'],
+		}),
+	).toThrow(/deterministic en-US ordering/)
+})
+
+test('discovery facets use two bounded source queries and one cached combined refresh', async () => {
+	await prisma.media.createMany({
+		data: [
+			{
+				kind: 'movie',
+				title: 'Facet One',
+				genres: 'Drama, Mystery',
+				releaseStatus: 'Released',
+			},
+			{
+				kind: 'anime',
+				title: 'Facet Two',
+				genres: 'drama, Action',
+				releaseStatus: 'Returning Series',
+			},
+			{
+				kind: 'manga',
+				title: 'Blank Facets',
+				genres: '   ',
+				releaseStatus: '   ',
+			},
+			{
+				kind: 'tv',
+				title: 'Oversized Facets',
+				genres: 'g'.repeat(513),
+				releaseStatus: 's'.repeat(61),
+			},
+		],
+	})
+	const runtime = createPublicSurfaceCacheRuntimeForTest()
+	const queryRaw = vi.spyOn(prisma, '$queryRaw')
+
+	const first = await getDiscoveryFacets({ runtime })
+	const cached = await getDiscoveryFacets({ runtime })
+
+	expect(first).toEqual({
+		genres: ['Action', 'Drama', 'Mystery'],
+		statuses: ['Released', 'Returning Series'],
+		truncated: { genres: false, statuses: false },
+	})
+	expect(cached).toEqual(first)
+	expect(Object.isFrozen(first)).toBe(true)
+	expect(Object.isFrozen(first.genres)).toBe(true)
+	expect(queryRaw).toHaveBeenCalledTimes(2)
+	const genreSql = Array.from(
+		queryRaw.mock.calls[0]![0] as unknown as readonly string[],
+	).join('?')
+	const statusSql = Array.from(
+		queryRaw.mock.calls[1]![0] as unknown as readonly string[],
+	).join('?')
+	expect(genreSql).toContain('SELECT DISTINCT "genres" AS "value"')
+	expect(statusSql).toContain('SELECT DISTINCT "releaseStatus" AS "value"')
+	expect(queryRaw.mock.calls[0]!.slice(1)).toEqual([
+		DISCOVERY_GENRE_SOURCE_MAX_CODE_UNITS,
+		DISCOVERY_GENRE_SOURCE_LIMIT + 1,
+	])
+	expect(queryRaw.mock.calls[1]!.slice(1)).toEqual([
+		DISCOVERY_STATUS_SOURCE_MAX_CODE_UNITS,
+		DISCOVERY_STATUS_SOURCE_LIMIT + 1,
+	])
+	expect(runtime.cache.snapshot().entries).toBe(1)
+	expect(getCacheOperationsSnapshot()['discovery-facets']).toMatchObject({
+		hit: 1,
+		miss: 1,
+		refresh: 1,
+	})
+})
+
+test('discovery facet cache expires and supports deterministic test bypass', async () => {
+	await prisma.media.create({
+		data: {
+			kind: 'movie',
+			title: 'Facet expiry',
+			genres: 'Drama',
+			releaseStatus: 'Released',
+		},
+	})
+	const queryRaw = vi.spyOn(prisma, '$queryRaw')
+	vi.useFakeTimers()
+	vi.setSystemTime(new Date('2026-07-29T12:00:00.000Z'))
+
+	try {
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+		await getDiscoveryFacets({ runtime })
+		vi.advanceTimersByTime(DISCOVERY_FACETS_CACHE_TTL_MS - 1)
+		await getDiscoveryFacets({ runtime })
+		expect(queryRaw).toHaveBeenCalledTimes(2)
+
+		vi.advanceTimersByTime(2)
+		await getDiscoveryFacets({ runtime })
+		expect(queryRaw).toHaveBeenCalledTimes(4)
+
+		const bypassRuntime = createPublicSurfaceCacheRuntimeForTest({
+			bypass: true,
+		})
+		await getDiscoveryFacets({ runtime: bypassRuntime })
+		await getDiscoveryFacets({ runtime: bypassRuntime })
+		expect(queryRaw).toHaveBeenCalledTimes(8)
+		expect(bypassRuntime.cache.snapshot().entries).toBe(0)
+	} finally {
+		vi.useRealTimers()
+	}
 })
 
 test('cached plans still hydrate catalog and viewer state freshly', async () => {

--- a/app/utils/discovery.server.ts
+++ b/app/utils/discovery.server.ts
@@ -11,6 +11,10 @@ import {
 import { type NaturalLanguageDiscoveryPlan } from './natural-language-discovery.ts'
 import { prismaSearchFilter } from './prisma-search.server.ts'
 import {
+	getPublicSurfaceFragment,
+	type PublicSurfaceCacheRuntime,
+} from './public-surface-cache.server.ts'
+import {
 	createRankedDiscoveryViewerFingerprint,
 	getRankedDiscoveryPlan,
 	type RankedDiscoveryPlanRequest,
@@ -22,6 +26,34 @@ const FOR_YOU_CANDIDATE_LIMIT = 500
 const RANKED_DISCOVERY_PLAN_LIMIT = 1_000
 const RANKING_QUERY_CHUNK_SIZE = 400
 const POPULAR_FEED_FRESHNESS_MS = 8 * 24 * 60 * 60 * 1_000
+export const DISCOVERY_FACETS_CACHE_TTL_MS = 5 * 60 * 1_000
+export const DISCOVERY_GENRE_SOURCE_LIMIT = 4_096
+export const DISCOVERY_STATUS_SOURCE_LIMIT = 256
+export const DISCOVERY_GENRE_SOURCE_MAX_CODE_UNITS = 512
+export const DISCOVERY_STATUS_SOURCE_MAX_CODE_UNITS = 60
+export const DISCOVERY_GENRE_LIMIT = 128
+export const DISCOVERY_STATUS_LIMIT = 64
+export const DISCOVERY_GENRE_MAX_CODE_UNITS = 80
+export const DISCOVERY_STATUS_MAX_CODE_UNITS = 60
+export const DISCOVERY_GENRE_MAX_BYTES = 240
+export const DISCOVERY_STATUS_MAX_BYTES = 180
+export const DISCOVERY_FACETS_CACHE_MAX_BYTES = 48 * 1_024
+
+const DISCOVERY_GENRE_SOURCE_QUERY_LIMIT = DISCOVERY_GENRE_SOURCE_LIMIT + 1
+const DISCOVERY_STATUS_SOURCE_QUERY_LIMIT = DISCOVERY_STATUS_SOURCE_LIMIT + 1
+const DISCOVERY_GENRE_SOURCE_MAX_BYTES =
+	DISCOVERY_GENRE_SOURCE_MAX_CODE_UNITS * 4
+const DISCOVERY_STATUS_SOURCE_MAX_BYTES =
+	DISCOVERY_STATUS_SOURCE_MAX_CODE_UNITS * 4
+const DISCOVERY_FACETS_CACHE_KEY_VERSION = 1
+const facetBaseCollator = new Intl.Collator('en-US', {
+	usage: 'sort',
+	sensitivity: 'base',
+})
+const facetVariantCollator = new Intl.Collator('en-US', {
+	usage: 'sort',
+	sensitivity: 'variant',
+})
 
 export const discoveryKinds = ['all', 'movie', 'tv', 'anime', 'manga'] as const
 export const discoveryProviders = ['all', 'tmdb', 'mal'] as const
@@ -1434,28 +1466,343 @@ export async function getDiscoveryResults(
 	}
 }
 
-export async function getDiscoveryGenres() {
-	const media = await prisma.media.findMany({
-		where: { genres: { not: null } },
-		select: { genres: true },
-		distinct: ['genres'],
+type DiscoveryFacetSourceRow = {
+	value?: unknown
+}
+
+export type DiscoveryFacets = Readonly<{
+	genres: readonly string[]
+	statuses: readonly string[]
+	truncated: Readonly<{
+		genres: boolean
+		statuses: boolean
+	}>
+}>
+
+type FacetEntry = {
+	key: string
+	value: string
+}
+
+type FacetAccumulator = {
+	entries: FacetEntry[]
+	entriesByKey: Map<string, FacetEntry>
+	limit: number
+	truncated: boolean
+}
+
+const discoveryFacetSourceRowSchema = z.object({ value: z.unknown() }).strict()
+
+function boundedFacetValueSchema(
+	maximumCodeUnits: number,
+	maximumBytes: number,
+) {
+	return z
+		.string()
+		.min(1)
+		.max(maximumCodeUnits)
+		.refine(value => value === value.trim(), {
+			message: 'facet values must not have surrounding whitespace',
+		})
+		.refine(value => !hasFacetControlCharacter(value), {
+			message: 'facet values must not contain control characters',
+		})
+		.refine(value => Buffer.byteLength(value, 'utf8') <= maximumBytes, {
+			message: 'facet value exceeds its UTF-8 byte limit',
+		})
+}
+
+const discoveryFacetsSchema = z
+	.object({
+		genres: z
+			.array(
+				boundedFacetValueSchema(
+					DISCOVERY_GENRE_MAX_CODE_UNITS,
+					DISCOVERY_GENRE_MAX_BYTES,
+				),
+			)
+			.max(DISCOVERY_GENRE_LIMIT),
+		statuses: z
+			.array(
+				boundedFacetValueSchema(
+					DISCOVERY_STATUS_MAX_CODE_UNITS,
+					DISCOVERY_STATUS_MAX_BYTES,
+				),
+			)
+			.max(DISCOVERY_STATUS_LIMIT),
+		truncated: z
+			.object({
+				genres: z.boolean(),
+				statuses: z.boolean(),
+			})
+			.strict(),
 	})
-	const genres = new Map<string, string>()
-	for (const item of media) {
-		for (const genre of splitGenres(item.genres)) {
-			const key = genre.toLocaleLowerCase()
-			if (!genres.has(key)) genres.set(key, genre)
+	.strict()
+	.superRefine((facets, context) => {
+		for (const [field, values] of [
+			['genres', facets.genres],
+			['statuses', facets.statuses],
+		] as const) {
+			const keys = new Set<string>()
+			for (const [index, value] of values.entries()) {
+				const key = facetKey(value)
+				if (keys.has(key)) {
+					context.addIssue({
+						code: 'custom',
+						path: [field, index],
+						message: 'facet values must be case-insensitively unique',
+					})
+				}
+				keys.add(key)
+				if (index > 0 && compareFacetValues(values[index - 1]!, value) >= 0) {
+					context.addIssue({
+						code: 'custom',
+						path: [field, index],
+						message: 'facet values must use deterministic en-US ordering',
+					})
+				}
+			}
+		}
+		if (
+			Buffer.byteLength(JSON.stringify(facets), 'utf8') >
+			DISCOVERY_FACETS_CACHE_MAX_BYTES
+		) {
+			context.addIssue({
+				code: 'custom',
+				message: 'discovery facet cache payload exceeds its byte limit',
+			})
+		}
+	})
+
+function facetKey(value: string) {
+	return value.normalize('NFKC').toLocaleLowerCase('en-US')
+}
+
+function hasFacetControlCharacter(value: string) {
+	for (let index = 0; index < value.length; index++) {
+		const codeUnit = value.charCodeAt(index)
+		if (codeUnit <= 0x1f || codeUnit === 0x7f) return true
+	}
+	return false
+}
+
+function compareFacetValues(left: string, right: string) {
+	return (
+		facetBaseCollator.compare(left, right) ||
+		facetVariantCollator.compare(left, right) ||
+		(left < right ? -1 : left > right ? 1 : 0)
+	)
+}
+
+function facetCaseRank(value: string) {
+	const lower = value.toLocaleLowerCase('en-US')
+	const upper = value.toLocaleUpperCase('en-US')
+	if (lower === upper) return 0
+	if (value === lower) return 1
+	if (value === upper) return 2
+	return 0
+}
+
+function compareFacetRepresentatives(left: string, right: string) {
+	return (
+		facetCaseRank(left) - facetCaseRank(right) ||
+		compareFacetValues(left, right)
+	)
+}
+
+function insertFacetEntry(entries: FacetEntry[], entry: FacetEntry) {
+	let start = 0
+	let end = entries.length
+	while (start < end) {
+		const middle = Math.floor((start + end) / 2)
+		if (compareFacetValues(entries[middle]!.value, entry.value) < 0) {
+			start = middle + 1
+		} else {
+			end = middle
 		}
 	}
-	return [...genres.values()].sort((left, right) => left.localeCompare(right))
+	entries.splice(start, 0, entry)
+}
+
+function addFacetValue(accumulator: FacetAccumulator, value: string) {
+	const key = facetKey(value)
+	const existing = accumulator.entriesByKey.get(key)
+	if (existing) {
+		if (compareFacetRepresentatives(value, existing.value) >= 0) return
+		const index = accumulator.entries.indexOf(existing)
+		if (index >= 0) accumulator.entries.splice(index, 1)
+		existing.value = value
+		insertFacetEntry(accumulator.entries, existing)
+		return
+	}
+
+	if (accumulator.entries.length >= accumulator.limit) {
+		accumulator.truncated = true
+		const last = accumulator.entries.at(-1)!
+		if (compareFacetValues(value, last.value) >= 0) return
+		accumulator.entries.pop()
+		accumulator.entriesByKey.delete(last.key)
+	}
+
+	const entry = { key, value }
+	accumulator.entriesByKey.set(key, entry)
+	insertFacetEntry(accumulator.entries, entry)
+}
+
+function normalizeFacetValue(
+	rawValue: unknown,
+	{
+		sourceMaxCodeUnits,
+		sourceMaxBytes,
+		valueMaxCodeUnits,
+		valueMaxBytes,
+	}: {
+		sourceMaxCodeUnits: number
+		sourceMaxBytes: number
+		valueMaxCodeUnits: number
+		valueMaxBytes: number
+	},
+) {
+	if (
+		typeof rawValue !== 'string' ||
+		rawValue.length === 0 ||
+		rawValue.length > sourceMaxCodeUnits ||
+		Buffer.byteLength(rawValue, 'utf8') > sourceMaxBytes
+	) {
+		return null
+	}
+	const value = rawValue.trim()
+	if (
+		!value ||
+		value.length > valueMaxCodeUnits ||
+		Buffer.byteLength(value, 'utf8') > valueMaxBytes ||
+		hasFacetControlCharacter(value)
+	) {
+		return null
+	}
+	return value
+}
+
+function parseFacetSourceRows(
+	value: unknown,
+	maximumRows: number,
+): DiscoveryFacetSourceRow[] {
+	return z.array(discoveryFacetSourceRowSchema).max(maximumRows).parse(value)
+}
+
+export function normalizeDiscoveryFacetSources({
+	genreRows: rawGenreRows,
+	statusRows: rawStatusRows,
+}: {
+	genreRows: unknown
+	statusRows: unknown
+}): DiscoveryFacets {
+	const genreRows = parseFacetSourceRows(
+		rawGenreRows,
+		DISCOVERY_GENRE_SOURCE_QUERY_LIMIT,
+	)
+	const statusRows = parseFacetSourceRows(
+		rawStatusRows,
+		DISCOVERY_STATUS_SOURCE_QUERY_LIMIT,
+	)
+	const genreAccumulator: FacetAccumulator = {
+		entries: [],
+		entriesByKey: new Map(),
+		limit: DISCOVERY_GENRE_LIMIT,
+		truncated: genreRows.length > DISCOVERY_GENRE_SOURCE_LIMIT,
+	}
+	const statusAccumulator: FacetAccumulator = {
+		entries: [],
+		entriesByKey: new Map(),
+		limit: DISCOVERY_STATUS_LIMIT,
+		truncated: statusRows.length > DISCOVERY_STATUS_SOURCE_LIMIT,
+	}
+
+	for (const row of genreRows.slice(0, DISCOVERY_GENRE_SOURCE_LIMIT)) {
+		if (
+			typeof row.value !== 'string' ||
+			row.value.length > DISCOVERY_GENRE_SOURCE_MAX_CODE_UNITS ||
+			Buffer.byteLength(row.value, 'utf8') > DISCOVERY_GENRE_SOURCE_MAX_BYTES
+		) {
+			continue
+		}
+		for (const rawGenre of row.value.split(',')) {
+			const genre = normalizeFacetValue(rawGenre, {
+				sourceMaxCodeUnits: DISCOVERY_GENRE_SOURCE_MAX_CODE_UNITS,
+				sourceMaxBytes: DISCOVERY_GENRE_SOURCE_MAX_BYTES,
+				valueMaxCodeUnits: DISCOVERY_GENRE_MAX_CODE_UNITS,
+				valueMaxBytes: DISCOVERY_GENRE_MAX_BYTES,
+			})
+			if (genre) addFacetValue(genreAccumulator, genre)
+		}
+	}
+
+	for (const row of statusRows.slice(0, DISCOVERY_STATUS_SOURCE_LIMIT)) {
+		const status = normalizeFacetValue(row.value, {
+			sourceMaxCodeUnits: DISCOVERY_STATUS_SOURCE_MAX_CODE_UNITS,
+			sourceMaxBytes: DISCOVERY_STATUS_SOURCE_MAX_BYTES,
+			valueMaxCodeUnits: DISCOVERY_STATUS_MAX_CODE_UNITS,
+			valueMaxBytes: DISCOVERY_STATUS_MAX_BYTES,
+		})
+		if (status) addFacetValue(statusAccumulator, status)
+	}
+
+	return parseDiscoveryFacets({
+		genres: genreAccumulator.entries.map(entry => entry.value),
+		statuses: statusAccumulator.entries.map(entry => entry.value),
+		truncated: {
+			genres: genreAccumulator.truncated,
+			statuses: statusAccumulator.truncated,
+		},
+	})
+}
+
+export function parseDiscoveryFacets(value: unknown): DiscoveryFacets {
+	return discoveryFacetsSchema.parse(value)
+}
+
+async function loadDiscoveryFacets() {
+	const [genreRows, statusRows] = await Promise.all([
+		prisma.$queryRaw<DiscoveryFacetSourceRow[]>`
+			SELECT DISTINCT "genres" AS "value"
+			FROM "Media"
+			WHERE "genres" IS NOT NULL
+				AND length("genres") BETWEEN 1 AND ${DISCOVERY_GENRE_SOURCE_MAX_CODE_UNITS}
+				AND length(trim("genres")) >= 1
+			ORDER BY "value" ASC
+			LIMIT ${DISCOVERY_GENRE_SOURCE_QUERY_LIMIT}
+		`,
+		prisma.$queryRaw<DiscoveryFacetSourceRow[]>`
+			SELECT DISTINCT "releaseStatus" AS "value"
+			FROM "Media"
+			WHERE "releaseStatus" IS NOT NULL
+				AND length("releaseStatus") BETWEEN 1 AND ${DISCOVERY_STATUS_SOURCE_MAX_CODE_UNITS}
+				AND length(trim("releaseStatus")) >= 1
+			ORDER BY "value" ASC
+			LIMIT ${DISCOVERY_STATUS_SOURCE_QUERY_LIMIT}
+		`,
+	])
+	return normalizeDiscoveryFacetSources({ genreRows, statusRows })
+}
+
+export async function getDiscoveryFacets(
+	options: { runtime?: PublicSurfaceCacheRuntime } = {},
+): Promise<DiscoveryFacets> {
+	return getPublicSurfaceFragment({
+		namespace: 'discovery-facets',
+		keyVersion: DISCOVERY_FACETS_CACHE_KEY_VERSION,
+		keyPayload: { projection: 'bounded-facets-v1' },
+		ttl: DISCOVERY_FACETS_CACHE_TTL_MS,
+		parse: parseDiscoveryFacets,
+		getFreshValue: loadDiscoveryFacets,
+		runtime: options.runtime,
+	})
+}
+
+export async function getDiscoveryGenres() {
+	return [...(await getDiscoveryFacets()).genres]
 }
 
 export async function getDiscoveryStatuses() {
-	const media = await prisma.media.findMany({
-		where: { releaseStatus: { not: null } },
-		select: { releaseStatus: true },
-		distinct: ['releaseStatus'],
-		orderBy: { releaseStatus: 'asc' },
-	})
-	return media.flatMap(item => (item.releaseStatus ? [item.releaseStatus] : []))
+	return [...(await getDiscoveryFacets()).statuses]
 }

--- a/app/utils/home-trending.server.test.ts
+++ b/app/utils/home-trending.server.test.ts
@@ -1,8 +1,61 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
+import { createMemoryCache } from './cache.server.ts'
 import { prisma } from './db.server.ts'
-import { getHomeTrending } from './home-trending.server.ts'
+import {
+	getHomeTrending,
+	HOME_TRENDING_LIMIT,
+	HOME_TRENDING_PLAN_TTL_MS,
+	parseHomeTrendingPlan,
+	type HomeTrendingPlan,
+} from './home-trending.server.ts'
+import { createPublicSurfaceCacheRuntimeForTest } from './public-surface-cache.server.ts'
 
 const now = new Date('2026-07-20T12:00:00.000Z')
+
+type TrendingKind = 'movie' | 'tv' | 'anime' | 'manga'
+
+async function createFreshFeed(
+	kind: TrendingKind,
+	titles: string[],
+	observedAt = now,
+) {
+	const media = await Promise.all(
+		titles.map((title, index) =>
+			prisma.media.create({
+				data: {
+					kind,
+					title,
+					catalogPopularity: titles.length - index,
+				},
+			}),
+		),
+	)
+	await prisma.catalogFeedItem.createMany({
+		data: media.map((item, index) => ({
+			provider: kind === 'anime' || kind === 'manga' ? 'mal' : 'tmdb',
+			kind,
+			feed: 'trending',
+			rank: index + 1,
+			rankingScore: titles.length - index,
+			rankingVersion: 3,
+			observedAt,
+			mediaId: item.id,
+		})),
+	})
+	return media
+}
+
+async function createOneFreshItemPerRail() {
+	const entries = await Promise.all(
+		(['movie', 'tv', 'anime', 'manga'] as const).map(async kind => ({
+			kind,
+			media: (await createFreshFeed(kind, [`Fresh ${kind}`]))[0]!,
+		})),
+	)
+	return Object.fromEntries(
+		entries.map(entry => [entry.kind, entry.media]),
+	) as Record<TrendingKind, (typeof entries)[number]['media']>
+}
 
 test('fresh trending rails stay pure instead of silently mixing fallback signals', async () => {
 	const viewer = await prisma.user.create({
@@ -288,4 +341,486 @@ test('popularity fallbacks exclude unranked anime and manga inventory', async ()
 	)
 	expect(manga).toBeUndefined()
 	expect(unrankedManga.catalogPopularity).toBeNull()
+})
+
+test('runs the four fresh rail queries together, short-circuits fallbacks, and bypasses cache by default in tests', async () => {
+	await createOneFreshItemPerRail()
+	const feedQueries = vi.spyOn(prisma.catalogFeedItem, 'findMany')
+	const mediaQueries = vi.spyOn(prisma.media, 'findMany')
+
+	const first = await getHomeTrending(null, { now })
+	const second = await getHomeTrending(null, { now })
+
+	expect(first.map(rail => rail.kind)).toEqual([
+		'movie',
+		'tv',
+		'anime',
+		'manga',
+	])
+	expect(second).toEqual(first)
+	expect(feedQueries).toHaveBeenCalledTimes(8)
+	expect(
+		feedQueries.mock.calls.every(call => {
+			const input = call[0] as { where?: { feed?: string } } | undefined
+			return input?.where?.feed === 'trending'
+		}),
+	).toBe(true)
+	expect(mediaQueries).toHaveBeenCalledTimes(2)
+	expect(
+		mediaQueries.mock.calls.every(call => {
+			const input = call[0] as
+				{ where?: { id?: { in?: string[] } } } | undefined
+			return input?.where?.id?.in?.length === 4
+		}),
+	).toBe(true)
+})
+
+test('queries each fallback tier sequentially and stops on the first nonempty tier', async () => {
+	const [movie] = await createFreshFeed('movie', ['Fresh movie'])
+	const [popularTv, seasonalAnime, catalogManga] = await Promise.all([
+		prisma.media.create({
+			data: { kind: 'tv', title: 'Popular TV' },
+		}),
+		prisma.media.create({
+			data: {
+				kind: 'anime',
+				title: 'Current seasonal anime',
+				startSeason: 'Summer 2026',
+			},
+		}),
+		prisma.media.create({
+			data: {
+				kind: 'manga',
+				title: 'Catalog manga',
+				catalogPopularity: 100,
+			},
+		}),
+	])
+	await prisma.catalogFeedItem.createMany({
+		data: [
+			{
+				provider: 'tmdb',
+				kind: 'tv',
+				feed: 'popular',
+				rank: 1,
+				rankingScore: 1,
+				rankingVersion: 3,
+				observedAt: now,
+				mediaId: popularTv.id,
+			},
+			{
+				provider: 'mal',
+				kind: 'anime',
+				feed: 'popular',
+				rank: 1,
+				rankingScore: 1,
+				rankingVersion: 1,
+				observedAt: now,
+				mediaId: seasonalAnime.id,
+			},
+		],
+	})
+	const feedQueries = vi.spyOn(prisma.catalogFeedItem, 'findMany')
+	const mediaQueries = vi.spyOn(prisma.media, 'findMany')
+
+	const rails = await getHomeTrending(null, { now })
+
+	const callsByKind = new Map<TrendingKind, string[]>()
+	for (const call of feedQueries.mock.calls) {
+		const input = call[0] as
+			{ where?: { kind?: TrendingKind; feed?: string } } | undefined
+		const kind = input?.where?.kind
+		const feed = input?.where?.feed
+		if (!kind || !feed) continue
+		const calls = callsByKind.get(kind) ?? []
+		calls.push(feed)
+		callsByKind.set(kind, calls)
+	}
+	expect(callsByKind).toEqual(
+		new Map([
+			['movie', ['trending']],
+			['tv', ['trending', 'popular']],
+			['anime', ['trending', 'popular']],
+			['manga', ['trending', 'popular']],
+		]),
+	)
+	expect(mediaQueries).toHaveBeenCalledTimes(2)
+	expect(
+		mediaQueries.mock.calls.filter(call => {
+			const input = call[0] as
+				{ where?: { kind?: string; catalogPopularity?: unknown } } | undefined
+			return (
+				input?.where?.kind === 'manga' &&
+				input.where.catalogPopularity !== undefined
+			)
+		}),
+	).toHaveLength(1)
+	expect(
+		rails.map(rail => [rail.kind, rail.signal, rail.items[0]?.id]),
+	).toEqual([
+		['movie', 'trending', movie!.id],
+		['tv', 'popular', popularTv.id],
+		['anime', 'trending', seasonalAnime.id],
+		['manga', 'legacy', catalogManga.id],
+	])
+})
+
+test('shares one public plan across concurrent callers through single-flight', async () => {
+	await createOneFreshItemPerRail()
+	const runtime = createPublicSurfaceCacheRuntimeForTest()
+	const feedQueries = vi.spyOn(prisma.catalogFeedItem, 'findMany')
+
+	const results = await Promise.all(
+		Array.from({ length: 8 }, () => getHomeTrending(null, { now, runtime })),
+	)
+
+	expect(results.every(result => result.length === 4)).toBe(true)
+	expect(feedQueries).toHaveBeenCalledTimes(4)
+	expect(runtime.cache.snapshot().entries).toBe(1)
+})
+
+test('expires the public plan after exactly the declared two-minute TTL', async () => {
+	await createOneFreshItemPerRail()
+	let cacheNow = Date.now()
+	const runtime = createPublicSurfaceCacheRuntimeForTest({
+		cache: createMemoryCache({
+			name: 'home-trending-ttl-test',
+			now: () => cacheNow,
+		}),
+	})
+	const feedQueries = vi.spyOn(prisma.catalogFeedItem, 'findMany')
+
+	await getHomeTrending(null, { now, runtime })
+	cacheNow += HOME_TRENDING_PLAN_TTL_MS - 1_000
+	await getHomeTrending(null, { now, runtime })
+	expect(feedQueries).toHaveBeenCalledTimes(4)
+
+	cacheNow += 2_000
+	await getHomeTrending(null, { now, runtime })
+	expect(HOME_TRENDING_PLAN_TTL_MS).toBe(120_000)
+	expect(feedQueries).toHaveBeenCalledTimes(8)
+})
+
+test('keeps cached plans fixed, exact, unique, canonical, and bounded', () => {
+	const emptyRails = () => [
+		{ kind: 'movie', items: [] },
+		{ kind: 'tv', items: [] },
+		{ kind: 'anime', items: [] },
+		{ kind: 'manga', items: [] },
+	]
+	expect(parseHomeTrendingPlan({ rails: emptyRails() }).rails).toHaveLength(4)
+
+	for (const invalid of [
+		{
+			rails: [
+				{
+					kind: 'movie',
+					items: Array.from(
+						{ length: HOME_TRENDING_LIMIT + 1 },
+						(_, index) => ({
+							id: `media-${index}`,
+							source: 'provider-feed',
+							observedAt: now.toISOString(),
+						}),
+					),
+				},
+				...emptyRails().slice(1),
+			],
+		},
+		{
+			rails: [
+				{
+					kind: 'movie',
+					items: [
+						{
+							id: 'duplicate-id',
+							source: 'provider-feed',
+							observedAt: now.toISOString(),
+						},
+						{
+							id: 'duplicate-id',
+							source: 'provider-feed',
+							observedAt: now.toISOString(),
+						},
+					],
+				},
+				...emptyRails().slice(1),
+			],
+		},
+		{
+			rails: [
+				{ kind: 'tv', items: [] },
+				{ kind: 'movie', items: [] },
+				...emptyRails().slice(2),
+			],
+		},
+		{
+			rails: emptyRails().map((rail, index) =>
+				index === 0 ? { ...rail, explanation: 'not cache data' } : rail,
+			),
+		},
+		{
+			rails: [
+				{
+					kind: 'movie',
+					items: [
+						{
+							id: 'media-a',
+							source: 'provider-feed',
+							observedAt: null,
+						},
+					],
+				},
+				...emptyRails().slice(1),
+			],
+		},
+		{
+			rails: [
+				{
+					kind: 'movie',
+					items: [
+						{
+							id: 'media-a',
+							source: 'catalog-popularity',
+							observedAt: now.toISOString(),
+						},
+					],
+				},
+				...emptyRails().slice(1),
+			],
+		},
+	]) {
+		expect(() => parseHomeTrendingPlan(invalid)).toThrow()
+	}
+})
+
+test('shares the anonymous public plan while hydrating each viewer state fresh and owner-scoped', async () => {
+	const [media, viewerA, viewerB] = await Promise.all([
+		createFreshFeed('movie', ['Shared public candidate']).then(
+			items => items[0]!,
+		),
+		prisma.user.create({
+			data: {
+				email: 'trending_cache_viewer_a@example.com',
+				username: 'trending_cache_viewer_a',
+			},
+		}),
+		prisma.user.create({
+			data: {
+				email: 'trending_cache_viewer_b@example.com',
+				username: 'trending_cache_viewer_b',
+			},
+		}),
+	])
+	await prisma.trackingState.createMany({
+		data: [
+			{ ownerId: viewerA.id, mediaId: media.id, status: 'watching' },
+			{ ownerId: viewerB.id, mediaId: media.id, status: 'completed' },
+		],
+	})
+	const runtime = createPublicSurfaceCacheRuntimeForTest()
+	const trackingQueries = vi.spyOn(prisma.trackingState, 'findMany')
+
+	const anonymous = await getHomeTrending(null, { now, runtime })
+	const forViewerA = await getHomeTrending(viewerA.id, { now, runtime })
+	const forViewerB = await getHomeTrending(viewerB.id, { now, runtime })
+	await prisma.trackingState.update({
+		where: {
+			ownerId_mediaId: { ownerId: viewerA.id, mediaId: media.id },
+		},
+		data: { status: 'completed' },
+	})
+	const refreshedViewerA = await getHomeTrending(viewerA.id, {
+		now,
+		runtime,
+	})
+
+	expect(anonymous[0]?.items[0]?.viewerTracking).toBeNull()
+	expect(forViewerA[0]?.items[0]?.viewerTracking?.status).toBe('watching')
+	expect(forViewerB[0]?.items[0]?.viewerTracking?.status).toBe('completed')
+	expect(refreshedViewerA[0]?.items[0]?.viewerTracking?.status).toBe(
+		'completed',
+	)
+	expect(runtime.cache.snapshot().entries).toBe(1)
+	expect(trackingQueries).toHaveBeenCalledTimes(3)
+	expect(
+		trackingQueries.mock.calls.map(call => {
+			const input = call[0] as { where?: { ownerId?: string } } | undefined
+			return input?.where?.ownerId
+		}),
+	).toEqual([viewerA.id, viewerB.id, viewerA.id])
+})
+
+test('rehydrates media metadata and drops deleted, title-null, or kind-changed cached IDs', async () => {
+	const media = await createFreshFeed('movie', [
+		'Delete after plan',
+		'Clear title after plan',
+		'Change kind after plan',
+		'Keep after plan',
+	])
+	const runtime = createPublicSurfaceCacheRuntimeForTest()
+	const feedQueries = vi.spyOn(prisma.catalogFeedItem, 'findMany')
+
+	const first = await getHomeTrending(null, { now, runtime })
+	const planQueryCount = feedQueries.mock.calls.length
+	expect(first[0]?.items.map(item => item.id)).toEqual(
+		media.map(item => item.id),
+	)
+	await Promise.all([
+		prisma.media.delete({ where: { id: media[0]!.id } }),
+		prisma.media.update({
+			where: { id: media[1]!.id },
+			data: { title: null },
+		}),
+		prisma.media.update({
+			where: { id: media[2]!.id },
+			data: { kind: 'tv' },
+		}),
+		prisma.media.update({
+			where: { id: media[3]!.id },
+			data: {
+				title: 'Freshly hydrated title',
+				catalogScore: 9.7,
+			},
+		}),
+	])
+
+	const second = await getHomeTrending(null, { now, runtime })
+
+	expect(feedQueries).toHaveBeenCalledTimes(planQueryCount)
+	expect(second).toHaveLength(1)
+	expect(second[0]?.items).toHaveLength(1)
+	expect(second[0]?.items[0]).toEqual(
+		expect.objectContaining({
+			id: media[3]!.id,
+			title: 'Freshly hydrated title',
+			score: 9.7,
+			rank: 1,
+		}),
+	)
+	expect(second[0]?.observedAt).toBeInstanceOf(Date)
+	expect(second[0]?.items[0]?.observedAt).toBeInstanceOf(Date)
+})
+
+test('keys plans by semantic MAL season while keeping caller limits out of the key', async () => {
+	const [summer, fall] = await Promise.all([
+		prisma.media.create({
+			data: {
+				kind: 'anime',
+				title: 'Summer seasonal result',
+				startSeason: 'Summer 2026',
+			},
+		}),
+		prisma.media.create({
+			data: {
+				kind: 'anime',
+				title: 'Fall seasonal result',
+				startSeason: 'Fall 2026',
+			},
+		}),
+	])
+	await prisma.catalogFeedItem.createMany({
+		data: [
+			{
+				provider: 'mal',
+				kind: 'anime',
+				feed: 'popular',
+				rank: 1,
+				rankingScore: 1,
+				observedAt: now,
+				mediaId: summer.id,
+			},
+			{
+				provider: 'mal',
+				kind: 'anime',
+				feed: 'popular',
+				rank: 1,
+				rankingScore: 1,
+				observedAt: now,
+				mediaId: fall.id,
+			},
+		],
+	})
+	const runtime = createPublicSurfaceCacheRuntimeForTest()
+
+	const earlySummer = await getHomeTrending(null, {
+		now: new Date('2026-07-01T00:00:00.000Z'),
+		limit: 1,
+		runtime,
+	})
+	const lateSummer = await getHomeTrending(null, {
+		now: new Date('2026-08-31T23:59:59.000Z'),
+		limit: HOME_TRENDING_LIMIT,
+		runtime,
+	})
+	expect(earlySummer.find(rail => rail.kind === 'anime')?.items[0]?.id).toBe(
+		summer.id,
+	)
+	expect(lateSummer.find(rail => rail.kind === 'anime')?.items[0]?.id).toBe(
+		summer.id,
+	)
+	expect(runtime.cache.snapshot().entries).toBe(1)
+
+	const fallRails = await getHomeTrending(null, {
+		now: new Date('2026-10-01T00:00:00.000Z'),
+		runtime,
+	})
+	expect(fallRails.find(rail => rail.kind === 'anime')?.items[0]?.id).toBe(
+		fall.id,
+	)
+	expect(runtime.cache.snapshot().entries).toBe(2)
+})
+
+test('stores eighteen ordered IDs regardless of the first caller limit and restores order after fresh hydration', async () => {
+	const titles = Array.from(
+		{ length: HOME_TRENDING_LIMIT + 2 },
+		(_, index) => `Ranked movie ${String(index + 1).padStart(2, '0')}`,
+	)
+	const media = await createFreshFeed('movie', titles)
+	const runtime = createPublicSurfaceCacheRuntimeForTest()
+	const feedQueries = vi.spyOn(prisma.catalogFeedItem, 'findMany')
+
+	const compact = await getHomeTrending(null, {
+		now,
+		limit: 3,
+		runtime,
+	})
+	const planQueryCount = feedQueries.mock.calls.length
+	const full = await getHomeTrending(null, {
+		now,
+		limit: HOME_TRENDING_LIMIT,
+		runtime,
+	})
+
+	expect(feedQueries).toHaveBeenCalledTimes(planQueryCount)
+	expect(compact[0]?.items.map(item => item.id)).toEqual(
+		media.slice(0, 3).map(item => item.id),
+	)
+	expect(full[0]?.items.map(item => item.id)).toEqual(
+		media.slice(0, HOME_TRENDING_LIMIT).map(item => item.id),
+	)
+	expect(full[0]?.items.map(item => item.rank)).toEqual(
+		Array.from({ length: HOME_TRENDING_LIMIT }, (_, index) => index + 1),
+	)
+	expect(runtime.cache.snapshot().entries).toBe(1)
+	const [key] = runtime.cache.keys()
+	const cachedEntry = key ? await runtime.cache.get(key) : undefined
+	expect(Object.isFrozen(cachedEntry?.value)).toBe(true)
+	expect(
+		Object.isFrozen(
+			(cachedEntry?.value as { rails?: unknown[] } | undefined)?.rails,
+		),
+	).toBe(true)
+	const cachedPlan: HomeTrendingPlan = parseHomeTrendingPlan(cachedEntry?.value)
+	expect(cachedPlan.rails).toHaveLength(4)
+	expect(cachedPlan.rails[0].items).toHaveLength(HOME_TRENDING_LIMIT)
+	expect(cachedPlan.rails.flatMap(rail => rail.items)).toHaveLength(
+		HOME_TRENDING_LIMIT,
+	)
+	expect(
+		cachedPlan.rails[0].items.every(
+			item =>
+				typeof item.observedAt === 'string' && item.observedAt.endsWith('Z'),
+		),
+	).toBe(true)
 })

--- a/app/utils/home-trending.server.ts
+++ b/app/utils/home-trending.server.ts
@@ -1,10 +1,20 @@
 import { type Prisma } from '@prisma/client'
+import { z } from 'zod'
 import { prisma } from './db.server.ts'
 import { currentMalSeason } from './mal-trending.server.ts'
+import {
+	getPublicSurfaceFragment,
+	type PublicSurfaceCacheRuntime,
+} from './public-surface-cache.server.ts'
 import { TMDB_FEED_RANKING_VERSION } from './tmdb-catalog-hydration.server.ts'
 
 export const HOME_TRENDING_LIMIT = 18
+export const HOME_TRENDING_PLAN_TTL_MS = 2 * 60 * 1_000
+export const HOME_TRENDING_ALGORITHM_VERSION = 1
+
+const HOME_TRENDING_PLAN_KEY_VERSION = 1
 const FEED_FRESHNESS_MS = 8 * 24 * 60 * 60 * 1_000
+const MEDIA_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
 
 const railDefinitions = [
 	{ kind: 'movie', title: 'Trending movies' },
@@ -12,6 +22,91 @@ const railDefinitions = [
 	{ kind: 'anime', title: 'Trending anime' },
 	{ kind: 'manga', title: 'Trending manga' },
 ] as const
+
+const homeTrendingSourceSchema = z.enum([
+	'provider-feed',
+	'popular-fallback',
+	'catalog-popularity',
+])
+type HomeTrendingSource = z.infer<typeof homeTrendingSourceSchema>
+
+const canonicalIsoDateSchema = z
+	.string()
+	.datetime()
+	.refine(value => new Date(value).toISOString() === value, {
+		message: 'observedAt must be a canonical ISO timestamp',
+	})
+
+const homeTrendingPlanItemSchema = z
+	.object({
+		id: z.string().regex(MEDIA_ID_PATTERN),
+		source: homeTrendingSourceSchema,
+		observedAt: canonicalIsoDateSchema.nullable(),
+	})
+	.strict()
+	.superRefine((item, context) => {
+		if ((item.source === 'catalog-popularity') !== (item.observedAt === null)) {
+			context.addIssue({
+				code: 'custom',
+				path: ['observedAt'],
+				message:
+					'catalog fallbacks require a null observation and feed rows require an observation',
+			})
+		}
+	})
+
+function planRailSchema<Kind extends HomeTrendingRail['kind']>(kind: Kind) {
+	return z
+		.object({
+			kind: z.literal(kind),
+			items: z.array(homeTrendingPlanItemSchema).max(HOME_TRENDING_LIMIT),
+		})
+		.strict()
+		.superRefine((rail, context) => {
+			const ids = new Set<string>()
+			const sources = new Set<HomeTrendingSource>()
+			for (const [index, item] of rail.items.entries()) {
+				if (ids.has(item.id)) {
+					context.addIssue({
+						code: 'custom',
+						path: ['items', index, 'id'],
+						message: 'trending plan IDs must be unique within a rail',
+					})
+				}
+				ids.add(item.id)
+				sources.add(item.source)
+			}
+			if (sources.size > 1) {
+				context.addIssue({
+					code: 'custom',
+					path: ['items'],
+					message: 'a trending rail cannot mix ranking signals',
+				})
+			}
+		})
+}
+
+const homeTrendingPlanSchema = z
+	.object({
+		rails: z.tuple([
+			planRailSchema('movie'),
+			planRailSchema('tv'),
+			planRailSchema('anime'),
+			planRailSchema('manga'),
+		]),
+	})
+	.strict()
+
+export type HomeTrendingPlan = z.infer<typeof homeTrendingPlanSchema>
+
+/**
+ * The cache boundary calls this parser on fresh, cached, bypassed, and returned
+ * values. It is exported so load gates can assert the exact public fragment
+ * contract without exposing a producer or cache override to application code.
+ */
+export function parseHomeTrendingPlan(value: unknown): HomeTrendingPlan {
+	return homeTrendingPlanSchema.parse(value)
+}
 
 const homeTrendingMediaSelect = {
 	id: true,
@@ -41,7 +136,7 @@ export type HomeTrendingItem = {
 	year: string | null
 	score: number | null
 	rank: number
-	source: 'provider-feed' | 'popular-fallback' | 'catalog-popularity'
+	source: HomeTrendingSource
 	observedAt: Date | null
 	viewerTracking: {
 		status: string
@@ -57,6 +152,8 @@ export type HomeTrendingRail = {
 	observedAt: Date | null
 }
 
+type PlannedCandidate = HomeTrendingPlan['rails'][number]['items'][number]
+
 function yearFor(media: HomeTrendingMedia) {
 	if (media.releaseStart) return String(media.releaseStart.getUTCFullYear())
 	return media.startYear || media.airYear || null
@@ -71,208 +168,263 @@ function providerScore(media: HomeTrendingMedia) {
 	return values.length ? Math.max(...values) : null
 }
 
+function uniqueFeedPlanItems(
+	items: Array<{ mediaId: string; observedAt: Date }>,
+	source: Extract<HomeTrendingSource, 'provider-feed' | 'popular-fallback'>,
+) {
+	return [...new Map(items.map(item => [item.mediaId, item] as const)).values()]
+		.slice(0, HOME_TRENDING_LIMIT)
+		.map((item): PlannedCandidate => ({
+			id: item.mediaId,
+			source,
+			observedAt: item.observedAt.toISOString(),
+		}))
+}
+
 async function candidatesForRail(input: {
 	kind: HomeTrendingRail['kind']
-	limit: number
 	freshAfter: Date
-	now: Date
+	currentSeasonLabel: string
 }) {
 	const provider =
 		input.kind === 'anime' || input.kind === 'manga' ? 'mal' : 'tmdb'
-	const currentSeason = currentMalSeason(input.now)
-	const currentSeasonLabel = `${currentSeason.season[0]!.toUpperCase()}${currentSeason.season.slice(1)} ${currentSeason.year}`
-	const [feedItems, seasonalAnimeItems, popularFeedItems, popular] =
-		await Promise.all([
-			prisma.catalogFeedItem.findMany({
-				where: {
-					provider,
-					kind: input.kind,
-					feed: 'trending',
-					rankingScore: { not: null },
-					rankingVersion: {
-						gte: provider === 'mal' ? 3 : TMDB_FEED_RANKING_VERSION,
+	const feedItems = await prisma.catalogFeedItem.findMany({
+		where: {
+			provider,
+			kind: input.kind,
+			feed: 'trending',
+			rankingScore: { not: null },
+			rankingVersion: {
+				gte: provider === 'mal' ? 3 : TMDB_FEED_RANKING_VERSION,
+			},
+			observedAt: { gte: input.freshAfter },
+			media: { is: { title: { not: null } } },
+		},
+		orderBy: [
+			{ observedAt: 'desc' },
+			{ rankingScore: 'desc' },
+			{ rank: 'asc' },
+		],
+		take: HOME_TRENDING_LIMIT,
+		select: {
+			mediaId: true,
+			observedAt: true,
+		},
+	})
+	const freshPlan = uniqueFeedPlanItems(feedItems, 'provider-feed')
+	if (freshPlan.length) return freshPlan
+
+	if (input.kind === 'anime') {
+		const seasonalAnimeItems = await prisma.catalogFeedItem.findMany({
+			where: {
+				provider: 'mal',
+				kind: 'anime',
+				feed: 'popular',
+				rankingScore: { not: null },
+				media: {
+					is: {
+						title: { not: null },
+						startSeason: input.currentSeasonLabel,
 					},
-					observedAt: { gte: input.freshAfter },
-					media: { is: { title: { not: null } } },
 				},
-				orderBy: [
-					{ observedAt: 'desc' },
-					{ rankingScore: 'desc' },
-					{ rank: 'asc' },
-				],
-				take: input.limit,
-				select: {
-					observedAt: true,
-					media: { select: homeTrendingMediaSelect },
-				},
-			}),
-			input.kind === 'anime'
-				? prisma.catalogFeedItem.findMany({
-						where: {
-							provider: 'mal',
-							kind: 'anime',
-							feed: 'popular',
-							rankingScore: { not: null },
-							media: {
-								is: {
-									title: { not: null },
-									startSeason: currentSeasonLabel,
-								},
-							},
-						},
-						orderBy: [{ rank: 'asc' }, { mediaId: 'asc' }],
-						take: input.limit,
-						select: {
-							observedAt: true,
-							media: { select: homeTrendingMediaSelect },
-						},
-					})
-				: Promise.resolve([]),
-			prisma.catalogFeedItem.findMany({
-				where: {
-					provider,
-					kind: input.kind,
-					feed: 'popular',
-					rankingScore: { not: null },
-					rankingVersion: {
-						gte: provider === 'mal' ? 1 : TMDB_FEED_RANKING_VERSION,
-					},
-					media: { is: { title: { not: null } } },
-				},
-				orderBy: [
-					{ rankingScore: 'desc' },
-					{ rank: 'asc' },
-					{ mediaId: 'asc' },
-				],
-				take: input.limit,
-				select: {
-					observedAt: true,
-					media: { select: homeTrendingMediaSelect },
-				},
-			}),
-			prisma.media.findMany({
-				where: {
-					kind: input.kind,
-					title: { not: null },
-					catalogPopularity: { not: null },
-				},
-				orderBy: [
-					{ catalogPopularity: 'desc' },
-					{ releaseStart: 'desc' },
-					{ title: 'asc' },
-				],
-				take: input.limit,
-				select: homeTrendingMediaSelect,
-			}),
-		])
-	const uniqueFeedItems = [
-		...new Map(feedItems.map(item => [item.media.id, item])).values(),
-	]
-	const uniquePopularFeedItems = [
-		...new Map(popularFeedItems.map(item => [item.media.id, item])).values(),
-	]
-	const uniqueSeasonalAnimeItems = [
-		...new Map(seasonalAnimeItems.map(item => [item.media.id, item])).values(),
-	]
-	if (uniqueFeedItems.length) {
-		return uniqueFeedItems.slice(0, input.limit).map(item => ({
-			media: item.media,
-			source: 'provider-feed' as const,
-			observedAt: item.observedAt,
-		}))
+			},
+			orderBy: [{ rank: 'asc' }, { mediaId: 'asc' }],
+			take: HOME_TRENDING_LIMIT,
+			select: {
+				mediaId: true,
+				observedAt: true,
+			},
+		})
+		const seasonalPlan = uniqueFeedPlanItems(
+			seasonalAnimeItems,
+			'provider-feed',
+		)
+		if (seasonalPlan.length) return seasonalPlan
 	}
-	if (uniqueSeasonalAnimeItems.length) {
-		return uniqueSeasonalAnimeItems.slice(0, input.limit).map(item => ({
-			media: item.media,
-			source: 'provider-feed' as const,
-			observedAt: item.observedAt,
-		}))
-	}
-	if (uniquePopularFeedItems.length) {
-		return uniquePopularFeedItems.slice(0, input.limit).map(item => ({
-			media: item.media,
-			source: 'popular-fallback' as const,
-			observedAt: item.observedAt,
-		}))
-	}
-	return popular.map(media => ({
-		media,
-		source: 'catalog-popularity' as const,
+
+	const popularFeedItems = await prisma.catalogFeedItem.findMany({
+		where: {
+			provider,
+			kind: input.kind,
+			feed: 'popular',
+			rankingScore: { not: null },
+			rankingVersion: {
+				gte: provider === 'mal' ? 1 : TMDB_FEED_RANKING_VERSION,
+			},
+			media: { is: { title: { not: null } } },
+		},
+		orderBy: [{ rankingScore: 'desc' }, { rank: 'asc' }, { mediaId: 'asc' }],
+		take: HOME_TRENDING_LIMIT,
+		select: {
+			mediaId: true,
+			observedAt: true,
+		},
+	})
+	const popularPlan = uniqueFeedPlanItems(popularFeedItems, 'popular-fallback')
+	if (popularPlan.length) return popularPlan
+
+	const popular = await prisma.media.findMany({
+		where: {
+			kind: input.kind,
+			title: { not: null },
+			catalogPopularity: { not: null },
+		},
+		orderBy: [
+			{ catalogPopularity: 'desc' },
+			{ releaseStart: 'desc' },
+			{ title: 'asc' },
+		],
+		take: HOME_TRENDING_LIMIT,
+		select: { id: true },
+	})
+	return popular.map((media): PlannedCandidate => ({
+		id: media.id,
+		source: 'catalog-popularity',
 		observedAt: null,
 	}))
 }
 
+async function createHomeTrendingPlan(now: Date) {
+	const currentSeason = currentMalSeason(now)
+	const currentSeasonLabel = `${currentSeason.season[0]!.toUpperCase()}${currentSeason.season.slice(1)} ${currentSeason.year}`
+	const freshAfter = new Date(now.getTime() - FEED_FRESHNESS_MS)
+	const rails = await Promise.all(
+		railDefinitions.map(async rail => ({
+			kind: rail.kind,
+			items: await candidatesForRail({
+				kind: rail.kind,
+				freshAfter,
+				currentSeasonLabel,
+			}),
+		})),
+	)
+	return parseHomeTrendingPlan({ rails })
+}
+
+function signalForSource(
+	source: HomeTrendingSource,
+): HomeTrendingRail['signal'] {
+	if (source === 'provider-feed') return 'trending'
+	if (source === 'popular-fallback') return 'popular'
+	return 'legacy'
+}
+
+function titleForRail(
+	rail: (typeof railDefinitions)[number],
+	source: HomeTrendingSource,
+) {
+	if (rail.kind === 'anime' || rail.kind === 'manga') return rail.title
+	if (source === 'provider-feed') return rail.title
+	if (source === 'popular-fallback') {
+		return `Popular ${rail.kind === 'tv' ? 'TV' : rail.kind}`
+	}
+	return `Catalog ${rail.kind === 'tv' ? 'TV' : rail.kind}`
+}
+
 export async function getHomeTrending(
 	viewerId: string | null,
-	options: { now?: Date; limit?: number } = {},
+	options: {
+		now?: Date
+		limit?: number
+		runtime?: PublicSurfaceCacheRuntime
+	} = {},
 ) {
 	const now = options.now ?? new Date()
 	const limit = Math.max(
 		1,
 		Math.min(options.limit ?? HOME_TRENDING_LIMIT, HOME_TRENDING_LIMIT),
 	)
-	const freshAfter = new Date(now.getTime() - FEED_FRESHNESS_MS)
-	const candidates = await Promise.all(
-		railDefinitions.map(async rail => ({
-			...rail,
-			items: await candidatesForRail({
-				kind: rail.kind,
-				limit,
-				freshAfter,
-				now,
-			}),
-		})),
-	)
-	const mediaIds = candidates.flatMap(rail =>
-		rail.items.map(item => item.media.id),
-	)
-	const viewerStates = viewerId
-		? await prisma.trackingState.findMany({
-				where: { ownerId: viewerId, mediaId: { in: mediaIds } },
-				select: {
-					mediaId: true,
-					status: true,
-					statusWatchlistId: true,
-				},
+	const currentSeason = currentMalSeason(now)
+	const plan = await getPublicSurfaceFragment({
+		namespace: 'home-trending-plan',
+		keyVersion: HOME_TRENDING_PLAN_KEY_VERSION,
+		keyPayload: {
+			algorithmVersion: HOME_TRENDING_ALGORITHM_VERSION,
+			malSeason: {
+				year: currentSeason.year,
+				season: currentSeason.season,
+			},
+		},
+		ttl: HOME_TRENDING_PLAN_TTL_MS,
+		parse: parseHomeTrendingPlan,
+		getFreshValue: () => createHomeTrendingPlan(now),
+		runtime: options.runtime,
+	})
+
+	const plannedIds = [
+		...new Set(plan.rails.flatMap(rail => rail.items.map(item => item.id))),
+	]
+	const media = plannedIds.length
+		? await prisma.media.findMany({
+				where: { id: { in: plannedIds } },
+				select: homeTrendingMediaSelect,
 			})
 		: []
+	const mediaById = new Map(media.map(item => [item.id, item]))
+	const hydratedRails = plan.rails.map((rail, railIndex) => {
+		const definition = railDefinitions[railIndex]!
+		const items = rail.items
+			.flatMap(item => {
+				const current = mediaById.get(item.id)
+				if (
+					!current ||
+					current.kind !== definition.kind ||
+					current.title === null
+				) {
+					return []
+				}
+				return [
+					{
+						media: current,
+						source: item.source,
+						observedAt:
+							item.observedAt === null ? null : new Date(item.observedAt),
+					},
+				]
+			})
+			.slice(0, limit)
+		return { definition, items }
+	})
+	const mediaIds = hydratedRails.flatMap(rail =>
+		rail.items.map(item => item.media.id),
+	)
+	const viewerStates =
+		viewerId && mediaIds.length
+			? await prisma.trackingState.findMany({
+					where: { ownerId: viewerId, mediaId: { in: mediaIds } },
+					select: {
+						mediaId: true,
+						status: true,
+						statusWatchlistId: true,
+					},
+				})
+			: []
 	const viewerStateByMediaId = new Map(
 		viewerStates.map(state => [state.mediaId, state]),
 	)
 
-	return candidates.flatMap(rail => {
-		if (!rail.items.length) return []
+	return hydratedRails.flatMap(({ definition, items }) => {
+		const first = items[0]
+		if (!first) return []
 		return [
 			{
-				kind: rail.kind,
-				title:
-					rail.kind === 'anime' || rail.kind === 'manga'
-						? rail.title
-						: rail.items[0]?.source === 'provider-feed'
-							? rail.title
-							: rail.items[0]?.source === 'popular-fallback'
-								? `Popular ${rail.kind === 'tv' ? 'TV' : rail.kind}`
-								: `Catalog ${rail.kind === 'tv' ? 'TV' : rail.kind}`,
-				signal:
-					rail.items[0]?.source === 'provider-feed'
-						? ('trending' as const)
-						: rail.items[0]?.source === 'popular-fallback'
-							? ('popular' as const)
-							: ('legacy' as const),
-				observedAt: rail.items[0]?.observedAt ?? null,
-				items: rail.items.map(({ media, source }, index) => {
-					const viewerState = viewerStateByMediaId.get(media.id)
+				kind: definition.kind,
+				title: titleForRail(definition, first.source),
+				signal: signalForSource(first.source),
+				observedAt: first.observedAt,
+				items: items.map(({ media: item, source, observedAt }, index) => {
+					const viewerState = viewerStateByMediaId.get(item.id)
 					return {
-						id: media.id,
-						kind: media.kind,
-						title: media.title?.trim() || `Untitled ${media.kind}`,
-						thumbnail: media.thumbnail,
-						type: media.type,
-						year: yearFor(media),
-						score: providerScore(media),
+						id: item.id,
+						kind: item.kind,
+						title: item.title?.trim() || `Untitled ${item.kind}`,
+						thumbnail: item.thumbnail,
+						type: item.type,
+						year: yearFor(item),
+						score: providerScore(item),
 						rank: index + 1,
 						source,
-						observedAt: rail.items[index]?.observedAt ?? null,
+						observedAt,
 						viewerTracking: viewerState
 							? {
 									status: viewerState.status,

--- a/app/utils/profile-headers.ts
+++ b/app/utils/profile-headers.ts
@@ -11,7 +11,7 @@ export const profileHeaders: HeadersFunction = ({
 	]
 		.filter(Boolean)
 		.join(',')
-	const headers = new Headers()
+	const headers = new Headers({ 'Cache-Control': 'private, no-store' })
 	if (serverTiming) headers.set('Server-Timing', serverTiming)
 	return headers
 }

--- a/app/utils/public-surface-cache.server.test.ts
+++ b/app/utils/public-surface-cache.server.test.ts
@@ -1,0 +1,426 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { z } from 'zod'
+import {
+	createMemoryCache,
+	getCacheOperationsSnapshot,
+	lruCache,
+	resetCacheResourcesForTest,
+	SAFE_CACHE_MAX_TTL_MS,
+} from './cache.server.ts'
+import {
+	createPublicSurfaceCacheRuntimeForTest,
+	getPublicSurfaceFragment,
+	publicSurfaceCacheNamespaces,
+	type PublicSurfaceCacheNamespace,
+} from './public-surface-cache.server.ts'
+
+const fragmentSchema = z
+	.object({
+		ids: z.array(z.string().trim().min(1).max(128)).max(8),
+	})
+	.strict()
+
+function parseFragment(value: unknown) {
+	return fragmentSchema.parse(value)
+}
+
+type Fragment = z.infer<typeof fragmentSchema>
+type FragmentOptions = Parameters<typeof getPublicSurfaceFragment<Fragment>>[0]
+
+function fragmentOptions(
+	overrides: Partial<FragmentOptions> = {},
+): FragmentOptions {
+	return {
+		namespace: 'home-trending-plan' as const,
+		keyVersion: 1,
+		keyPayload: { season: 'summer-2026' },
+		ttl: 1_000,
+		parse: parseFragment,
+		getFreshValue: () => ({ ids: ['media-a'] }),
+		...overrides,
+	}
+}
+
+afterEach(() => {
+	vi.useRealTimers()
+	vi.unstubAllEnvs()
+	resetCacheResourcesForTest()
+})
+
+describe('public surface cache policy', () => {
+	test('registers only the three public fragment families', () => {
+		expect(publicSurfaceCacheNamespaces).toEqual([
+			'anonymous-home-summary',
+			'home-trending-plan',
+			'discovery-facets',
+		])
+	})
+
+	test('bypasses by default in Vitest without cache state or metrics', async () => {
+		const entriesBefore = lruCache.snapshot().entries
+		const fresh = vi
+			.fn<() => Promise<{ ids: string[] }>>()
+			.mockResolvedValue({ ids: ['media-a'] })
+
+		const first = await getPublicSurfaceFragment(
+			fragmentOptions({ getFreshValue: fresh }),
+		)
+		const second = await getPublicSurfaceFragment(
+			fragmentOptions({ getFreshValue: fresh }),
+		)
+
+		expect(first).toEqual({ ids: ['media-a'] })
+		expect(second).toEqual(first)
+		expect(fresh).toHaveBeenCalledTimes(2)
+		expect(lruCache.snapshot().entries).toBe(entriesBefore)
+		expect(getCacheOperationsSnapshot()).toEqual({})
+		expect(Object.isFrozen(first)).toBe(true)
+		expect(Object.isFrozen(first.ids)).toBe(true)
+	})
+
+	test('checks the browser-test bypass marker on every call', async () => {
+		vi.stubEnv('NODE_ENV', 'production')
+		vi.stubEnv('VEUD_E2E', '0')
+		const fresh = vi.fn(() => ({ ids: ['media-a'] }))
+
+		await getPublicSurfaceFragment(fragmentOptions({ getFreshValue: fresh }))
+		const entriesBeforeBypass = lruCache.snapshot().entries
+		const metricsBeforeBypass = getCacheOperationsSnapshot()
+
+		vi.stubEnv('VEUD_E2E', '1')
+		await getPublicSurfaceFragment(fragmentOptions({ getFreshValue: fresh }))
+
+		expect(fresh).toHaveBeenCalledTimes(2)
+		expect(lruCache.snapshot().entries).toBe(entriesBeforeBypass)
+		expect(getCacheOperationsSnapshot()).toEqual(metricsBeforeBypass)
+	})
+
+	test('accepts branded runtime overrides only in the test process', async () => {
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+		vi.stubEnv('NODE_ENV', 'production')
+
+		expect(() => createPublicSurfaceCacheRuntimeForTest()).toThrow(
+			/only be created by tests/,
+		)
+		await expect(
+			getPublicSurfaceFragment(fragmentOptions({ runtime })),
+		).rejects.toThrow(/only be used by tests/)
+	})
+
+	test('validates namespace, version, key material, ttl, and callbacks before bypass', async () => {
+		for (const input of [
+			fragmentOptions({
+				namespace: 'viewer-private' as PublicSurfaceCacheNamespace,
+			}),
+			fragmentOptions({ keyVersion: 0 }),
+			fragmentOptions({ keyVersion: Number.NaN }),
+			fragmentOptions({ keyPayload: { invalid: undefined } as never }),
+			fragmentOptions({ ttl: 0 }),
+			fragmentOptions({ ttl: SAFE_CACHE_MAX_TTL_MS + 1 }),
+			fragmentOptions({ parse: null as never }),
+			fragmentOptions({ getFreshValue: null as never }),
+		]) {
+			await expect(getPublicSurfaceFragment(input)).rejects.toThrow()
+		}
+
+		await expect(
+			getPublicSurfaceFragment(fragmentOptions({ ttl: SAFE_CACHE_MAX_TTL_MS })),
+		).resolves.toEqual({ ids: ['media-a'] })
+	})
+})
+
+describe('public surface cache correctness', () => {
+	test('coalesces concurrent refreshes and retains only opaque public keys', async () => {
+		const privateMaterial = 'member-private-query'
+		const timings = {}
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+		let release: (() => void) | undefined
+		const gate = new Promise<void>(resolve => {
+			release = resolve
+		})
+		const fresh = vi.fn(async () => {
+			await gate
+			return { ids: ['media-a'] }
+		})
+
+		const calls = Array.from({ length: 12 }, () =>
+			getPublicSurfaceFragment(
+				fragmentOptions({
+					keyPayload: { semanticInput: privateMaterial },
+					getFreshValue: fresh,
+					timings,
+					runtime,
+				}),
+			),
+		)
+		await vi.waitFor(() => expect(fresh).toHaveBeenCalledOnce())
+		release?.()
+
+		await expect(Promise.all(calls)).resolves.toEqual(
+			Array.from({ length: 12 }, () => ({ ids: ['media-a'] })),
+		)
+		expect(runtime.cache.keys()).toHaveLength(1)
+		expect(runtime.cache.keys()[0]).toMatch(
+			/^ck1_home-trending-plan_v1_[A-Za-z0-9_-]{43}$/,
+		)
+		expect(
+			JSON.stringify({
+				keys: runtime.cache.keys(),
+				metrics: getCacheOperationsSnapshot(),
+				timings,
+			}),
+		).not.toContain(privateMaterial)
+		expect(Object.keys(timings).sort()).toEqual([
+			'cache:home-trending-plan',
+			'getFreshValue:home-trending-plan',
+		])
+		expect(getCacheOperationsSnapshot()['home-trending-plan']).toMatchObject({
+			miss: 12,
+			refresh: 1,
+		})
+	})
+
+	test('isolates semantic inputs, versions, namespaces, and datasources', async () => {
+		const cache = createMemoryCache()
+		const firstRuntime = createPublicSurfaceCacheRuntimeForTest({
+			cache,
+			datasourceUrl:
+				'postgresql://first-user:first-secret@db.example.invalid/veud',
+		})
+		const secondRuntime = createPublicSurfaceCacheRuntimeForTest({
+			cache,
+			datasourceUrl:
+				'postgresql://second-user:second-secret@db.example.invalid/other',
+		})
+		let sequence = 0
+		const fresh = vi.fn(() => ({ ids: [`media-${++sequence}`] }))
+
+		for (const options of [
+			fragmentOptions({ runtime: firstRuntime, getFreshValue: fresh }),
+			fragmentOptions({
+				runtime: firstRuntime,
+				keyPayload: { season: 'fall-2026' },
+				getFreshValue: fresh,
+			}),
+			fragmentOptions({
+				runtime: firstRuntime,
+				keyVersion: 2,
+				getFreshValue: fresh,
+			}),
+			fragmentOptions({
+				namespace: 'discovery-facets',
+				runtime: firstRuntime,
+				getFreshValue: fresh,
+			}),
+			fragmentOptions({ runtime: secondRuntime, getFreshValue: fresh }),
+		]) {
+			await getPublicSurfaceFragment(options)
+		}
+
+		expect(fresh).toHaveBeenCalledTimes(5)
+		expect(cache.keys()).toHaveLength(5)
+		for (const key of cache.keys()) {
+			expect(key).not.toContain('first-user')
+			expect(key).not.toContain('first-secret')
+			expect(key).not.toContain('second-user')
+			expect(key).not.toContain('second-secret')
+			expect(key).not.toContain('summer-2026')
+		}
+	})
+
+	test('returns cached values until ttl then performs one blocking refresh', async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(1_000)
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+		let sequence = 0
+		const fresh = vi.fn(() => ({ ids: [`media-${++sequence}`] }))
+		const options = fragmentOptions({
+			ttl: 1_000,
+			getFreshValue: fresh,
+			runtime,
+		})
+
+		await expect(getPublicSurfaceFragment(options)).resolves.toEqual({
+			ids: ['media-1'],
+		})
+		vi.setSystemTime(1_999)
+		await expect(getPublicSurfaceFragment(options)).resolves.toEqual({
+			ids: ['media-1'],
+		})
+		vi.setSystemTime(2_001)
+		const expiredCalls = Array.from({ length: 8 }, () =>
+			getPublicSurfaceFragment(options),
+		)
+		await expect(Promise.all(expiredCalls)).resolves.toEqual(
+			Array.from({ length: 8 }, () => ({ ids: ['media-2'] })),
+		)
+
+		expect(fresh).toHaveBeenCalledTimes(2)
+	})
+
+	test('rejects invalid fresh values without storing them', async () => {
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+
+		await expect(
+			getPublicSurfaceFragment(
+				fragmentOptions({
+					runtime,
+					getFreshValue: () => ({
+						ids: ['media-a'],
+						privateViewer: 'must-not-be-cached',
+					}),
+				}),
+			),
+		).rejects.toThrow()
+		expect(runtime.cache.snapshot().entries).toBe(0)
+		expect(getCacheOperationsSnapshot()['home-trending-plan']).toMatchObject({
+			'refresh-error': 1,
+		})
+	})
+
+	test('strictly parses bypassed fresh values without recording cache activity', async () => {
+		const runtime = createPublicSurfaceCacheRuntimeForTest({ bypass: true })
+
+		await expect(
+			getPublicSurfaceFragment(
+				fragmentOptions({
+					runtime,
+					getFreshValue: () => ({
+						ids: ['media-a'],
+						privateViewer: 'must-not-cross-the-boundary',
+					}),
+				}),
+			),
+		).rejects.toThrow()
+		expect(runtime.cache.snapshot().entries).toBe(0)
+		expect(getCacheOperationsSnapshot()).toEqual({})
+	})
+
+	test('evicts invalid cached values and refreshes through the strict parser', async () => {
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+		await getPublicSurfaceFragment(fragmentOptions({ runtime }))
+		const [key] = runtime.cache.keys()
+		if (!key) throw new Error('test setup: expected a cache key')
+		runtime.cache.set(key, {
+			metadata: { createdTime: Date.now(), ttl: 1_000, swr: 0 },
+			value: { ids: ['media-a'], unexpected: 'poison' },
+		})
+		const fresh = vi.fn(() => ({ ids: ['media-b'] }))
+
+		await expect(
+			getPublicSurfaceFragment(
+				fragmentOptions({ runtime, getFreshValue: fresh }),
+			),
+		).resolves.toEqual({ ids: ['media-b'] })
+		expect(fresh).toHaveBeenCalledOnce()
+		expect(await runtime.cache.get(key)).toMatchObject({
+			value: { ids: ['media-b'] },
+		})
+		expect(getCacheOperationsSnapshot()['home-trending-plan']).toMatchObject({
+			invalid: 1,
+		})
+	})
+
+	test('never returns an expired or invalid value when refresh fails', async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(1_000)
+		const expiredRuntime = createPublicSurfaceCacheRuntimeForTest()
+		await getPublicSurfaceFragment(
+			fragmentOptions({ ttl: 100, runtime: expiredRuntime }),
+		)
+		vi.setSystemTime(1_101)
+		await expect(
+			getPublicSurfaceFragment(
+				fragmentOptions({
+					ttl: 100,
+					runtime: expiredRuntime,
+					getFreshValue() {
+						throw new Error('expired refresh failed')
+					},
+				}),
+			),
+		).rejects.toThrow('expired refresh failed')
+
+		const invalidRuntime = createPublicSurfaceCacheRuntimeForTest()
+		await getPublicSurfaceFragment(fragmentOptions({ runtime: invalidRuntime }))
+		const [key] = invalidRuntime.cache.keys()
+		if (!key) throw new Error('test setup: expected a cache key')
+		invalidRuntime.cache.set(key, {
+			metadata: { createdTime: Date.now(), ttl: 1_000, swr: 0 },
+			value: { ids: [null] },
+		})
+		await expect(
+			getPublicSurfaceFragment(
+				fragmentOptions({
+					runtime: invalidRuntime,
+					getFreshValue() {
+						throw new Error('invalid refresh failed')
+					},
+				}),
+			),
+		).rejects.toThrow('invalid refresh failed')
+		expect(await invalidRuntime.cache.get(key)).toBeUndefined()
+	})
+
+	test('detaches and deeply freezes fresh, cached, and bypassed values', async () => {
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+		const producerValue = { ids: ['media-a'] }
+		const first = await getPublicSurfaceFragment(
+			fragmentOptions({
+				runtime,
+				getFreshValue: () => producerValue,
+			}),
+		)
+		producerValue.ids[0] = 'producer-poison'
+		expect(first).toEqual({ ids: ['media-a'] })
+		expect(Object.isFrozen(first)).toBe(true)
+		expect(Object.isFrozen(first.ids)).toBe(true)
+		expect(Reflect.set(first.ids, '0', 'consumer-poison')).toBe(false)
+
+		const second = await getPublicSurfaceFragment(
+			fragmentOptions({
+				runtime,
+				getFreshValue: () => ({ ids: ['unexpected'] }),
+			}),
+		)
+		expect(second).toEqual({ ids: ['media-a'] })
+		expect(second).not.toBe(first)
+		expect(second.ids).not.toBe(first.ids)
+		expect(Object.isFrozen(second)).toBe(true)
+		expect(Object.isFrozen(second.ids)).toBe(true)
+
+		const bypassed = await getPublicSurfaceFragment(
+			fragmentOptions({
+				runtime: createPublicSurfaceCacheRuntimeForTest({ bypass: true }),
+			}),
+		)
+		expect(Object.isFrozen(bypassed)).toBe(true)
+		expect(Object.isFrozen(bypassed.ids)).toBe(true)
+	})
+
+	test('records aggregate metrics for every family without payload data', async () => {
+		const privateText = 'private-member-id'
+		const runtime = createPublicSurfaceCacheRuntimeForTest()
+		for (const namespace of publicSurfaceCacheNamespaces) {
+			await getPublicSurfaceFragment(
+				fragmentOptions({
+					namespace,
+					keyPayload: { privateText },
+					runtime,
+				}),
+			)
+		}
+
+		const snapshot = getCacheOperationsSnapshot()
+		expect(Object.keys(snapshot).sort()).toEqual(
+			[...publicSurfaceCacheNamespaces].sort(),
+		)
+		for (const namespace of publicSurfaceCacheNamespaces) {
+			expect(snapshot[namespace]).toMatchObject({
+				miss: 1,
+				refresh: 1,
+			})
+		}
+		expect(JSON.stringify(snapshot)).not.toContain(privateText)
+	})
+})

--- a/app/utils/public-surface-cache.server.ts
+++ b/app/utils/public-surface-cache.server.ts
@@ -1,0 +1,205 @@
+import {
+	canonicalCachePayload,
+	createOpaqueCacheKey,
+	type CanonicalCacheValue,
+} from './cache-key.server.ts'
+import {
+	cachifiedSafely,
+	createMemoryCache,
+	SAFE_CACHE_MAX_TTL_MS,
+	type CacheMetricNamespace,
+	type InspectableMemoryCache,
+} from './cache.server.ts'
+import { type Timings } from './timing.server.ts'
+
+export const publicSurfaceCacheNamespaces = [
+	'anonymous-home-summary',
+	'home-trending-plan',
+	'discovery-facets',
+] as const satisfies readonly CacheMetricNamespace[]
+
+export type PublicSurfaceCacheNamespace =
+	(typeof publicSurfaceCacheNamespaces)[number]
+
+const publicSurfaceCacheNamespaceSet = new Set<string>(
+	publicSurfaceCacheNamespaces,
+)
+const publicSurfaceCacheRuntimeBrand = Symbol('public-surface-cache-runtime')
+
+export type PublicSurfaceCacheRuntime = Readonly<{
+	bypass: boolean
+	cache: InspectableMemoryCache
+	datasourceUrl: string
+	[publicSurfaceCacheRuntimeBrand]: true
+}>
+
+type PublicSurfaceFragmentOptions<Value extends CanonicalCacheValue> = {
+	namespace: PublicSurfaceCacheNamespace
+	keyVersion: number
+	keyPayload: CanonicalCacheValue
+	ttl: number
+	parse: (value: unknown) => Value
+	getFreshValue: () => Value | Promise<Value>
+	timings?: Timings
+	runtime?: PublicSurfaceCacheRuntime
+}
+
+function deepFreeze<Value extends CanonicalCacheValue>(value: Value): Value {
+	if (value === null || typeof value !== 'object') return value
+	if (Array.isArray(value)) {
+		for (const child of value as readonly CanonicalCacheValue[]) {
+			deepFreeze(child)
+		}
+	} else {
+		for (const child of Object.values(
+			value as Readonly<Record<string, CanonicalCacheValue>>,
+		)) {
+			deepFreeze(child)
+		}
+	}
+	return Object.freeze(value)
+}
+
+function canonicalCloneAndFreeze<Value extends CanonicalCacheValue>(
+	value: Value,
+): Value {
+	const canonical = canonicalCachePayload(value)
+	if (value === null || typeof value !== 'object') return value
+	return deepFreeze(JSON.parse(canonical) as Value)
+}
+
+function parseFragment<Value extends CanonicalCacheValue>(
+	parse: (value: unknown) => Value,
+	value: unknown,
+) {
+	return canonicalCloneAndFreeze(parse(value))
+}
+
+function validateBoundary(input: {
+	namespace: PublicSurfaceCacheNamespace
+	keyVersion: number
+	keyPayload: CanonicalCacheValue
+	ttl: number
+}) {
+	if (!publicSurfaceCacheNamespaceSet.has(input.namespace)) {
+		throw new TypeError('Public surface cache namespace is not registered.')
+	}
+	if (
+		!Number.isSafeInteger(input.keyVersion) ||
+		input.keyVersion < 1 ||
+		input.keyVersion > 1_000_000_000
+	) {
+		throw new TypeError('Public surface cache key version is invalid.')
+	}
+	if (
+		!Number.isFinite(input.ttl) ||
+		input.ttl <= 0 ||
+		input.ttl > SAFE_CACHE_MAX_TTL_MS
+	) {
+		throw new RangeError(
+			`Public surface cache ttl must be finite, positive, and no greater than ${SAFE_CACHE_MAX_TTL_MS} milliseconds.`,
+		)
+	}
+	canonicalCachePayload(input.keyPayload)
+}
+
+function isBypassed(runtime: PublicSurfaceCacheRuntime | undefined) {
+	if (runtime) {
+		if (
+			process.env.NODE_ENV !== 'test' ||
+			runtime[publicSurfaceCacheRuntimeBrand] !== true
+		) {
+			throw new Error(
+				'Public surface cache runtimes can only be used by tests.',
+			)
+		}
+		return runtime.bypass
+	}
+	return process.env.NODE_ENV === 'test' || process.env.VEUD_E2E === '1'
+}
+
+/**
+ * Creates an isolated cache runtime for boundary tests. Production callers
+ * cannot replace the shared cache or override bypass policy.
+ */
+export function createPublicSurfaceCacheRuntimeForTest({
+	bypass = false,
+	cache = createMemoryCache({ name: 'public-surface-test-cache' }),
+	datasourceUrl = 'file::memory:',
+}: {
+	bypass?: boolean
+	cache?: InspectableMemoryCache
+	datasourceUrl?: string
+} = {}): PublicSurfaceCacheRuntime {
+	if (process.env.NODE_ENV !== 'test') {
+		throw new Error(
+			'Public surface cache runtimes can only be created by tests.',
+		)
+	}
+	if (typeof bypass !== 'boolean') {
+		throw new TypeError('Public surface cache bypass must be a boolean.')
+	}
+	return Object.freeze({
+		bypass,
+		cache,
+		datasourceUrl,
+		[publicSurfaceCacheRuntimeBrand]: true as const,
+	})
+}
+
+/**
+ * Cache a bounded, schema-owned public fragment. Scope is always public and
+ * callers cannot provide raw keys, cache adapters, stale windows, or fallback
+ * behavior. The parse callback must reject every value outside the fragment's
+ * strict canonical JSON schema.
+ */
+export async function getPublicSurfaceFragment<
+	Value extends CanonicalCacheValue,
+>({
+	namespace,
+	keyVersion,
+	keyPayload,
+	ttl,
+	parse,
+	getFreshValue,
+	timings,
+	runtime,
+}: PublicSurfaceFragmentOptions<Value>): Promise<Value> {
+	validateBoundary({ namespace, keyVersion, keyPayload, ttl })
+	if (typeof parse !== 'function' || typeof getFreshValue !== 'function') {
+		throw new TypeError(
+			'Public surface cache requires parse and getFreshValue callbacks.',
+		)
+	}
+
+	if (isBypassed(runtime)) {
+		return parseFragment(parse, await getFreshValue())
+	}
+
+	const key = createOpaqueCacheKey({
+		namespace,
+		version: keyVersion,
+		scope: { kind: 'public' },
+		payload: keyPayload,
+		...(runtime ? { datasourceUrl: runtime.datasourceUrl } : {}),
+	})
+	const value = await cachifiedSafely(
+		namespace,
+		{
+			key,
+			ttl,
+			timings,
+			checkValue(cachedValue) {
+				try {
+					parseFragment(parse, cachedValue)
+					return true
+				} catch {
+					return false
+				}
+			},
+			getFreshValue: async () => parseFragment(parse, await getFreshValue()),
+		},
+		runtime?.cache,
+	)
+	return parseFragment(parse, value)
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "db:cutover:postgres": "node scripts/check-postgres-cutover.mjs",
     "db:loadtest:postgres": "node scripts/load-test-postgres-catalog.mjs",
     "db:migrate:postgres": "npm run prisma:postgres:check && prisma migrate deploy --schema=prisma/postgresql/schema.prisma",
+    "db:smoke:public-surfaces:postgres": "tsx scripts/smoke-public-surfaces-postgres.ts",
     "db:smoke:postgres": "tsx scripts/smoke-postgres.ts",
     "db:transfer:postgres": "node scripts/transfer-sqlite-to-postgres.mjs",
     "db:verify:postgres": "npm run prisma:postgres:check && prisma migrate status --schema=prisma/postgresql/schema.prisma && prisma migrate diff --exit-code --from-schema-datasource=prisma/postgresql/schema.prisma --to-schema-datamodel=prisma/postgresql/schema.prisma",

--- a/scripts/load-test-postgres-catalog.mjs
+++ b/scripts/load-test-postgres-catalog.mjs
@@ -7,6 +7,7 @@ import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import { PrismaClient } from '@prisma/client'
 import {
+	assertPublicSurfaceLoadBudgets,
 	assertRequiredQueryIndexes,
 	assertRequiredQueryRows,
 	assertSafeLoadDatabaseUrl,
@@ -484,7 +485,8 @@ async function insertCatalogContext(prisma, count, scheduleAnchor) {
 	)
 	await prisma.$executeRawUnsafe(
 		`INSERT INTO "CatalogFeedItem" (
-			"id", "provider", "kind", "feed", "rank", "observedAt", "mediaId"
+			"id", "provider", "kind", "feed", "rank", "audience",
+			"rankingScore", "rankingVersion", "observedAt", "mediaId"
 		)
 		SELECT
 			'${prefix}feed-' || n,
@@ -492,10 +494,19 @@ async function insertCatalogContext(prisma, count, scheduleAnchor) {
 			${kindSql()},
 			CASE n % 300 WHEN 0 THEN 'popular' ELSE 'trending' END,
 			(n / 100)::int,
+			(($1::int - n) + 1) * 10,
+			(1.0 / n::double precision),
+			3,
 			CURRENT_TIMESTAMP,
 			'${prefix}media-' || n
 		FROM generate_series(100, $1::int, 100) AS n
-		ON CONFLICT DO NOTHING`,
+		ON CONFLICT ("id") DO UPDATE SET
+			"feed" = EXCLUDED."feed",
+			"rank" = EXCLUDED."rank",
+			"audience" = EXCLUDED."audience",
+			"rankingScore" = EXCLUDED."rankingScore",
+			"rankingVersion" = EXCLUDED."rankingVersion",
+			"observedAt" = EXCLUDED."observedAt"`,
 		count,
 	)
 	await prisma.$executeRawUnsafe(
@@ -565,6 +576,29 @@ async function insertRepresentativeMemberBatch(
 			CURRENT_TIMESTAMP,
 			CURRENT_TIMESTAMP - ((n % 72) || ' hours')::interval
 		FROM generate_series($1::int, $2::int) AS n
+		ON CONFLICT DO NOTHING`,
+		start,
+		end,
+	)
+	await prisma.$executeRawUnsafe(
+		`INSERT INTO "MediaCollection" (
+			"id", "title", "description", "isPublic", "createdAt", "updatedAt",
+			"moderationStatus", "ownerId"
+		)
+		SELECT
+			'${prefix}collection-' || member_number || '-' || visibility.label,
+			'Representative ' || visibility.label || ' collection ' || member_number,
+			'Representative PostgreSQL public-surface collection fixture.',
+			visibility.is_public,
+			CURRENT_TIMESTAMP - ((member_number % 45) || ' days')::interval,
+			CURRENT_TIMESTAMP,
+			'visible',
+			'${prefix}member-' || member_number
+		FROM generate_series($1::int, $2::int) AS member_number
+		CROSS JOIN (VALUES
+			('public', true),
+			('private', false)
+		) AS visibility(label, is_public)
 		ON CONFLICT DO NOTHING`,
 		start,
 		end,
@@ -1010,6 +1044,11 @@ async function representativeCounts(prisma) {
 			 WHERE id LIKE '${prefix}occurrence-%') AS "releaseOccurrenceRows",
 			(SELECT COUNT(*)::int FROM "User" WHERE id LIKE '${prefix}member-%') AS "memberCount",
 			(SELECT COUNT(*)::int FROM "Watchlist" WHERE id LIKE '${prefix}watchlist-%') AS "watchlistRows",
+			(SELECT COUNT(*)::int FROM "MediaCollection"
+			 WHERE id LIKE '${prefix}collection-%') AS "collectionRows",
+			(SELECT COUNT(*)::int FROM "MediaCollection"
+			 WHERE id LIKE '${prefix}collection-%' AND "isPublic" = true
+			   AND "moderationStatus" = 'visible') AS "publicCollectionRows",
 			(SELECT COUNT(*)::int FROM "TrackingState" WHERE id LIKE '${prefix}tracking-%') AS "trackingRows",
 			(SELECT COUNT(*)::int FROM "TrackingState" AS tracking
 			 JOIN "Watchlist" AS watchlist ON watchlist.id = tracking."statusWatchlistId"
@@ -1225,8 +1264,63 @@ async function queryMetrics(prisma, count, shape, scheduleAnchor) {
 		[
 			'trending-feed',
 			`SELECT "mediaId" FROM "CatalogFeedItem"
-			 WHERE kind = $1 AND feed = $2 ORDER BY rank LIMIT 18`,
-			['movie', 'trending'],
+			 WHERE provider = $1
+			   AND kind = $2
+			   AND feed = $3
+			   AND "rankingScore" IS NOT NULL
+			   AND "rankingVersion" >= $4
+			   AND "observedAt" >= $5
+			 ORDER BY "observedAt" DESC, "rankingScore" DESC, rank ASC
+			 LIMIT 18`,
+			[
+				'tmdb',
+				'movie',
+				'trending',
+				3,
+				new Date(new Date(scheduleAnchor).getTime() - 8 * 24 * 60 * 60 * 1_000),
+			],
+		],
+		[
+			'popular-feed-fallback',
+			`SELECT "mediaId" FROM "CatalogFeedItem"
+			 WHERE provider = $1
+			   AND kind = $2
+			   AND feed = $3
+			   AND "rankingScore" IS NOT NULL
+			   AND "rankingVersion" >= $4
+			 ORDER BY "rankingScore" DESC, rank ASC, "mediaId" ASC
+			 LIMIT 18`,
+			['tmdb', 'movie', 'popular', 3],
+		],
+		[
+			'catalog-popularity-fallback',
+			`SELECT id FROM "Media"
+			 WHERE kind = $1
+			   AND title IS NOT NULL
+			   AND "catalogPopularity" IS NOT NULL
+			 ORDER BY "catalogPopularity" DESC, "releaseStart" DESC, title ASC
+			 LIMIT 18`,
+			['movie'],
+		],
+		[
+			'discovery-genre-facets',
+			`SELECT DISTINCT genres AS value
+			 FROM "Media"
+			 WHERE genres IS NOT NULL
+			   AND length(genres) BETWEEN 1 AND $1
+			 ORDER BY genres ASC
+			 LIMIT $2`,
+			[512, 4_097],
+		],
+		[
+			'discovery-status-facets',
+			`SELECT DISTINCT "releaseStatus" AS value
+			 FROM "Media"
+			 WHERE "releaseStatus" IS NOT NULL
+			   AND length("releaseStatus") BETWEEN 1 AND $1
+			 ORDER BY "releaseStatus" ASC
+			 LIMIT $2`,
+			[60, 257],
 		],
 		[
 			'calendar-media-range',
@@ -1317,6 +1411,20 @@ async function queryMetrics(prisma, count, shape, scheduleAnchor) {
 			 WHERE "authorId" = $1 AND "moderationStatus" = 'visible'
 			 ORDER BY "createdAt" DESC, id DESC LIMIT 100`,
 			[memberId],
+		),
+		await explain(
+			prisma,
+			'anonymous-public-collection-count',
+			`SELECT COUNT(*)::int
+			 FROM "MediaCollection" AS collection
+			 WHERE collection."isPublic" = true
+			   AND collection."moderationStatus" = 'visible'
+			   AND EXISTS (
+			     SELECT 1
+			     FROM "User" AS owner
+			     WHERE owner.id = collection."ownerId"
+			       AND owner."accountStatus" = 'active'
+			   )`,
 		),
 		await explain(
 			prisma,
@@ -1445,6 +1553,53 @@ async function runProfileLoaderSmoke({
 	}
 	const report = readJson(smokeReportPath, 'Profile loader smoke report')
 	fs.unlinkSync(smokeReportPath)
+	return report
+}
+
+async function runPublicSurfaceSmoke({ username, reportPath }) {
+	const smokeReportPath = `${reportPath}.public-surfaces.json`
+	if (fs.existsSync(smokeReportPath)) fs.unlinkSync(smokeReportPath)
+	const smokeScript = path.resolve('scripts/smoke-public-surfaces-postgres.ts')
+	const childArgs = [
+		'--import',
+		'tsx',
+		smokeScript,
+		'--username',
+		username,
+		'--report',
+		smokeReportPath,
+	]
+	await new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, childArgs, {
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				NODE_ENV: 'test',
+				CACHE_DATABASE_PATH: ':memory:',
+				SESSION_SECRET:
+					process.env.SESSION_SECRET ?? 'postgres-public-surface-smoke-only',
+			},
+			stdio: 'inherit',
+		})
+		child.once('error', reject)
+		child.once('exit', (code, signal) => {
+			if (code === 0) {
+				resolve()
+				return
+			}
+			reject(
+				new Error(
+					`Public-surface smoke failed (${signal ? `signal ${signal}` : `exit ${code}`})`,
+				),
+			)
+		})
+	})
+	if (!fs.existsSync(smokeReportPath)) {
+		throw new Error('Public-surface smoke did not write its report')
+	}
+	const report = readJson(smokeReportPath, 'Public-surface smoke report')
+	fs.unlinkSync(smokeReportPath)
+	assertPublicSurfaceLoadBudgets(report)
 	return report
 }
 
@@ -1794,6 +1949,8 @@ async function main() {
 			releaseOccurrenceRows: shape.releaseOccurrenceRows,
 			memberCount: shape.memberCount,
 			watchlistRows: shape.watchlistRows,
+			collectionRows: shape.collectionRows,
+			publicCollectionRows: shape.publicCollectionRows,
 			trackingRows: shape.trackingRows,
 			publicListTrackingRows: shape.publicListTrackingRows,
 			privateListTrackingRows: shape.privateListTrackingRows,
@@ -1840,6 +1997,7 @@ async function main() {
 			await prisma.$executeRawUnsafe('ANALYZE "Entry"')
 			await prisma.$executeRawUnsafe('ANALYZE "ActivityEvent"')
 			await prisma.$executeRawUnsafe('ANALYZE "Review"')
+			await prisma.$executeRawUnsafe('ANALYZE "MediaCollection"')
 			await prisma.$executeRawUnsafe('ANALYZE "DiaryEntry"')
 		}
 		const communityAggregates = shape.memberCount
@@ -1863,6 +2021,12 @@ async function main() {
 					expectedEntries: profileFixture.expectedEntries,
 					expectedActivity: 100,
 					unsafeActivityId: `${prefix}activity-unsafe-${profileFixture.memberNumber}`,
+					reportPath,
+				})
+			: null
+		const publicSurfaceSmoke = profileFixture.memberNumber
+			? await runPublicSurfaceSmoke({
+					username: 'load_catalog_member_1',
 					reportPath,
 				})
 			: null
@@ -1963,6 +2127,7 @@ async function main() {
 			},
 			communityAggregates,
 			profileLoaderSmoke,
+			publicSurfaceSmoke,
 			recovery: {
 				checkpointSha256,
 				interruptedAt: checkpoint.interruptedAt ?? null,
@@ -2006,6 +2171,11 @@ async function main() {
 		if (profileLoaderSmoke) {
 			console.log(
 				`Real profile loaders: overview=${profileLoaderSmoke.overview.wallMs}ms/${profileLoaderSmoke.overview.bytes}B, stats=${profileLoaderSmoke.stats.wallMs}ms/${profileLoaderSmoke.stats.bytes}B, activity=${profileLoaderSmoke.activity.wallMs}ms/${profileLoaderSmoke.activity.bytes}B.`,
+			)
+		}
+		if (publicSurfaceSmoke) {
+			console.log(
+				`Public surfaces: anonymous=${publicSurfaceSmoke.anonymousHome.coldQueries}/${publicSurfaceSmoke.anonymousHome.warmQueries}, signed trending=${publicSurfaceSmoke.signedTrending.coldQueries}/${publicSurfaceSmoke.signedTrending.warmQueries}, facets=${publicSurfaceSmoke.discoveryFacets.coldQueries}/${publicSurfaceSmoke.discoveryFacets.warmQueries} cold/warm queries.`,
 			)
 		}
 		console.log(`Report written: ${reportPath}`)

--- a/scripts/postgres-load-utils.mjs
+++ b/scripts/postgres-load-utils.mjs
@@ -161,6 +161,113 @@ export function assertRequiredQueryRows(queryPlans, requirements) {
 	throw error
 }
 
+export const publicSurfaceLoadBudgets = Object.freeze({
+	anonymousHome: Object.freeze({
+		coldQueries: 12,
+		warmQueries: 4,
+		coldSqlQueries: 20,
+		warmSqlQueries: 12,
+		payloadBytes: 128 * 1024,
+	}),
+	signedTrending: Object.freeze({
+		coldQueries: 6,
+		warmQueries: 2,
+		coldSqlQueries: 6,
+		warmSqlQueries: 2,
+		payloadBytes: 128 * 1024,
+	}),
+	discoveryFacets: Object.freeze({
+		coldQueries: 2,
+		warmQueries: 0,
+		coldSqlQueries: 2,
+		warmSqlQueries: 0,
+		payloadBytes: 48 * 1024,
+	}),
+})
+
+function publicSurfaceMeasurement(report, name) {
+	const measurement = report?.[name]
+	if (!measurement || typeof measurement !== 'object') {
+		throw new Error(`Public-surface smoke report is missing ${name}`)
+	}
+	for (const field of [
+		'coldQueries',
+		'warmQueries',
+		'coldSqlQueries',
+		'warmSqlQueries',
+		'payloadBytes',
+	]) {
+		if (!Number.isSafeInteger(measurement[field]) || measurement[field] < 0) {
+			throw new Error(
+				`Public-surface smoke ${name}.${field} must be a non-negative integer`,
+			)
+		}
+	}
+	return measurement
+}
+
+export function assertPublicSurfaceLoadBudgets(
+	report,
+	budgets = publicSurfaceLoadBudgets,
+) {
+	if (!report || typeof report !== 'object' || report.version !== 1) {
+		throw new Error('Public-surface smoke report must use version 1')
+	}
+	const failures = []
+	for (const [name, budget] of Object.entries(budgets)) {
+		const measurement = publicSurfaceMeasurement(report, name)
+		for (const field of [
+			'coldQueries',
+			'warmQueries',
+			'coldSqlQueries',
+			'warmSqlQueries',
+			'payloadBytes',
+		]) {
+			if (measurement[field] <= budget[field]) continue
+			failures.push({
+				surface: name,
+				field,
+				observed: measurement[field],
+				budget: budget[field],
+			})
+		}
+		if (measurement.warmQueries > measurement.coldQueries) {
+			failures.push({
+				surface: name,
+				field: 'warmQueries',
+				observed: measurement.warmQueries,
+				budget: measurement.coldQueries,
+			})
+		}
+		for (const phase of ['cold', 'warm']) {
+			const logicalField = `${phase}Queries`
+			const sqlField = `${phase}SqlQueries`
+			if (measurement[sqlField] >= measurement[logicalField]) continue
+			failures.push({
+				surface: name,
+				field: sqlField,
+				observed: measurement[sqlField],
+				budget: measurement[logicalField],
+				reason: 'below-logical-query-count',
+			})
+		}
+	}
+	if (!failures.length) return
+
+	const error = new Error(
+		`Public-surface load budgets exceeded: ${failures
+			.map(
+				failure =>
+					`${failure.surface}.${failure.field}=${failure.observed} ${
+						failure.reason === 'below-logical-query-count' ? '<' : '>'
+					} ${failure.budget}`,
+			)
+			.join('; ')}`,
+	)
+	error.budgetFailures = failures
+	throw error
+}
+
 export function bytesLabel(value) {
 	const bytes = Number(value)
 	if (!Number.isFinite(bytes) || bytes < 0) return 'unknown'
@@ -225,6 +332,8 @@ export function representativeLoadShape({
 	return {
 		memberCount,
 		watchlistRows: memberCount * 3,
+		collectionRows: memberCount * 2,
+		publicCollectionRows: memberCount,
 		trackingPerMember: effectiveTrackingPerMember,
 		trackingRows,
 		publicListTrackingRows:

--- a/scripts/postgres-load-utils.test.mjs
+++ b/scripts/postgres-load-utils.test.mjs
@@ -1,10 +1,12 @@
 import { expect, test } from 'vitest'
 import {
+	assertPublicSurfaceLoadBudgets,
 	assertRequiredQueryIndexes,
 	assertRequiredQueryRows,
 	assertSafeLoadDatabaseUrl,
 	bytesLabel,
 	calendarLoadWindow,
+	publicSurfaceLoadBudgets,
 	representativeProfileEntryShape,
 	representativeLoadShape,
 	summarizeDatabasePressure,
@@ -213,6 +215,78 @@ test('requires every representative query plan to return meaningful rows', () =>
 	])
 })
 
+test('enforces cold, warm, and payload budgets for public surfaces', () => {
+	const report = {
+		version: 1,
+		anonymousHome: {
+			coldQueries: 12,
+			warmQueries: 4,
+			coldSqlQueries: 19,
+			warmSqlQueries: 11,
+			payloadBytes: 40_000,
+		},
+		signedTrending: {
+			coldQueries: 6,
+			warmQueries: 2,
+			coldSqlQueries: 6,
+			warmSqlQueries: 2,
+			payloadBytes: 35_000,
+		},
+		discoveryFacets: {
+			coldQueries: 2,
+			warmQueries: 0,
+			coldSqlQueries: 2,
+			warmSqlQueries: 0,
+			payloadBytes: 12_000,
+		},
+	}
+
+	expect(publicSurfaceLoadBudgets.discoveryFacets.payloadBytes).toBe(48 * 1024)
+	expect(() => assertPublicSurfaceLoadBudgets(report)).not.toThrow()
+
+	report.anonymousHome.coldQueries = 13
+	report.discoveryFacets.warmQueries = 1
+	report.discoveryFacets.warmSqlQueries = 1
+	let failure
+	try {
+		assertPublicSurfaceLoadBudgets(report)
+	} catch (error) {
+		failure = error
+	}
+
+	expect(failure).toBeInstanceOf(Error)
+	expect(failure.message).toMatch(
+		/anonymousHome\.coldQueries=13.*discoveryFacets\.warmQueries=1/s,
+	)
+	expect(failure.budgetFailures).toEqual([
+		{
+			surface: 'anonymousHome',
+			field: 'coldQueries',
+			observed: 13,
+			budget: 12,
+		},
+		{
+			surface: 'discoveryFacets',
+			field: 'warmQueries',
+			observed: 1,
+			budget: 0,
+		},
+		{
+			surface: 'discoveryFacets',
+			field: 'warmSqlQueries',
+			observed: 1,
+			budget: 0,
+		},
+	])
+
+	report.anonymousHome.coldQueries = 12
+	report.discoveryFacets.warmQueries = 1
+	report.discoveryFacets.warmSqlQueries = 0
+	expect(() => assertPublicSurfaceLoadBudgets(report)).toThrow(
+		/discoveryFacets\.warmSqlQueries=0 < 1/,
+	)
+})
+
 test('derives a bounded representative catalog and member load shape', () => {
 	expect(
 		representativeLoadShape({
@@ -224,6 +298,8 @@ test('derives a bounded representative catalog and member load shape', () => {
 	).toEqual({
 		memberCount: 25,
 		watchlistRows: 75,
+		collectionRows: 50,
+		publicCollectionRows: 25,
 		trackingPerMember: 120,
 		trackingRows: 3_000,
 		publicListTrackingRows: 2_420,

--- a/scripts/smoke-public-surfaces-postgres.ts
+++ b/scripts/smoke-public-surfaces-postgres.ts
@@ -1,0 +1,345 @@
+#!/usr/bin/env -S npx tsx
+import 'dotenv/config'
+import fs from 'node:fs'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
+import {
+	assertPublicSurfaceLoadBudgets,
+	assertSafeLoadDatabaseUrl,
+} from './postgres-load-utils.mjs'
+
+const args = process.argv.slice(2)
+const knownArguments = new Set(['--username', '--report'])
+
+function valueFor(flag: string) {
+	const index = args.indexOf(flag)
+	if (index < 0) throw new Error(`${flag} is required`)
+	const value = args[index + 1]
+	if (!value || value.startsWith('--')) {
+		throw new Error(`${flag} requires a value`)
+	}
+	return value
+}
+
+function assertKnownArguments() {
+	for (let index = 0; index < args.length; index += 2) {
+		const flag = args[index]
+		if (!flag || !knownArguments.has(flag)) {
+			throw new Error(`Unknown argument: ${flag ?? '(missing)'}`)
+		}
+		if (!args[index + 1] || args[index + 1]!.startsWith('--')) {
+			throw new Error(`${flag} requires a value`)
+		}
+	}
+}
+
+function writePrivateJson(filename: string, value: unknown) {
+	fs.mkdirSync(path.dirname(filename), { recursive: true })
+	const partial = `${filename}.partial`
+	fs.writeFileSync(partial, `${JSON.stringify(value, null, 2)}\n`, {
+		mode: 0o600,
+	})
+	fs.renameSync(partial, filename)
+	fs.chmodSync(filename, 0o600)
+}
+
+function payloadBytes(value: unknown) {
+	return Buffer.byteLength(JSON.stringify(value))
+}
+
+async function main() {
+	assertKnownArguments()
+	assertSafeLoadDatabaseUrl(process.env.DATABASE_URL)
+	if (process.env.NODE_ENV !== 'test') {
+		throw new Error('Public-surface PostgreSQL smoke must run in test mode')
+	}
+
+	const username = valueFor('--username')
+	const reportPath = path.resolve(valueFor('--report'))
+	const [{ prisma }, anonymousHome, trending, discovery, publicCache, cache] =
+		await Promise.all([
+			import('#app/utils/db.server.ts'),
+			import('#app/utils/anonymous-home.server.ts'),
+			import('#app/utils/home-trending.server.ts'),
+			import('#app/utils/discovery.server.ts'),
+			import('#app/utils/public-surface-cache.server.ts'),
+			import('#app/utils/cache.server.ts'),
+		])
+
+	let activeMeasurement: { queries: number; sqlQueries: number } | null = null
+	prisma.$on('query', () => {
+		if (activeMeasurement) activeMeasurement.sqlQueries += 1
+	})
+
+	type InstrumentedOperation = (...args: never[]) => unknown
+	function instrumentOperation(target: object, operation: string) {
+		const delegate = target as Record<string, InstrumentedOperation>
+		const original = delegate[operation]
+		if (typeof original !== 'function') {
+			throw new Error(`Cannot instrument Prisma operation ${operation}`)
+		}
+		Object.defineProperty(target, operation, {
+			configurable: true,
+			value: (...operationArgs: never[]) => {
+				if (activeMeasurement) activeMeasurement.queries += 1
+				return original.apply(target, operationArgs)
+			},
+		})
+	}
+	for (const [delegate, operations] of [
+		[prisma.media, ['count', 'groupBy', 'findMany']],
+		[prisma.review, ['count', 'findMany']],
+		[prisma.mediaCollection, ['count', 'findMany']],
+		[prisma.activityEvent, ['findMany']],
+		[prisma.catalogFeedItem, ['findMany']],
+		[prisma.trackingState, ['findMany']],
+		[prisma, ['$queryRaw']],
+	] as const) {
+		for (const operation of operations) {
+			instrumentOperation(delegate, operation)
+		}
+	}
+	let smokeFixture:
+		| {
+				activityId: string
+				reviewId: string
+				collectionId: string
+		  }
+		| undefined
+
+	async function measured<Value>(operation: () => Promise<Value>) {
+		if (activeMeasurement) {
+			throw new Error('Public-surface measurements may not overlap')
+		}
+		const measurement = { queries: 0, sqlQueries: 0 }
+		activeMeasurement = measurement
+		const started = performance.now()
+		try {
+			const value = await operation()
+			return {
+				value,
+				queries: measurement.queries,
+				sqlQueries: measurement.sqlQueries,
+				wallMs: Number((performance.now() - started).toFixed(3)),
+			}
+		} finally {
+			activeMeasurement = null
+		}
+	}
+
+	try {
+		const viewer = await prisma.user.findUniqueOrThrow({
+			where: { username },
+			select: { id: true },
+		})
+		const media = await prisma.media.findFirstOrThrow({
+			where: {
+				id: { startsWith: 'load-catalog-media-' },
+				reviews: { none: { authorId: viewer.id } },
+			},
+			orderBy: { id: 'asc' },
+			select: { id: true },
+		})
+		const fixtureSuffix = `${process.pid}-${Date.now()}`
+		smokeFixture = {
+			activityId: `public-smoke-activity-${fixtureSuffix}`,
+			reviewId: `public-smoke-review-${fixtureSuffix}`,
+			collectionId: `public-smoke-collection-${fixtureSuffix}`,
+		}
+		const fixtureNow = Date.now()
+		await Promise.all([
+			prisma.activityEvent.create({
+				data: {
+					id: smokeFixture.activityId,
+					type: 'score',
+					score: 8,
+					isPublic: true,
+					publicEligible: true,
+					createdAt: new Date(fixtureNow),
+					actorId: viewer.id,
+					mediaId: media.id,
+				},
+			}),
+			prisma.review.create({
+				data: {
+					id: smokeFixture.reviewId,
+					body: 'Representative public-surface smoke review.',
+					createdAt: new Date(fixtureNow - 1_000),
+					authorId: viewer.id,
+					mediaId: media.id,
+				},
+			}),
+			prisma.mediaCollection.create({
+				data: {
+					id: smokeFixture.collectionId,
+					title: 'Representative public-surface smoke collection',
+					createdAt: new Date(fixtureNow - 2_000),
+					ownerId: viewer.id,
+				},
+			}),
+		])
+
+		const anonymousRuntime =
+			publicCache.createPublicSurfaceCacheRuntimeForTest()
+		const loadAnonymousHome = () =>
+			Promise.all([
+				anonymousHome.getAnonymousHomeProof({
+					cacheRuntime: anonymousRuntime,
+				}),
+				trending.getHomeTrending(null, { runtime: anonymousRuntime }),
+			]).then(([proof, rails]) => ({ proof, rails }))
+		const anonymousCold = await measured(loadAnonymousHome)
+		const anonymousWarm = await measured(loadAnonymousHome)
+
+		const signedRuntime = publicCache.createPublicSurfaceCacheRuntimeForTest()
+		const loadSignedTrending = () =>
+			trending.getHomeTrending(viewer.id, { runtime: signedRuntime })
+		const signedCold = await measured(loadSignedTrending)
+		const signedWarm = await measured(loadSignedTrending)
+
+		const facetsRuntime = publicCache.createPublicSurfaceCacheRuntimeForTest()
+		const loadFacets = () =>
+			discovery.getDiscoveryFacets({ runtime: facetsRuntime })
+		const facetsCold = await measured(loadFacets)
+		const facetsWarm = await measured(loadFacets)
+
+		for (const [label, rails] of [
+			['anonymous', anonymousCold.value.rails],
+			['signed', signedCold.value],
+		] as const) {
+			if (
+				rails.length !== 4 ||
+				rails.some(rail => rail.items.length < 1 || rail.items.length > 18)
+			) {
+				throw new Error(
+					`${label} trending did not return four nonempty bounded rails`,
+				)
+			}
+			if (
+				rails.some(
+					rail =>
+						new Set(rail.items.map(item => item.id)).size !== rail.items.length,
+				)
+			) {
+				throw new Error(`${label} trending returned duplicate rail items`)
+			}
+		}
+		if (
+			anonymousCold.value.rails.some(rail =>
+				rail.items.some(item => item.viewerTracking !== null),
+			)
+		) {
+			throw new Error('Anonymous trending exposed viewer tracking state')
+		}
+		if (
+			!signedCold.value.some(rail =>
+				rail.items.some(item => item.viewerTracking !== null),
+			)
+		) {
+			throw new Error(
+				'Signed trending did not exercise owner-scoped tracking hydration',
+			)
+		}
+		if (
+			anonymousCold.value.proof.catalogTotal < 1 ||
+			anonymousCold.value.proof.reviewTotal < 1 ||
+			anonymousCold.value.proof.publicCollectionTotal < 1 ||
+			anonymousCold.value.proof.activity.length < 1
+		) {
+			throw new Error(
+				'Anonymous home did not exercise catalog, review, collection, and activity data',
+			)
+		}
+		const activityKinds = new Set(
+			anonymousCold.value.proof.activity.map(item => item.kind),
+		)
+		for (const expectedKind of ['tracking', 'review', 'collection'] as const) {
+			if (activityKinds.has(expectedKind)) continue
+			throw new Error(
+				`Anonymous home did not exercise ${expectedKind} activity`,
+			)
+		}
+		if (
+			facetsCold.value.genres.length < 1 ||
+			facetsCold.value.genres.length > discovery.DISCOVERY_GENRE_LIMIT ||
+			facetsCold.value.statuses.length < 1 ||
+			facetsCold.value.statuses.length > discovery.DISCOVERY_STATUS_LIMIT
+		) {
+			throw new Error('Discovery facets were empty or exceeded cardinality')
+		}
+
+		const report = {
+			version: 1,
+			measuredAt: new Date().toISOString(),
+			anonymousHome: {
+				coldQueries: anonymousCold.queries,
+				warmQueries: anonymousWarm.queries,
+				coldSqlQueries: anonymousCold.sqlQueries,
+				warmSqlQueries: anonymousWarm.sqlQueries,
+				payloadBytes: payloadBytes(anonymousWarm.value),
+				coldWallMs: anonymousCold.wallMs,
+				warmWallMs: anonymousWarm.wallMs,
+				activityItems: anonymousWarm.value.proof.activity.length,
+				railItems: anonymousWarm.value.rails.reduce(
+					(total, rail) => total + rail.items.length,
+					0,
+				),
+			},
+			signedTrending: {
+				coldQueries: signedCold.queries,
+				warmQueries: signedWarm.queries,
+				coldSqlQueries: signedCold.sqlQueries,
+				warmSqlQueries: signedWarm.sqlQueries,
+				payloadBytes: payloadBytes(signedWarm.value),
+				coldWallMs: signedCold.wallMs,
+				warmWallMs: signedWarm.wallMs,
+				railItems: signedWarm.value.reduce(
+					(total, rail) => total + rail.items.length,
+					0,
+				),
+				trackedItems: signedWarm.value.reduce(
+					(total, rail) =>
+						total +
+						rail.items.filter(item => item.viewerTracking !== null).length,
+					0,
+				),
+			},
+			discoveryFacets: {
+				coldQueries: facetsCold.queries,
+				warmQueries: facetsWarm.queries,
+				coldSqlQueries: facetsCold.sqlQueries,
+				warmSqlQueries: facetsWarm.sqlQueries,
+				payloadBytes: payloadBytes(facetsWarm.value),
+				coldWallMs: facetsCold.wallMs,
+				warmWallMs: facetsWarm.wallMs,
+				genres: facetsWarm.value.genres.length,
+				statuses: facetsWarm.value.statuses.length,
+				truncated: facetsWarm.value.truncated,
+			},
+			cacheOperations: cache.getCacheOperationsSnapshot(),
+		}
+		assertPublicSurfaceLoadBudgets(report)
+		writePrivateJson(reportPath, report)
+		console.log(
+			`Public-surface smoke passed: anonymous ${report.anonymousHome.coldQueries}/${report.anonymousHome.warmQueries}, signed trending ${report.signedTrending.coldQueries}/${report.signedTrending.warmQueries}, facets ${report.discoveryFacets.coldQueries}/${report.discoveryFacets.warmQueries} cold/warm queries.`,
+		)
+	} finally {
+		if (smokeFixture) {
+			await Promise.all([
+				prisma.activityEvent.deleteMany({
+					where: { id: smokeFixture.activityId },
+				}),
+				prisma.review.deleteMany({ where: { id: smokeFixture.reviewId } }),
+				prisma.mediaCollection.deleteMany({
+					where: { id: smokeFixture.collectionId },
+				}),
+			])
+		}
+		await prisma.$disconnect()
+	}
+}
+
+main().catch(error => {
+	console.error(error)
+	process.exitCode = 1
+})


### PR DESCRIPTION
## What changed

- add a bounded, schema-owned cache for anonymous aggregate summaries, home trending ID plans, and discovery facets
- keep activity identities, current media metadata, viewer tracking, session state, and route responses fresh and outside the cache
- short-circuit trending fallbacks, bound native facet queries, and expose aggregate-only cache counters on the protected operations dashboard
- enforce `private, no-store` through root and nested profile/settings header composition
- extend the PostgreSQL release/scale harness with real cold/warm loader budgets, payload ceilings, representative collections, and production-shaped plans

## Why

The anonymous home and discovery surfaces repeated slow-changing public work on every request, while whole-response caching would be unsafe because root and child loaders include viewer/session state. This implements only the bounded public fragment layer supported by the privacy and freshness model.

## Validation

- independent adversarial integration, security, and release reviews: clean
- focused: 10 files / 127 tests
- full SQLite: 171 files / 979 tests
- coverage: 66.27% statements, 55.13% branches, 62.28% functions, 67.78% lines
- full release static, production build, and bundle budgets: pass
- Chromium: 98/98
- disposable PostgreSQL release and 100,000-media scale gates: pass, including drift, smoke, query/payload budgets, plan checks, cleanup, database drop, and SQLite client restoration

No schema/index change was added: the measured 100,000-row plans use existing indexes and the representative public-collection count completes in 1.322 ms.