### PR TITLE
Batch Tip of My Tongue catalog resolution

### DIFF
--- a/app/utils/catalog-candidates.server.test.ts
+++ b/app/utils/catalog-candidates.server.test.ts
@@ -1,0 +1,509 @@
+import { expect, test } from 'vitest'
+import {
+	combinedLexicalTerms,
+	containsPattern,
+	findCatalogCandidateIds,
+	findSuggestionCandidateIds,
+	hydrateCatalogCandidates,
+	lexicalTerms,
+	MAX_CATALOG_CANDIDATES,
+	MAX_LEXICAL_TERMS,
+	MAX_SUGGESTION_EXACT_TITLES,
+	MAX_SUGGESTION_TITLE_TERMS,
+} from './catalog-candidates.server.ts'
+import { prisma } from './db.server.ts'
+
+async function seedMedia(
+	rows: Array<{
+		title: string
+		kind?: string
+		description?: string
+		genres?: string
+		popularity?: number
+		alternateTitles?: string[]
+	}>,
+) {
+	const created = []
+	for (const row of rows) {
+		const media = await prisma.media.create({
+			data: {
+				kind: row.kind ?? 'movie',
+				title: row.title,
+				description: row.description ?? null,
+				genres: row.genres ?? null,
+				catalogPopularity: row.popularity ?? 0,
+				...(row.alternateTitles?.length
+					? {
+							titles: {
+								create: row.alternateTitles.map(value => ({
+									provider: 'test',
+									titleType: 'alternate',
+									value,
+									normalized: value.toLowerCase(),
+									isPrimary: false,
+								})),
+							},
+						}
+					: {}),
+			},
+			select: { id: true, title: true },
+		})
+		created.push(media)
+	}
+	return created
+}
+
+test('lexical terms normalize once, drop noise, and stay capped', () => {
+	expect(lexicalTerms('The a an of')).toEqual([])
+	expect(lexicalTerms('ab xy')).toEqual([])
+	// Repetition ranks a term higher without adding query work.
+	expect(lexicalTerms('lighthouse keeper lighthouse')[0]).toBe('lighthouse')
+	// Unicode is normalized rather than rejected.
+	expect(lexicalTerms('Café Society')).toContain('cafe')
+	const many = Array.from({ length: 40 }, (_, index) => `term${index}`).join(
+		' ',
+	)
+	expect(lexicalTerms(many)).toHaveLength(MAX_LEXICAL_TERMS)
+	// Hostile input cannot widen the search.
+	expect(lexicalTerms('%%% ___ \\\\\\')).toEqual([])
+	expect(lexicalTerms('x'.repeat(5000))).toHaveLength(1)
+})
+
+test('combined terms share one budget across prompt and expansions', () => {
+	const prompt = Array.from({ length: 8 }, (_, i) => `prompt${i}`).join(' ')
+	const expansions = Array.from({ length: 30 }, (_, i) => `extra${i}`)
+	const combined = combinedLexicalTerms(prompt, expansions)
+	expect(combined).toHaveLength(MAX_LEXICAL_TERMS)
+	// The prompt keeps priority; expansions only fill the remainder.
+	expect(combined.slice(0, 8).every(term => term.startsWith('prompt'))).toBe(
+		true,
+	)
+	const full = Array.from({ length: 20 }, (_, i) => `full${i}`).join(' ')
+	expect(combinedLexicalTerms(full, expansions)).toHaveLength(MAX_LEXICAL_TERMS)
+})
+
+test('wildcards in member text stay literal search characters', () => {
+	expect(containsPattern('50%')).toBe('%50!%%')
+	expect(containsPattern('a_b')).toBe('%a!_b%')
+	expect(containsPattern('bang!')).toBe('%bang!!%')
+})
+
+test('candidate identifiers come from one query and respect the kind boundary', async () => {
+	const seeded = await seedMedia([
+		{ title: 'Cobalt Lighthouse', kind: 'movie', popularity: 90 },
+		{ title: 'Cobalt Harbor', kind: 'anime', popularity: 95 },
+		{
+			title: 'Amber Journal',
+			kind: 'movie',
+			description: 'A keeper finds a cobalt journal.',
+			popularity: 10,
+		},
+	])
+	const queries: string[] = []
+	const detach = attachQueryRecorder(queries)
+	try {
+		const movieIds = await findCatalogCandidateIds({
+			kind: 'movie',
+			terms: ['cobalt'],
+			popularLimit: 0,
+		})
+		expect(queries).toHaveLength(1)
+		expect(movieIds).toContain(seeded[0]!.id)
+		expect(movieIds).toContain(seeded[2]!.id)
+		// The requested kind is authoritative.
+		expect(movieIds).not.toContain(seeded[1]!.id)
+
+		// A canonical title match outranks a description-only match.
+		expect(movieIds.indexOf(seeded[0]!.id)).toBeLessThan(
+			movieIds.indexOf(seeded[2]!.id),
+		)
+	} finally {
+		detach()
+		await prisma.media.deleteMany({
+			where: { id: { in: seeded.map(item => item.id) } },
+		})
+	}
+})
+
+test('alternate normalized titles are matched without a correlated subquery', async () => {
+	const seeded = await seedMedia([
+		{
+			title: 'Unrelated Canonical',
+			kind: 'anime',
+			alternateTitles: ['Kurenai Tousen'],
+			popularity: 5,
+		},
+	])
+	try {
+		const ids = await findCatalogCandidateIds({
+			kind: 'anime',
+			terms: ['kurenai'],
+			popularLimit: 0,
+		})
+		expect(ids).toEqual([seeded[0]!.id])
+	} finally {
+		await prisma.media.deleteMany({
+			where: { id: { in: seeded.map(item => item.id) } },
+		})
+	}
+})
+
+test('serialized genres never seed candidates', async () => {
+	const seeded = await seedMedia([
+		{ title: 'Genre Only', kind: 'movie', genres: 'Psychological Thriller' },
+	])
+	try {
+		// Genre text is a ranking signal after hydration, never an index-less
+		// leading scan.
+		expect(
+			await findCatalogCandidateIds({
+				kind: 'movie',
+				terms: ['psychological'],
+				popularLimit: 0,
+			}),
+		).toEqual([])
+	} finally {
+		await prisma.media.deleteMany({
+			where: { id: { in: seeded.map(item => item.id) } },
+		})
+	}
+})
+
+test('literal wildcards cannot broaden a candidate search', async () => {
+	const seeded = await seedMedia([
+		{ title: 'Plain Title', kind: 'movie' },
+		{ title: 'Has 50% Off', kind: 'movie' },
+	])
+	try {
+		const ids = await findCatalogCandidateIds({
+			kind: 'movie',
+			terms: ['50%'],
+			popularLimit: 0,
+		})
+		// A bare `%` term would otherwise match every row.
+		expect(ids).not.toContain(seeded[0]!.id)
+	} finally {
+		await prisma.media.deleteMany({
+			where: { id: { in: seeded.map(item => item.id) } },
+		})
+	}
+})
+
+test('every AI hypothesis resolves through one batched lookup', async () => {
+	const seeded = await seedMedia([
+		{ title: 'First Hypothesis', kind: 'movie', popularity: 50 },
+		{ title: 'Second Hypothesis', kind: 'movie', popularity: 40 },
+		{ title: 'Third Hypothesis', kind: 'movie', popularity: 30 },
+		{ title: 'Fourth Hypothesis', kind: 'movie', popularity: 20 },
+		{ title: 'Fifth Hypothesis', kind: 'movie', popularity: 10 },
+	])
+	const queries: string[] = []
+	const detach = attachQueryRecorder(queries)
+	try {
+		const ids = await findSuggestionCandidateIds({
+			suggestions: seeded.map(item => ({
+				kind: 'movie',
+				exactTitles: [item.title!.toLowerCase()],
+				titleTerms: ['hypothesis'],
+			})),
+		})
+		// One query for five hypotheses, not one per hypothesis.
+		expect(queries).toHaveLength(1)
+		for (const item of seeded) expect(ids).toContain(item.id)
+	} finally {
+		detach()
+		await prisma.media.deleteMany({
+			where: { id: { in: seeded.map(item => item.id) } },
+		})
+	}
+})
+
+test('suggestion lookups enforce their exact-title and term budgets', async () => {
+	const queries: string[] = []
+	const detach = attachQueryRecorder(queries)
+	try {
+		await findSuggestionCandidateIds({
+			suggestions: Array.from({ length: 40 }, (_, index) => ({
+				kind: `kind${index}`,
+				exactTitles: Array.from(
+					{ length: 60 },
+					(_, i) => `title ${index}-${i}`,
+				),
+				titleTerms: Array.from({ length: 200 }, (_, i) => `term${index}-${i}`),
+			})),
+		})
+		expect(queries).toHaveLength(1)
+		const sql = queries[0]!
+		// Bound parameters, not interpolated text, and capped in every dimension.
+		// Each exact title emits a canonical-equality and an alternate-title
+		// branch, so count distinct titles rather than bindings.
+		const distinctTitles = new Set(sql.match(/title \d+-\d+/g) ?? [])
+		expect(distinctTitles.size).toBeLessThanOrEqual(MAX_SUGGESTION_EXACT_TITLES)
+		const distinctTerms = new Set(sql.match(/term\d+-\d+/g) ?? [])
+		expect(distinctTerms.size).toBeLessThanOrEqual(MAX_SUGGESTION_TITLE_TERMS)
+	} finally {
+		detach()
+	}
+})
+
+test('empty and unusable input issues no candidate query at all', async () => {
+	const queries: string[] = []
+	const detach = attachQueryRecorder(queries)
+	try {
+		expect(
+			await findSuggestionCandidateIds({
+				suggestions: [{ kind: 'movie', exactTitles: [], titleTerms: [] }],
+			}),
+		).toEqual([])
+		expect(
+			await findCatalogCandidateIds({
+				kind: 'movie',
+				terms: [],
+				popularLimit: 0,
+			}),
+		).toEqual([])
+		expect(queries).toHaveLength(0)
+	} finally {
+		detach()
+	}
+})
+
+test('hydration is one bounded read that preserves candidate order', async () => {
+	const seeded = await seedMedia([
+		{ title: 'Order One', kind: 'movie' },
+		{ title: 'Order Two', kind: 'movie' },
+		{ title: 'Order Three', kind: 'movie' },
+	])
+	const queries: string[] = []
+	const detach = attachQueryRecorder(queries)
+	try {
+		const requested = [seeded[2]!.id, seeded[0]!.id, seeded[1]!.id]
+		const hydrated = await hydrateCatalogCandidates(requested)
+		expect(queries).toHaveLength(1)
+		expect(hydrated.map(item => item.id)).toEqual(requested)
+		// Unknown identifiers are dropped rather than producing holes.
+		const withMissing = await hydrateCatalogCandidates([
+			'missing-id',
+			seeded[0]!.id,
+		])
+		expect(withMissing.map(item => item.id)).toEqual([seeded[0]!.id])
+		// The hydration ceiling is enforced regardless of the caller.
+		const overflow = Array.from(
+			{ length: MAX_CATALOG_CANDIDATES + 40 },
+			(_, index) => `absent-${index}`,
+		)
+		expect(await hydrateCatalogCandidates(overflow)).toEqual([])
+	} finally {
+		detach()
+		await prisma.media.deleteMany({
+			where: { id: { in: seeded.map(item => item.id) } },
+		})
+	}
+})
+
+/**
+ * Record the SQL of every raw candidate query so budgets and round-trip counts
+ * are asserted against real behavior rather than source text.
+ */
+function attachQueryRecorder(sink: string[]) {
+	const originalQueryRaw = prisma.$queryRaw.bind(prisma)
+	const originalFindMany = prisma.media.findMany.bind(prisma.media)
+	Object.assign(prisma, {
+		$queryRaw: (query: unknown, ...values: unknown[]) => {
+			const sql = (query as { sql?: string; strings?: string[] })?.sql
+			const text =
+				typeof sql === 'string'
+					? sql
+					: ((query as { strings?: string[] })?.strings ?? []).join('?')
+			const bound = ((query as { values?: unknown[] })?.values ?? [])
+				.map(value => String(value))
+				.join(' ')
+			sink.push(`${text} :: ${bound}`)
+			return originalQueryRaw(query as never, ...(values as never[]))
+		},
+	})
+	Object.assign(prisma.media, {
+		findMany: (args: unknown) => {
+			sink.push('findMany :: media')
+			return originalFindMany(args as never)
+		},
+	})
+	return () => {
+		Object.assign(prisma, { $queryRaw: originalQueryRaw })
+		Object.assign(prisma.media, { findMany: originalFindMany })
+	}
+}
+
+test('a canonical title with no alternate-title rows is still reachable', async () => {
+	// Short titles produce no lexical terms, so canonical-title equality is the
+	// only path that can find them.
+	const seeded = await seedMedia([{ title: 'Up', kind: 'movie' }])
+	try {
+		const ids = await findSuggestionCandidateIds({
+			suggestions: [{ kind: 'movie', exactTitles: ['up'], titleTerms: [] }],
+		})
+		expect(ids).toEqual([seeded[0]!.id])
+	} finally {
+		await prisma.media.deleteMany({
+			where: { id: { in: seeded.map(item => item.id) } },
+		})
+	}
+})
+
+test('one crowded hypothesis cannot starve the others of candidates', async () => {
+	// The crowd must compete at the SAME source rank as the victims, otherwise a
+	// shared pool would still rank the victims first and the test would pass
+	// without proving per-hypothesis allocation. 80 rows share hypothesis one's
+	// exact title with high popularity; the other four hypotheses match a single
+	// low-popularity row each.
+	const crowd = await seedMedia(
+		Array.from({ length: 80 }, (_, index) => ({
+			title: 'Crowded Signal',
+			kind: 'movie',
+			popularity: 500 + index,
+		})),
+	)
+	const distinct = await seedMedia([
+		{ title: 'Lonely Beacon', kind: 'movie', popularity: 1 },
+		{ title: 'Quiet Harbor', kind: 'movie', popularity: 1 },
+		{ title: 'Still Water', kind: 'movie', popularity: 1 },
+		{ title: 'Empty Road', kind: 'movie', popularity: 1 },
+	])
+	try {
+		const ids = await findSuggestionCandidateIds({
+			suggestions: [
+				{ kind: 'movie', exactTitles: ['crowded signal'], titleTerms: [] },
+				{ kind: 'movie', exactTitles: ['lonely beacon'], titleTerms: [] },
+				{ kind: 'movie', exactTitles: ['quiet harbor'], titleTerms: [] },
+				{ kind: 'movie', exactTitles: ['still water'], titleTerms: [] },
+				{ kind: 'movie', exactTitles: ['empty road'], titleTerms: [] },
+			],
+		})
+		// Every hypothesis keeps its own guaranteed slots even though the crowd
+		// could otherwise fill the entire shared budget.
+		for (const item of distinct) expect(ids).toContain(item.id)
+		// And the crowded hypothesis is held to its share rather than the whole
+		// pool.
+		const crowdIds = new Set(crowd.map(item => item.id))
+		expect(ids.filter(id => crowdIds.has(id)).length).toBeLessThan(crowd.length)
+	} finally {
+		await prisma.media.deleteMany({
+			where: {
+				id: { in: [...crowd, ...distinct].map(item => item.id) },
+			},
+		})
+	}
+})
+
+test('the full candidate budget stays usable instead of being truncated', async () => {
+	// One hypothesis matching 20 rows and four matching one each is well inside
+	// the 72-candidate budget: a hard per-hypothesis cut would drop rows while
+	// most of the budget sat idle.
+	const crowd = await seedMedia(
+		Array.from({ length: 20 }, (_, index) => ({
+			title: 'Recall Signal',
+			kind: 'movie',
+			popularity: 100 + index,
+		})),
+	)
+	const distinct = await seedMedia([
+		{ title: 'Recall Alpha', kind: 'movie', popularity: 1 },
+		{ title: 'Recall Beta', kind: 'movie', popularity: 1 },
+		{ title: 'Recall Gamma', kind: 'movie', popularity: 1 },
+		{ title: 'Recall Delta', kind: 'movie', popularity: 1 },
+	])
+	try {
+		const ids = await findSuggestionCandidateIds({
+			suggestions: [
+				{ kind: 'movie', exactTitles: ['recall signal'], titleTerms: [] },
+				{ kind: 'movie', exactTitles: ['recall alpha'], titleTerms: [] },
+				{ kind: 'movie', exactTitles: ['recall beta'], titleTerms: [] },
+				{ kind: 'movie', exactTitles: ['recall gamma'], titleTerms: [] },
+				{ kind: 'movie', exactTitles: ['recall delta'], titleTerms: [] },
+			],
+		})
+		// Nothing is dropped: 20 + 4 all fit inside the budget.
+		for (const item of [...crowd, ...distinct]) expect(ids).toContain(item.id)
+	} finally {
+		await prisma.media.deleteMany({
+			where: { id: { in: [...crowd, ...distinct].map(item => item.id) } },
+		})
+	}
+})
+
+test('every hypothesis keeps a reserved share of the term budget', async () => {
+	// A verbose first hypothesis must not consume the shared term budget and
+	// leave later hypotheses with no fuzzy matching.
+	const seeded = await seedMedia([
+		{ title: 'Reserved Zulu', kind: 'movie' },
+		{ title: 'Reserved Yankee', kind: 'movie' },
+	])
+	try {
+		const ids = await findSuggestionCandidateIds({
+			suggestions: [
+				{
+					kind: 'movie',
+					exactTitles: [],
+					titleTerms: Array.from({ length: 60 }, (_, i) => `verbose${i}`),
+				},
+				{ kind: 'movie', exactTitles: [], titleTerms: ['zulu'] },
+				{ kind: 'movie', exactTitles: [], titleTerms: ['yankee'] },
+			],
+		})
+		for (const item of seeded) expect(ids).toContain(item.id)
+	} finally {
+		await prisma.media.deleteMany({
+			where: { id: { in: seeded.map(item => item.id) } },
+		})
+	}
+})
+
+test('the PostgreSQL dialect emits index-visible predicates, not LOWER()', async () => {
+	// The load test measures hand-written copies of these shapes, so it cannot
+	// catch the application regressing. This asserts the SQL the application
+	// actually emits: LOWER(column) hides the GIN trigram indexes, ILIKE does
+	// not.
+	const queries: string[] = []
+	const detach = attachQueryRecorder(queries)
+	const postgresUrl = 'postgresql://user@127.0.0.1:5432/veud?schema=public'
+	try {
+		await findCatalogCandidateIds({
+			kind: 'movie',
+			terms: ['lighthouse'],
+			popularLimit: 0,
+			databaseUrl: postgresUrl,
+		}).catch(() => undefined)
+		await findSuggestionCandidateIds({
+			suggestions: [
+				{ kind: 'movie', exactTitles: ['exact title'], titleTerms: ['term'] },
+			],
+			databaseUrl: postgresUrl,
+		}).catch(() => undefined)
+		expect(queries).toHaveLength(2)
+		for (const sql of queries) {
+			expect(sql).toContain('ILIKE')
+			expect(sql).not.toContain('LOWER(')
+			expect(sql).toContain("ESCAPE '!'")
+		}
+	} finally {
+		detach()
+	}
+})
+
+test('the SQLite dialect never emits PostgreSQL-only ILIKE', async () => {
+	const queries: string[] = []
+	const detach = attachQueryRecorder(queries)
+	try {
+		await findCatalogCandidateIds({
+			kind: 'movie',
+			terms: ['lighthouse'],
+			popularLimit: 0,
+			databaseUrl: 'file:./tests/prisma/data.db',
+		})
+		expect(queries).toHaveLength(1)
+		expect(queries[0]).not.toContain('ILIKE')
+		expect(queries[0]).toContain('LIKE')
+	} finally {
+		detach()
+	}
+})

--- a/app/utils/catalog-candidates.server.ts
+++ b/app/utils/catalog-candidates.server.ts
@@ -1,0 +1,488 @@
+import { Prisma } from '@prisma/client'
+import { normalizeCatalogTitle } from './catalog-sync.server.ts'
+import { prisma } from './db.server.ts'
+import {
+	escapeSqlLikeLiteral,
+	isPostgresDatasource,
+} from './prisma-search.server.ts'
+
+/**
+ * Relation-free catalog candidate repository.
+ *
+ * Tip of My Tongue used to fan out one query per search term and per AI
+ * hypothesis, so its database work grew with prompt length rather than staying
+ * fixed. Every lookup here is bounded by an explicit budget and issues one
+ * candidate-identifier query plus one logical hydration read, whatever the
+ * caller supplies. The hydration read is two SQL statements because candidates
+ * include their alternate titles relation. SQL construction and those budgets
+ * stay in this module so the ranking and presentation code has no reason to
+ * build predicates.
+ */
+
+/** Hydrated candidate ceiling shared by local and AI resolution. */
+export const MAX_CATALOG_CANDIDATES = 72
+/** Distinct lexical terms accepted from member text (matches prior ranking). */
+export const MAX_LEXICAL_TERMS = 16
+/** Normalized exact titles accepted from a whole AI response. */
+export const MAX_SUGGESTION_EXACT_TITLES = 10
+/** Lexical title terms accepted from a whole AI response. */
+export const MAX_SUGGESTION_TITLE_TERMS = 40
+/** AI hypotheses resolved by one batched lookup. */
+const MAX_SUGGESTION_HYPOTHESES = 5
+/** Popularity rows folded into the local candidate union. */
+const POPULAR_CANDIDATE_LIMIT = 24
+/** Shortest term allowed to widen a search. */
+const MIN_TERM_LENGTH = 3
+
+const STOP_WORDS = new Set([
+	'about',
+	'and',
+	'after',
+	'again',
+	'also',
+	'any',
+	'because',
+	'before',
+	'but',
+	'could',
+	'didn',
+	'does',
+	'for',
+	'from',
+	'had',
+	'has',
+	'have',
+	'her',
+	'him',
+	'his',
+	'into',
+	'just',
+	'like',
+	'movie',
+	'not',
+	'our',
+	'out',
+	'remember',
+	'scene',
+	'show',
+	'some',
+	'something',
+	'than',
+	'that',
+	'the',
+	'there',
+	'they',
+	'this',
+	'was',
+	'were',
+	'what',
+	'where',
+	'which',
+	'who',
+	'why',
+	'with',
+	'woman',
+	'would',
+	'you',
+	'your',
+])
+
+export const catalogCandidateSelect = {
+	id: true,
+	title: true,
+	kind: true,
+	type: true,
+	genres: true,
+	description: true,
+	releaseStart: true,
+	startYear: true,
+	airYear: true,
+	catalogPopularity: true,
+	titles: {
+		select: {
+			value: true,
+			normalized: true,
+		},
+	},
+} satisfies Prisma.MediaSelect
+
+export type CatalogCandidate = Prisma.MediaGetPayload<{
+	select: typeof catalogCandidateSelect
+}>
+
+/**
+ * Rank lexical terms from free text, keeping repetition and prompt length from
+ * widening the query. Terms are normalized once, deduplicated, and capped.
+ */
+export function lexicalTerms(text: string, limit = MAX_LEXICAL_TERMS) {
+	const counts = new Map<string, number>()
+	for (const word of normalizeCatalogTitle(text).match(/[a-z0-9]+/g) ?? []) {
+		if (word.length < MIN_TERM_LENGTH || STOP_WORDS.has(word)) continue
+		counts.set(word, (counts.get(word) ?? 0) + 1)
+	}
+	return [...counts.entries()]
+		.sort(
+			(left, right) => right[1] - left[1] || right[0].length - left[0].length,
+		)
+		.slice(0, Math.max(0, limit))
+		.map(([word]) => word)
+}
+
+/**
+ * Combine a primary prompt with expansion text under one shared budget, so an
+ * AI response cannot multiply the term count.
+ */
+export function combinedLexicalTerms(
+	text: string,
+	expansions: string[] = [],
+	limit = MAX_LEXICAL_TERMS,
+) {
+	const primary = lexicalTerms(text, limit)
+	if (primary.length >= limit) return primary
+	const seen = new Set(primary)
+	const expanded = lexicalTerms(expansions.join(' '), limit)
+	for (const term of expanded) {
+		if (primary.length >= limit) break
+		if (seen.has(term)) continue
+		seen.add(term)
+		primary.push(term)
+	}
+	return primary
+}
+
+/**
+ * Build a contains pattern whose wildcards stay literal search text. The
+ * predicate must declare `ESCAPE '!'` to match.
+ */
+export function containsPattern(term: string) {
+	return `%${escapeSqlLikeLiteral(term)}%`
+}
+
+/**
+ * Case-insensitive contains predicate that stays visible to the trigram
+ * indexes.
+ *
+ * The PostgreSQL GIN indexes are declared on the raw `title`, `description`,
+ * and `MediaTitle.normalized` columns, so wrapping a column in `LOWER(...)`
+ * hides them from the planner and forces a sequential scan. PostgreSQL's
+ * `ILIKE` works directly against `gin_trgm_ops`; SQLite's `LIKE` is already
+ * case-insensitive for ASCII, so the same shape is correct on both engines.
+ */
+function likeCondition(
+	column: Prisma.Sql,
+	literal: string,
+	databaseUrl = process.env.DATABASE_URL,
+) {
+	return isPostgresDatasource(databaseUrl)
+		? Prisma.sql`${column} ILIKE ${literal} ESCAPE '!'`
+		: Prisma.sql`${column} LIKE ${literal} ESCAPE '!'`
+}
+
+/** Case-insensitive contains match against an already-built pattern. */
+function containsCondition(
+	column: Prisma.Sql,
+	pattern: string,
+	databaseUrl = process.env.DATABASE_URL,
+) {
+	return likeCondition(column, pattern, databaseUrl)
+}
+
+/**
+ * Case-insensitive equality against a raw value. Escaping happens here so a
+ * caller cannot accidentally turn an equality into a contains scan; a
+ * wildcard-free LIKE/ILIKE literal is still an equality, and expressing it this
+ * way is what keeps it visible to the trigram indexes.
+ */
+function equalsCondition(
+	column: Prisma.Sql,
+	value: string,
+	databaseUrl = process.env.DATABASE_URL,
+) {
+	return likeCondition(column, escapeSqlLikeLiteral(value), databaseUrl)
+}
+
+function kindCondition(kind: string) {
+	return kind === 'all'
+		? Prisma.empty
+		: Prisma.sql`AND "Media"."kind" = ${kind}`
+}
+
+type CandidateIdRow = { id: string; source_rank: number; popularity: number }
+type SuggestionCandidateIdRow = CandidateIdRow & { slot: number }
+
+/**
+ * One query returning the ordered candidate identifiers for member text.
+ *
+ * Branches are unioned rather than OR-ed so each stays independently
+ * plan-visible, and a popularity branch keeps the result non-empty without a
+ * second round trip. Serialized genres are deliberately excluded: that column
+ * has no suitable index and must never lead candidate generation. Genre text
+ * remains a ranking signal after hydration.
+ */
+export async function findCatalogCandidateIds({
+	kind,
+	terms,
+	limit = MAX_CATALOG_CANDIDATES,
+	popularLimit = POPULAR_CANDIDATE_LIMIT,
+	databaseUrl = process.env.DATABASE_URL,
+}: {
+	kind: string
+	terms: string[]
+	limit?: number
+	popularLimit?: number
+	databaseUrl?: string
+}) {
+	const boundedTerms = terms.slice(0, MAX_LEXICAL_TERMS)
+	const boundedLimit = Math.max(0, Math.min(limit, MAX_CATALOG_CANDIDATES))
+	if (!boundedLimit) return []
+	const filter = kindCondition(kind)
+	const branches: Prisma.Sql[] = []
+	for (const term of boundedTerms) {
+		const pattern = containsPattern(term)
+		branches.push(Prisma.sql`
+			SELECT "Media"."id" AS id, 0 AS source_rank,
+				COALESCE("Media"."catalogPopularity", 0) AS popularity
+			FROM "Media"
+			WHERE "Media"."title" IS NOT NULL
+			${filter}
+			AND ${containsCondition(Prisma.sql`"Media"."title"`, pattern, databaseUrl)}
+		`)
+		branches.push(Prisma.sql`
+			SELECT "Media"."id" AS id, 1 AS source_rank,
+				COALESCE("Media"."catalogPopularity", 0) AS popularity
+			FROM "Media"
+			JOIN "MediaTitle" ON "MediaTitle"."mediaId" = "Media"."id"
+			WHERE "Media"."title" IS NOT NULL
+			${filter}
+			AND ${containsCondition(
+				Prisma.sql`"MediaTitle"."normalized"`,
+				pattern,
+				databaseUrl,
+			)}
+		`)
+		branches.push(Prisma.sql`
+			SELECT "Media"."id" AS id, 2 AS source_rank,
+				COALESCE("Media"."catalogPopularity", 0) AS popularity
+			FROM "Media"
+			WHERE "Media"."title" IS NOT NULL
+			${filter}
+			AND ${containsCondition(
+				Prisma.sql`"Media"."description"`,
+				pattern,
+				databaseUrl,
+			)}
+		`)
+	}
+	if (popularLimit > 0) {
+		// ORDER BY/LIMIT cannot appear directly in a UNION ALL member, so the
+		// popularity branch is bounded inside its own subquery.
+		branches.push(Prisma.sql`
+			SELECT popular.id AS id, 3 AS source_rank, popular.popularity AS popularity
+			FROM (
+				SELECT "Media"."id" AS id,
+					COALESCE("Media"."catalogPopularity", 0) AS popularity
+				FROM "Media"
+				WHERE "Media"."title" IS NOT NULL
+				${filter}
+				ORDER BY COALESCE("Media"."catalogPopularity", 0) DESC,
+					"Media"."title" ASC
+				LIMIT ${popularLimit}
+			) AS popular
+		`)
+	}
+	if (!branches.length) return []
+	const rows = await prisma.$queryRaw<CandidateIdRow[]>(Prisma.sql`
+		WITH matched AS (
+			${Prisma.join(branches, ' UNION ALL ')}
+		)
+		SELECT matched.id AS id,
+			MIN(matched.source_rank) AS source_rank,
+			MAX(matched.popularity) AS popularity
+		FROM matched
+		GROUP BY matched.id
+		ORDER BY source_rank ASC, popularity DESC, id ASC
+		LIMIT ${boundedLimit}
+	`)
+	return rows.map(row => row.id)
+}
+
+/**
+ * One query returning ordered candidate identifiers for every AI hypothesis at
+ * once, replacing a per-suggestion lookup.
+ */
+/**
+ * A single AI hypothesis reduced to the exact lookup keys it needs.
+ */
+export type SuggestionCandidateSpec = {
+	kind: string
+	exactTitles: string[]
+	titleTerms: string[]
+}
+
+/**
+ * One query returning ordered candidate identifiers for every AI hypothesis.
+ *
+ * Each hypothesis gets its own guaranteed slice of the candidate budget. A
+ * shared pool would let one popular hypothesis consume every slot and starve
+ * the other four, so branches are tagged with their hypothesis and ranked
+ * within it before the union is capped.
+ */
+export async function findSuggestionCandidateIds({
+	suggestions,
+	limit = MAX_CATALOG_CANDIDATES,
+	databaseUrl = process.env.DATABASE_URL,
+}: {
+	suggestions: SuggestionCandidateSpec[]
+	limit?: number
+	databaseUrl?: string
+}) {
+	const boundedSuggestions = suggestions.slice(0, MAX_SUGGESTION_HYPOTHESES)
+	const boundedLimit = Math.max(0, Math.min(limit, MAX_CATALOG_CANDIDATES))
+	if (!boundedLimit || !boundedSuggestions.length) return []
+	// Allocate the shared title and term budgets from actual demand: give every
+	// hypothesis an equal floor, then hand the genuinely unused remainder to the
+	// hypotheses that want more. First-come consumption let a verbose first
+	// hypothesis leave the others with no fuzzy matching at all.
+	const uniqueTitlesBySuggestion = boundedSuggestions.map(suggestion =>
+		[...new Set(suggestion.exactTitles)].filter(Boolean),
+	)
+	const uniqueTermsBySuggestion = boundedSuggestions.map(suggestion =>
+		[...new Set(suggestion.titleTerms)].filter(Boolean),
+	)
+	const allocate = (demands: number[], total: number) => {
+		const share = Math.max(1, Math.floor(total / demands.length))
+		const granted = demands.map(demand => Math.min(demand, share))
+		let spare = total - granted.reduce((sum, value) => sum + value, 0)
+		// Hand the remainder to whoever still wants it, one pass, in order.
+		for (let index = 0; index < demands.length && spare > 0; index += 1) {
+			const extra = Math.min(demands[index]! - granted[index]!, spare)
+			if (extra <= 0) continue
+			granted[index]! += extra
+			spare -= extra
+		}
+		return granted
+	}
+	const titleAllocation = allocate(
+		uniqueTitlesBySuggestion.map(titles => titles.length),
+		MAX_SUGGESTION_EXACT_TITLES,
+	)
+	const termAllocation = allocate(
+		uniqueTermsBySuggestion.map(terms => terms.length),
+		MAX_SUGGESTION_TITLE_TERMS,
+	)
+	const branches: Prisma.Sql[] = []
+	boundedSuggestions.forEach((suggestion, index) => {
+		const titles = uniqueTitlesBySuggestion[index]!.slice(
+			0,
+			titleAllocation[index],
+		)
+		const terms = uniqueTermsBySuggestion[index]!.slice(
+			0,
+			termAllocation[index],
+		)
+		const filter = Prisma.sql`AND "Media"."kind" = ${suggestion.kind}`
+		for (const title of titles) {
+			// Canonical-title equality must stay a candidate source: a media row
+			// with no MediaTitle rows would otherwise be unreachable, and short
+			// titles ("Up", "It") produce no lexical terms to fall back on.
+			branches.push(Prisma.sql`
+				SELECT "Media"."id" AS id, ${index} AS suggestion_index, 0 AS source_rank,
+					COALESCE("Media"."catalogPopularity", 0) AS popularity
+				FROM "Media"
+				WHERE "Media"."title" IS NOT NULL
+				${filter}
+				AND ${equalsCondition(Prisma.sql`"Media"."title"`, title, databaseUrl)}
+			`)
+			branches.push(Prisma.sql`
+				SELECT "Media"."id" AS id, ${index} AS suggestion_index, 0 AS source_rank,
+					COALESCE("Media"."catalogPopularity", 0) AS popularity
+				FROM "Media"
+				JOIN "MediaTitle" ON "MediaTitle"."mediaId" = "Media"."id"
+				WHERE "Media"."title" IS NOT NULL
+				${filter}
+				AND "MediaTitle"."normalized" = ${title}
+			`)
+		}
+		for (const term of terms) {
+			const pattern = containsPattern(term)
+			branches.push(Prisma.sql`
+				SELECT "Media"."id" AS id, ${index} AS suggestion_index, 1 AS source_rank,
+					COALESCE("Media"."catalogPopularity", 0) AS popularity
+				FROM "Media"
+				WHERE "Media"."title" IS NOT NULL
+				${filter}
+				AND ${containsCondition(Prisma.sql`"Media"."title"`, pattern, databaseUrl)}
+			`)
+			branches.push(Prisma.sql`
+				SELECT "Media"."id" AS id, ${index} AS suggestion_index, 2 AS source_rank,
+					COALESCE("Media"."catalogPopularity", 0) AS popularity
+				FROM "Media"
+				JOIN "MediaTitle" ON "MediaTitle"."mediaId" = "Media"."id"
+				WHERE "Media"."title" IS NOT NULL
+				${filter}
+				AND ${containsCondition(
+					Prisma.sql`"MediaTitle"."normalized"`,
+					pattern,
+					databaseUrl,
+				)}
+			`)
+		}
+	})
+	if (!branches.length) return []
+	// Interleave by rank-within-hypothesis rather than truncating each
+	// hypothesis: every hypothesis's Nth-best candidate precedes anyone's
+	// (N+1)th-best, so a crowded hypothesis still cannot starve the others while
+	// the full budget stays usable. A hard per-hypothesis cut would idle most of
+	// the budget and drop legitimate candidates.
+	const rows = await prisma.$queryRaw<SuggestionCandidateIdRow[]>(Prisma.sql`
+		WITH matched AS (
+			${Prisma.join(branches, ' UNION ALL ')}
+		), deduped AS (
+			SELECT matched.suggestion_index AS suggestion_index,
+				matched.id AS id,
+				MIN(matched.source_rank) AS source_rank,
+				MAX(matched.popularity) AS popularity
+			FROM matched
+			GROUP BY matched.suggestion_index, matched.id
+		), allocated AS (
+			SELECT deduped.id AS id,
+				deduped.source_rank AS source_rank,
+				deduped.popularity AS popularity,
+				ROW_NUMBER() OVER (
+					PARTITION BY deduped.suggestion_index
+					ORDER BY deduped.source_rank ASC,
+						deduped.popularity DESC,
+						deduped.id ASC
+				) AS slot
+			FROM deduped
+		)
+		SELECT allocated.id AS id,
+			MIN(allocated.slot) AS slot,
+			MIN(allocated.source_rank) AS source_rank,
+			MAX(allocated.popularity) AS popularity
+		FROM allocated
+		GROUP BY allocated.id
+		ORDER BY slot ASC, source_rank ASC, popularity DESC, id ASC
+		LIMIT ${boundedLimit}
+	`)
+	return rows.map(row => row.id)
+}
+
+/**
+ * One bounded, logical hydration read that preserves the candidate order
+ * established by the identifier query. It is two SQL statements: the media rows
+ * and their alternate titles relation.
+ */
+export async function hydrateCatalogCandidates(ids: string[]) {
+	const bounded = ids.slice(0, MAX_CATALOG_CANDIDATES)
+	if (!bounded.length) return []
+	const rows = await prisma.media.findMany({
+		where: { id: { in: bounded } },
+		select: catalogCandidateSelect,
+	})
+	const byId = new Map(rows.map(row => [row.id, row]))
+	return bounded.flatMap(id => {
+		const row = byId.get(id)
+		return row ? [row] : []
+	})
+}

--- a/app/utils/tip-of-tongue.server.test.ts
+++ b/app/utils/tip-of-tongue.server.test.ts
@@ -520,7 +520,15 @@ test('AI identification resolves short canonical titles without alternate-title 
 		{ fetchImpl, allowAi: true },
 	)
 
-	expect(result.matches[0]?.mediaId).toBe(candidate.id)
+	// The AI path must be what resolves this, not the supplemental local
+	// fallback: assert the AI's own reason and clues survive, so a regression
+	// that loses canonical-title matching cannot pass by falling back.
+	expect(result.source).toBe('ai')
+	expect(result.matches[0]).toEqual({
+		mediaId: candidate.id,
+		summary: 'Up may match the elderly widower, young scout, and flying house.',
+		matchedClues: ['elderly widower', 'young scout', 'flying house'],
+	})
 })
 
 test('AI identification is limited per member and falls back to catalog matching', async () => {
@@ -631,4 +639,169 @@ test('AI quota failures open a circuit while catalog matching stays available', 
 			fallbackReason: 'ai-unavailable',
 		}),
 	)
+})
+
+/**
+ * Count the catalog round trips a resolution performs. The budgets are the
+ * point of the batched repository: work must stay fixed whatever the prompt or
+ * the AI response contains.
+ */
+function countCatalogQueries() {
+	const queries: string[] = []
+	// Count real SQL round trips from Prisma's own query event rather than
+	// patching a hand-picked list of delegate methods: that approach missed
+	// transactions, unlisted models, and raw variants, so equivalent fan-out
+	// could hide from the budget.
+	const record = (event: { query: string }) => {
+		const sql = String(event.query)
+		if (!/^\s*(SELECT|WITH)/i.test(sql)) return
+		if (/sqlite_master|_prisma_migrations|PRAGMA/i.test(sql)) return
+		queries.push(sql.replace(/\s+/g, ' ').slice(0, 60))
+	}
+	const client = prisma as unknown as {
+		$on: (event: 'query', handler: (event: { query: string }) => void) => void
+	}
+	client.$on('query', record)
+	return {
+		queries,
+		restore() {
+			// Prisma exposes no removeListener for $on. A fresh recorder per test
+			// keeps counts scoped because each handler only appends to its own
+			// array, so there is nothing to undo here.
+		},
+	}
+}
+
+test('local fallback resolves within two catalog queries whatever the prompt', async () => {
+	const seeded = await prisma.media.create({
+		data: {
+			kind: 'movie',
+			title: 'Bounded Lighthouse',
+			description: 'A keeper tends an isolated lighthouse.',
+			catalogPopularity: 40,
+		},
+	})
+	// A deliberately long, repetitive prompt must not add round trips.
+	const memory = `${'lighthouse keeper isolated storm journal '.repeat(30)} ${Array.from(
+		{ length: 60 },
+		(_, index) => `filler${index}`,
+	).join(' ')}`
+	const counter = countCatalogQueries()
+	try {
+		const result = await getTipOfTongueMatches(
+			{ memory, kind: 'movie' },
+			{ allowAi: false },
+		)
+		expect(result.source).toBe('catalog-match')
+		expect(result.matches.map(match => match.mediaId)).toContain(seeded.id)
+		// One bounded candidate query, then one logical hydration read. Hydration
+		// is two SQL statements because the candidate select includes the titles
+		// relation, so the honest SQL total is three.
+		expect(
+			counter.queries.filter(sql => sql.includes('WITH matched')),
+		).toHaveLength(1)
+		expect(counter.queries).toHaveLength(3)
+	} finally {
+		counter.restore()
+		await prisma.media.delete({ where: { id: seeded.id } })
+	}
+})
+
+test('AI resolution plus supplement stays within four catalog queries', async () => {
+	const seeded = await Promise.all(
+		['Alpha Signal', 'Beta Signal', 'Gamma Signal'].map((title, index) =>
+			prisma.media.create({
+				data: {
+					kind: 'movie',
+					title,
+					description: `${title} concerns a distant broadcast.`,
+					catalogPopularity: 90 - index,
+				},
+			}),
+		),
+	)
+	vi.stubEnv('OPENAI_API_KEY', 'test-key')
+	// Five hypotheses, only three of which can resolve, so the supplemental
+	// local fallback also runs. That is the most expensive supported path.
+	const fetchImpl = vi.fn<typeof fetch>(async () =>
+		aiSuggestionResponse([
+			{ title: 'Alpha Signal', kind: 'movie', matchedClues: ['broadcast'] },
+			{ title: 'Beta Signal', kind: 'movie', matchedClues: ['broadcast'] },
+			{ title: 'Gamma Signal', kind: 'movie', matchedClues: ['broadcast'] },
+			{ title: 'Absent One', kind: 'movie', matchedClues: ['broadcast'] },
+			{ title: 'Absent Two', kind: 'movie', matchedClues: ['broadcast'] },
+		]),
+	)
+	const counter = countCatalogQueries()
+	try {
+		const result = await getTipOfTongueMatches(
+			{ memory: 'A film about a distant broadcast signal.', kind: 'movie' },
+			{ fetchImpl, allowAi: true },
+		)
+		expect(result.source).toBe('ai')
+		// Exactly two candidate queries on the most expensive supported path: one
+		// batched hypothesis lookup plus the supplemental local fallback. Five
+		// would mean per-hypothesis fan-out returned.
+		expect(
+			counter.queries.filter(sql => sql.includes('WITH matched')),
+		).toHaveLength(2)
+		// Two logical resolutions, each one candidate query plus a two-statement
+		// hydration read.
+		expect(counter.queries).toHaveLength(6)
+	} finally {
+		counter.restore()
+		await prisma.media.deleteMany({
+			where: { id: { in: seeded.map(item => item.id) } },
+		})
+	}
+})
+
+test('a fully resolved AI response needs only the batched lookup and hydration', async () => {
+	const seeded = await Promise.all(
+		['One Ridge', 'Two Ridge', 'Three Ridge', 'Four Ridge', 'Five Ridge'].map(
+			(title, index) =>
+				prisma.media.create({
+					data: {
+						kind: 'movie',
+						title,
+						description: `${title} climbs a ridge.`,
+						catalogPopularity: 90 - index,
+					},
+				}),
+		),
+	)
+	vi.stubEnv('OPENAI_API_KEY', 'test-key')
+	const fetchImpl = vi.fn<typeof fetch>(async () =>
+		aiSuggestionResponse(
+			['One Ridge', 'Two Ridge', 'Three Ridge', 'Four Ridge', 'Five Ridge'].map(
+				title => ({ title, kind: 'movie' as const, matchedClues: ['ridge'] }),
+			),
+		),
+	)
+	const counter = countCatalogQueries()
+	try {
+		const result = await getTipOfTongueMatches(
+			{ memory: 'Five films that climb a ridge.', kind: 'movie' },
+			{ fetchImpl, allowAi: true },
+		)
+		expect(result.source).toBe('ai')
+		expect(result.matches).toHaveLength(5)
+		// No supplemental fallback is needed: one batched candidate query and one
+		// hydration read (two SQL statements) resolve all five hypotheses.
+		expect(
+			counter.queries.filter(sql => sql.includes('WITH matched')),
+		).toHaveLength(1)
+		expect(counter.queries).toHaveLength(3)
+		// Every result is a distinct existing canonical media identifier.
+		const ids = result.matches.map(match => match.mediaId)
+		expect(new Set(ids).size).toBe(5)
+		for (const id of ids) {
+			expect(seeded.map(item => item.id)).toContain(id)
+		}
+	} finally {
+		counter.restore()
+		await prisma.media.deleteMany({
+			where: { id: { in: seeded.map(item => item.id) } },
+		})
+	}
 })

--- a/app/utils/tip-of-tongue.server.ts
+++ b/app/utils/tip-of-tongue.server.ts
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client'
 import sharp from 'sharp'
 import { z } from 'zod'
 import {
@@ -6,8 +5,15 @@ import {
 	type AiCircuit,
 	requestStructuredAi,
 } from './ai-gateway.server.ts'
+import {
+	combinedLexicalTerms,
+	findCatalogCandidateIds,
+	findSuggestionCandidateIds,
+	hydrateCatalogCandidates,
+	lexicalTerms,
+	type CatalogCandidate,
+} from './catalog-candidates.server.ts'
 import { normalizeCatalogTitle } from './catalog-sync.server.ts'
-import { prisma } from './db.server.ts'
 import { discoveryKinds, type DiscoveryQuery } from './discovery.server.ts'
 
 const MAX_CANDIDATES = 72
@@ -15,59 +21,6 @@ const MAX_MATCHES = 5
 const MAX_IMAGE_BYTES = 6 * 1024 * 1024
 const MAX_IMAGE_PIXELS = 12_000_000
 const mediaKinds = ['movie', 'tv', 'anime', 'manga'] as const
-const STOP_WORDS = new Set([
-	'about',
-	'and',
-	'after',
-	'again',
-	'also',
-	'any',
-	'because',
-	'before',
-	'but',
-	'could',
-	'didn',
-	'does',
-	'for',
-	'from',
-	'had',
-	'has',
-	'have',
-	'her',
-	'him',
-	'his',
-	'into',
-	'just',
-	'like',
-	'movie',
-	'not',
-	'our',
-	'out',
-	'remember',
-	'scene',
-	'show',
-	'some',
-	'something',
-	'than',
-	'that',
-	'the',
-	'there',
-	'they',
-	'this',
-	'was',
-	'were',
-	'what',
-	'where',
-	'which',
-	'who',
-	'why',
-	'with',
-	'woman',
-	'would',
-	'you',
-	'your',
-])
-
 const AiMediaSuggestionSchema = z.object({
 	title: z.string().trim().min(1).max(200),
 	alternateTitle: z.string().trim().min(1).max(200).nullable(),
@@ -121,19 +74,7 @@ const aiSuggestionJsonSchema = {
 
 type AiMediaSuggestion = z.infer<typeof AiMediaSuggestionSchema>
 
-type Candidate = {
-	id: string
-	title: string | null
-	kind: string
-	type: string | null
-	genres: string | null
-	description: string | null
-	releaseStart: Date | null
-	startYear: string | null
-	airYear: string | null
-	catalogPopularity: number | null
-	titles: Array<{ value: string; normalized: string }>
-}
+type Candidate = CatalogCandidate
 
 export type TipOfTongueMatch = {
 	mediaId: string
@@ -164,37 +105,8 @@ export class TipOfTongueImageError extends Error {
 	}
 }
 
-const candidateSelect = {
-	id: true,
-	title: true,
-	kind: true,
-	type: true,
-	genres: true,
-	description: true,
-	releaseStart: true,
-	startYear: true,
-	airYear: true,
-	catalogPopularity: true,
-	titles: {
-		select: {
-			value: true,
-			normalized: true,
-		},
-	},
-} satisfies Prisma.MediaSelect
-
 function memoryTerms(memory: string) {
-	const counts = new Map<string, number>()
-	for (const word of normalizeCatalogTitle(memory).match(/[a-z0-9]+/g) ?? []) {
-		if (word.length < 3 || STOP_WORDS.has(word)) continue
-		counts.set(word, (counts.get(word) ?? 0) + 1)
-	}
-	return [...counts.entries()]
-		.sort(
-			(left, right) => right[1] - left[1] || right[0].length - left[0].length,
-		)
-		.slice(0, 16)
-		.map(([word]) => word)
+	return lexicalTerms(memory)
 }
 
 function excerptFor(candidate: Candidate, matchedClues: string[]) {
@@ -222,77 +134,20 @@ function excerptFor(candidate: Candidate, matchedClues: string[]) {
 	return `${shortened.slice(0, Math.max(lastSpace, 160)).trimEnd()}…`
 }
 
-function candidateWhere(kind: DiscoveryQuery['kind']) {
-	return {
-		title: { not: null },
-		...(kind === 'all' ? {} : { kind }),
-	}
-}
-
 async function candidatesFor(
 	memory: string,
 	kind: DiscoveryQuery['kind'],
 	expandedTerms: string[] = [],
 ) {
-	const terms = [
-		...new Set([
-			...memoryTerms(memory),
-			...expandedTerms.flatMap(term => memoryTerms(term)),
-		]),
-	].slice(0, 28)
-	const base = candidateWhere(kind)
-	const lexicalIds = terms.length
-		? await prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
-				SELECT "Media"."id"
-				FROM "Media"
-				WHERE "Media"."title" IS NOT NULL
-				${kind === 'all' ? Prisma.empty : Prisma.sql`AND "Media"."kind" = ${kind}`}
-				AND (
-					${Prisma.join(
-						terms.map(term => {
-							const pattern = `%${term}%`
-							return Prisma.sql`
-								LOWER(COALESCE("Media"."title", '')) LIKE ${pattern}
-								OR LOWER(COALESCE("Media"."description", '')) LIKE ${pattern}
-								OR LOWER(COALESCE("Media"."genres", '')) LIKE ${pattern}
-								OR EXISTS (
-									SELECT 1
-									FROM "MediaTitle"
-									WHERE "MediaTitle"."mediaId" = "Media"."id"
-									AND "MediaTitle"."normalized" LIKE ${pattern}
-								)
-							`
-						}),
-						' OR ',
-					)}
-				)
-				ORDER BY COALESCE("Media"."catalogPopularity", 0) DESC, "Media"."title" ASC
-				LIMIT ${MAX_CANDIDATES}
-			`)
-		: []
-	const lexicalIdOrder = lexicalIds.map(item => item.id)
-	const [lexicalRows, popular] = await Promise.all([
-		lexicalIdOrder.length
-			? prisma.media.findMany({
-					where: { id: { in: lexicalIdOrder } },
-					select: candidateSelect,
-				})
-			: Promise.resolve([]),
-		prisma.media.findMany({
-			where: base,
-			select: candidateSelect,
-			orderBy: [{ catalogPopularity: 'desc' }, { title: 'asc' }],
-			take: 24,
-		}),
-	])
-	const lexicalById = new Map(lexicalRows.map(item => [item.id, item]))
-	const lexical = lexicalIdOrder.flatMap(id => {
-		const item = lexicalById.get(id)
-		return item ? [item] : []
+	// Exactly two catalog queries: bounded candidate identifiers, then one
+	// hydration read. Terms share a single budget so a long prompt or a verbose
+	// AI response cannot widen the search.
+	const ids = await findCatalogCandidateIds({
+		kind,
+		terms: combinedLexicalTerms(memory, expandedTerms),
+		limit: MAX_CANDIDATES,
 	})
-	return [
-		...new Map([...lexical, ...popular].map(item => [item.id, item])).values(),
-	].slice(0, MAX_CANDIDATES)
+	return hydrateCatalogCandidates(ids)
 }
 
 function localMatches(
@@ -302,9 +157,9 @@ function localMatches(
 	expandedTerms: string[] = [],
 ) {
 	const terms = memoryTerms(memory)
-	const expansionWords = [
-		...new Set(expandedTerms.flatMap(term => memoryTerms(term))),
-	].filter(term => !terms.includes(term))
+	const expansionWords = lexicalTerms(expandedTerms.join(' ')).filter(
+		term => !terms.includes(term),
+	)
 	return candidates
 		.map((candidate, originalIndex) => {
 			const title = normalizeCatalogTitle(candidate.title ?? '')
@@ -372,83 +227,33 @@ function normalizedSuggestionTitles(suggestion: AiMediaSuggestion) {
 	]
 }
 
-async function candidatesForSuggestion(
-	suggestion: AiMediaSuggestion,
+/**
+ * Resolve every AI hypothesis with one bounded candidate query.
+ *
+ * The previous shape ran up to three queries per suggestion, so five
+ * hypotheses cost fifteen round trips. Titles and terms from the whole
+ * response are pooled under fixed budgets, looked up once, hydrated once, and
+ * then ranked locally per hypothesis against that shared set.
+ */
+async function candidatesForSuggestions(
+	suggestions: AiMediaSuggestion[],
 	requestedKind: DiscoveryQuery['kind'],
 ) {
-	const kind = suggestionKind(suggestion, requestedKind)
-	const normalizedTitles = normalizedSuggestionTitles(suggestion)
-	const titleTerms = [
-		...new Set(normalizedTitles.flatMap(title => memoryTerms(title))),
-	].slice(0, 8)
-	const exactTitleRows = normalizedTitles.length
-		? await prisma.mediaTitle.findMany({
-				where: {
-					normalized: { in: normalizedTitles },
-					media: { kind },
-				},
-				select: { media: { select: candidateSelect } },
-				orderBy: [{ isPrimary: 'desc' }, { updatedAt: 'desc' }],
-				take: 16,
-			})
-		: []
-	const titleConditions = [
-		...normalizedTitles.map(
-			title => Prisma.sql`
-				LOWER(COALESCE("Media"."title", '')) = ${title}
-				OR EXISTS (
-					SELECT 1
-					FROM "MediaTitle"
-					WHERE "MediaTitle"."mediaId" = "Media"."id"
-					AND "MediaTitle"."normalized" = ${title}
-				)
-			`,
-		),
-		...titleTerms.map(term => {
-			const pattern = `%${term}%`
-			return Prisma.sql`
-				LOWER(COALESCE("Media"."title", '')) LIKE ${pattern}
-				OR EXISTS (
-					SELECT 1
-					FROM "MediaTitle"
-					WHERE "MediaTitle"."mediaId" = "Media"."id"
-					AND "MediaTitle"."normalized" LIKE ${pattern}
-				)
-			`
+	// One bounded lookup for every hypothesis, each with its own guaranteed
+	// slice of the candidate budget so a crowded hypothesis cannot starve the
+	// rest.
+	const ids = await findSuggestionCandidateIds({
+		suggestions: suggestions.map(suggestion => {
+			const titles = normalizedSuggestionTitles(suggestion)
+			return {
+				kind: suggestionKind(suggestion, requestedKind),
+				exactTitles: titles,
+				titleTerms: titles.flatMap(title => lexicalTerms(title)),
+			}
 		}),
-	]
-	const lexicalIds = titleConditions.length
-		? await prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
-				SELECT "Media"."id"
-				FROM "Media"
-				WHERE "Media"."title" IS NOT NULL
-				AND "Media"."kind" = ${kind}
-				AND (
-					${Prisma.join(titleConditions, ' OR ')}
-				)
-				ORDER BY COALESCE("Media"."catalogPopularity", 0) DESC, "Media"."title" ASC
-				LIMIT 36
-			`)
-		: []
-	const lexicalIdOrder = lexicalIds.map(item => item.id)
-	const lexicalRows = lexicalIdOrder.length
-		? await prisma.media.findMany({
-				where: { id: { in: lexicalIdOrder } },
-				select: candidateSelect,
-			})
-		: []
-	const lexicalById = new Map(lexicalRows.map(item => [item.id, item]))
-	const orderedLexical = lexicalIdOrder.flatMap(id => {
-		const item = lexicalById.get(id)
-		return item ? [item] : []
+		limit: MAX_CANDIDATES,
 	})
-	return [
-		...new Map(
-			[...exactTitleRows.map(row => row.media), ...orderedLexical].map(
-				candidate => [candidate.id, candidate],
-			),
-		).values(),
-	]
+	return hydrateCatalogCandidates(ids)
 }
 
 function candidateYear(candidate: Candidate) {
@@ -520,18 +325,19 @@ async function matchAiSuggestions(
 	kind: DiscoveryQuery['kind'],
 	suggestions: AiMediaSuggestion[],
 ) {
-	const rankedBySuggestion = await Promise.all(
-		suggestions.map(async suggestion => ({
-			suggestion,
-			ranked: rankSuggestionCandidates(
-				suggestion,
-				await candidatesForSuggestion(suggestion, kind),
-			),
-		})),
-	)
+	const sharedCandidates = await candidatesForSuggestions(suggestions, kind)
 	const usedMediaIds = new Set<string>()
 	const matches: TipOfTongueMatch[] = []
-	for (const { suggestion, ranked } of rankedBySuggestion) {
+	for (const suggestion of suggestions) {
+		const requiredKind = suggestionKind(suggestion, kind)
+		// Rank locally against the shared bounded set; the requested-kind
+		// boundary still decides which candidates a hypothesis may claim.
+		const ranked = rankSuggestionCandidates(
+			suggestion,
+			// The shared candidate set is already capped, so a hypothesis can map to
+			// at most MAX_CANDIDATES entries.
+			sharedCandidates.filter(candidate => candidate.kind === requiredKind),
+		)
 		const resolved = ranked.find(item => !usedMediaIds.has(item.candidate.id))
 		if (!resolved) continue
 		usedMediaIds.add(resolved.candidate.id)

--- a/scripts/load-test-postgres-catalog.mjs
+++ b/scripts/load-test-postgres-catalog.mjs
@@ -35,6 +35,14 @@ const requiredTrigramIndexesByQuery = {
 	'tracking-exact-title': 'Media_title_trgm_idx',
 	'alternate-title': 'MediaTitle_normalized_trgm_idx',
 	'rare-description': 'Media_description_trgm_idx',
+	// Batched Tip of My Tongue branches must each stay index-visible; a
+	// LOWER(...) wrapper or an OR-ed predicate would regress to a scan.
+	'tip-of-tongue-canonical-title': 'Media_title_trgm_idx',
+	'tip-of-tongue-description': 'Media_description_trgm_idx',
+	'tip-of-tongue-alternate-title': 'MediaTitle_normalized_trgm_idx',
+	// The union is what the application actually issues, so it must stay
+	// index-visible too, not only its individual branches.
+	'tip-of-tongue-batched-union': 'Media_title_trgm_idx',
 }
 const requiredCalendarIndexesByQuery = {
 	'calendar-media-range': 'Media_nextReleaseAt_idx',
@@ -1347,6 +1355,66 @@ async function queryMetrics(prisma, count, shape, scheduleAnchor) {
 			   AND status = 'scheduled' AND "expiresAt" > $3
 			 ORDER BY "releaseAt", id LIMIT 10001`,
 			[calendarWindow.start, calendarWindow.end, calendarWindow.reference],
+		],
+		// Tip of My Tongue candidate branches. Each is measured on its own so a
+		// branch that stops using its trigram index is caught rather than hidden
+		// inside a union. ILIKE is what keeps the GIN indexes plan-visible; a
+		// LOWER(...) wrapper would silently force a sequential scan.
+		[
+			'tip-of-tongue-canonical-title',
+			`SELECT id FROM "Media"
+			 WHERE "title" IS NOT NULL AND "kind" = $1
+			   AND "title" ILIKE $2 ESCAPE '!'
+			 LIMIT 72`,
+			['movie', `%Catalog Work ${needle}%`],
+		],
+		[
+			'tip-of-tongue-description',
+			`SELECT id FROM "Media"
+			 WHERE "title" IS NOT NULL AND "kind" = $1
+			   AND "description" ILIKE $2 ESCAPE '!'
+			 LIMIT 72`,
+			['movie', `%${syntheticRareDescriptionNeedle}%`],
+		],
+		[
+			'tip-of-tongue-alternate-title',
+			`SELECT "Media".id FROM "Media"
+			 JOIN "MediaTitle" ON "MediaTitle"."mediaId" = "Media".id
+			 WHERE "Media"."title" IS NOT NULL AND "Media"."kind" = $1
+			   AND "MediaTitle"."normalized" ILIKE $2 ESCAPE '!'
+			 LIMIT 72`,
+			['movie', `%alternate load alias ${alternate}%`],
+		],
+		[
+			'tip-of-tongue-batched-union',
+			`WITH matched AS (
+				SELECT id AS id, 0 AS source_rank,
+					COALESCE("catalogPopularity", 0) AS popularity
+				FROM "Media"
+				WHERE "title" IS NOT NULL AND "kind" = $1
+				  AND "title" ILIKE $2 ESCAPE '!'
+				UNION ALL
+				SELECT "Media".id AS id, 1 AS source_rank,
+					COALESCE("Media"."catalogPopularity", 0) AS popularity
+				FROM "Media"
+				JOIN "MediaTitle" ON "MediaTitle"."mediaId" = "Media".id
+				WHERE "Media"."title" IS NOT NULL AND "Media"."kind" = $1
+				  AND "MediaTitle"."normalized" ILIKE $2 ESCAPE '!'
+				UNION ALL
+				SELECT id AS id, 2 AS source_rank,
+					COALESCE("catalogPopularity", 0) AS popularity
+				FROM "Media"
+				WHERE "title" IS NOT NULL AND "kind" = $1
+				  AND "description" ILIKE $2 ESCAPE '!'
+			 )
+			 SELECT matched.id AS id,
+				MIN(matched.source_rank) AS source_rank,
+				MAX(matched.popularity) AS popularity
+			 FROM matched
+			 GROUP BY matched.id
+			 ORDER BY source_rank ASC, popularity DESC, id ASC
+			 LIMIT 72`,
+			['movie', `%Catalog Work ${needle}%`],
 		],
 	]
 	const queries = []


### PR DESCRIPTION
## Problem

Tip of My Tongue fanned out **one database query per search term and per AI hypothesis**. Five hypotheses cost up to fifteen round trips, plus three more for the local fallback, so cost grew with prompt length and with how verbose the model was rather than staying fixed.

## Batching

A new relation-free candidate repository (`app/utils/catalog-candidates.server.ts`) owns all SQL construction and every budget: 72 hydrated candidates, 16 lexical terms, 10 exact titles, 40 title terms, five hypotheses, three-character minimum term.

- **Local fallback**: one bounded candidate-identifier union plus one logical hydration read (the popularity fallback folded into the same query rather than costing a round trip).
- **AI resolution**: all five hypotheses resolve through **one** batched query. Branches are tagged per hypothesis, deduplicated, then interleaved round-robin by rank *within* each hypothesis — so a crowded hypothesis cannot starve the others, while the full budget stays usable. Title and term budgets are allocated from actual demand rather than first-come.
- Canonical-title equality remains a candidate source, so a media row with no alternate-title rows and a short title ("Up", "It") stays reachable.

Honest SQL counts: **3 statements** locally and **6** for AI resolution plus the supplemental fallback (hydration is two statements because candidates include their titles relation).

## Index-visibility defect found and fixed

The trigram indexes are declared on the **raw** columns (`Media_title_trgm_idx` on `"title"`, etc.), but every previous predicate wrapped them in `LOWER(COALESCE(...))`, which hides a GIN trigram index from the planner. **These searches were recorded as trigram-covered while actually scanning.** Predicates now use `ILIKE` on PostgreSQL and `LIKE` on SQLite, chosen through the existing `isPostgresDatasource` helper.

Measured on a disposable PostgreSQL 16.14 cluster at 100,000 media rows:

| branch | plan | planning | execution |
| --- | --- | --- | --- |
| canonical title (`ILIKE`) | `Media_title_trgm_idx` | 0.541 ms | **2.261 ms** |
| description (`ILIKE`) | `Media_description_trgm_idx` | 0.490 ms | 1.810 ms |
| alternate title (`ILIKE`) | `MediaTitle_normalized_trgm_idx` | 0.850 ms | 1.480 ms |
| **old** canonical title (`LOWER(...) LIKE`) | **Seq Scan** | 0.319 ms | **21.298 ms** |
| batched union (all three) | all three trigram indexes | 1.101 ms | 5.172 ms |

## Deliberate recall deltas

Serialized genres no longer seed candidates (that column has no suitable index and must not lead a scan); they remain a ranking signal after hydration. The AI-supplemented local fallback searches 16 terms where the previous code searched 28, because prompt and AI expansions now share one budget.

## Validation

Query counts are asserted from **Prisma's own query events**, so fan-out through transactions, unlisted models, or raw variants cannot hide. Dialect assertions prove the application emits `ILIKE` and never `LOWER(` on PostgreSQL — the load test measures hand-written copies of these shapes and provably could not catch that regression. The four measured `tip-of-tongue-*` load shapes now use corpus-derived needles and are all required to keep their trigram indexes at scale.

Gates: static clean, **1486/1486** unit with coverage, **17/17** bundle budgets, **98/98** Chromium, plus the 100k plan evidence above.

**Three independent adversarial reviews ran against frozen bytes. Rounds one and two returned BLOCK and were correct** — round one caught that canonical-title matching had been dropped, that a shared candidate pool let one hypothesis starve the others, and that I had silently changed the stop-word list; round two caught that a bespoke load-evidence gate **synthesized the very numbers it checked**, so it was deleted rather than shipped. Round three returned PUBLISH, and its two pre-merge findings are fixed here.