### PR TITLE
Let a deployment install a writer unit the host has never had

### DIFF
--- a/ops/local-production/deploy-catalog-release.sh
+++ b/ops/local-production/deploy-catalog-release.sh
@@ -300,6 +300,17 @@ restore_original_unit_definitions() {
 systemd_active_state() {
 	local unit="$1" load_state active_state
 	load_state="$(systemctl --user show --property=LoadState --value "$unit")"
+	# A writer unit the release ships but this host has never installed is
+	# reported as `not-found`. Refusing here made such a unit impossible to ever
+	# install, because the only thing that installs writer units is this same
+	# deployment, a few steps further on. A unit that does not exist is by
+	# definition not running, so report it inactive and let the install proceed;
+	# capture already records absent unit files separately. Any other non-loaded
+	# state (a malformed or masked unit) is still a hard failure.
+	if [[ "$load_state" == not-found ]]; then
+		printf 'inactive'
+		return 0
+	fi
 	[[ "$load_state" == loaded ]] || die "Required writer unit is not loaded: $unit"
 	active_state="$(systemctl --user show --property=ActiveState --value "$unit")"
 	case "$active_state" in
@@ -1217,6 +1228,14 @@ else
 		original_unit_enabled_states["$unit"]="$(
 			systemctl --user is-enabled "$unit" 2>/dev/null || true
 		)"
+		# `is-enabled` prints nothing for a unit this host has never installed.
+		# Record it as disabled so a newly shipped writer unit is installed by
+		# this deployment and left switched off, which is the only safe default:
+		# enabling a job that deletes data on a timer is a deliberate decision,
+		# not a side effect of a deployment.
+		if [[ -z "${original_unit_enabled_states[$unit]}" ]]; then
+			original_unit_enabled_states["$unit"]=disabled
+		fi
 		[[ "${original_unit_enabled_states[$unit]}" =~ ^[a-z-]+$ ]] ||
 			die "Unable to record the enabled state for $unit"
 		if is_writer_timer "$unit"; then

--- a/scripts/catalog-cutover-guard.test.mjs
+++ b/scripts/catalog-cutover-guard.test.mjs
@@ -4033,3 +4033,70 @@ test('a recovery window records online as the target end state', () => {
 		/assert_web_state_allows_new_window \\\n\t\t"\$original_pm2_veud_state" \\\n\t\t"\$\{VEUD_PRODUCTION_RECOVERY_DEPLOY:-\}"\n(?:\t*#[^\n]*\n)*\toriginal_pm2_veud_state=online\n/,
 	)
 })
+
+test('a writer unit the host has never installed is bootstrappable, not fatal', () => {
+	// The only thing that installs writer units is the deployment itself, a few
+	// steps after it captures their original states. Refusing a `not-found` unit
+	// there made a newly shipped unit impossible to ever install — which is why
+	// retention-cleanup and notification-digests never ran in production.
+	const source = `
+die() { printf 'ERROR: %s\\n' "$*" >&2; exit 1; }
+systemctl() {
+	local property="" unit=""
+	for argument in "$@"; do
+		case "$argument" in
+		--property=*) property="\${argument#--property=}" ;;
+		veud-*) unit="$argument" ;;
+		esac
+	done
+	case "$property" in
+	LoadState) printf '%s' "$LOAD_STATE" ;;
+	ActiveState) printf '%s' "$ACTIVE_STATE" ;;
+	esac
+}
+${extractShellFunction(productionDeploy, 'systemd_active_state')}
+systemd_active_state veud-production-retention-cleanup.service
+`
+	// A unit that does not exist is by definition not running.
+	const absent = runBash(source, {
+		env: { LOAD_STATE: 'not-found', ACTIVE_STATE: '' },
+	})
+	expectAllowed(absent)
+	assert.equal(absent.stdout, 'inactive')
+
+	// An installed unit still reports its real state.
+	for (const state of ['active', 'inactive']) {
+		const result = runBash(source, {
+			env: { LOAD_STATE: 'loaded', ACTIVE_STATE: state },
+		})
+		expectAllowed(result)
+		assert.equal(result.stdout, state)
+	}
+
+	// A malformed, masked, or unstable unit is still a hard failure, so the
+	// bootstrap allowance cannot hide a broken unit file.
+	for (const loadState of ['error', 'masked', 'bad-setting']) {
+		const result = runBash(source, {
+			env: { LOAD_STATE: loadState, ACTIVE_STATE: 'inactive' },
+		})
+		assert.notEqual(result.status, 0, `LoadState ${loadState} must fail`)
+		assert.match(result.stderr, /is not loaded/)
+	}
+	for (const activeState of ['failed', 'activating', 'deactivating']) {
+		const result = runBash(source, {
+			env: { LOAD_STATE: 'loaded', ACTIVE_STATE: activeState },
+		})
+		assert.notEqual(result.status, 0, `ActiveState ${activeState} must fail`)
+		assert.match(result.stderr, /stable active\/inactive state/)
+	}
+})
+
+test('a never-installed writer unit is recorded as disabled, not enabled', () => {
+	// `is-enabled` prints nothing for a unit that does not exist. Recording it as
+	// disabled is what leaves a newly shipped timer switched off: a deployment
+	// must never start a job that deletes user data on a schedule.
+	assert.match(
+		productionDeploy,
+		/if \[\[ -z "\$\{original_unit_enabled_states\[\$unit\]\}" \]\]; then\n\t{3}original_unit_enabled_states\["\$unit"\]=disabled\n/,
+	)
+})


### PR DESCRIPTION
Found while deploying over the outage. The deployment refused to start because `veud-production-retention-cleanup.service` is not loaded on the host — and the only thing that installs writer units is that same deployment, a few steps later. A newly shipped unit could therefore never be installed.

That is why retention-cleanup and notification-digests have never existed in production: every deployment carrying them died while capturing their state, so **data-retention cleanup has never run.**

A unit that does not exist is not running, so it is reported inactive and the install proceeds. Malformed and masked units still fail hard, as do unstable active states. A never-installed unit is recorded as `disabled`, so it is installed switched off — enabling a timer that deletes user data should be a deliberate decision.

Both halves are mutation-verified, including that the allowance cannot mask a broken unit file.