### PR TITLE
Promote writer unit enablement fix

### DIFF
--- a/ops/local-production/deploy-catalog-release.sh
+++ b/ops/local-production/deploy-catalog-release.sh
@@ -793,6 +793,33 @@ disable_writer_timers() {
 	done
 }
 
+# Record a writer unit's enablement, resolving the reading systemd gives for a
+# unit this host has never installed.
+#
+# `is-enabled` reports the literal `not-found` (exit 4) for such a unit. The
+# recorded value is read by both the enablement restore and the final
+# unchanged-comparison, and that comparison runs AFTER the database has been
+# migrated — so recording the raw reading would fail the deployment at its most
+# expensive point. Record instead the state the unit will hold once this same
+# deployment installs it: a timer lands installed but switched off, and these
+# writer services carry no [Install] section, so systemd reports them `static`.
+#
+# Switched off is the only safe default. Enabling a job that deletes user data on
+# a schedule is a deliberate decision, not a side effect of a deployment that
+# happened to ship a new unit file.
+record_original_unit_enablement() {
+	local unit="$1" enablement
+	enablement="$(systemctl --user is-enabled "$unit" 2>/dev/null || true)"
+	if [[ -z "$enablement" || "$enablement" == not-found ]]; then
+		if is_writer_timer "$unit"; then
+			enablement=disabled
+		else
+			enablement=static
+		fi
+	fi
+	original_unit_enabled_states["$unit"]="$enablement"
+}
+
 restore_writer_enablement() {
 	local unit result=0
 	for unit in "${writer_timers[@]}"; do
@@ -1225,17 +1252,7 @@ else
 		die 'The production backup process must be installed and healthy before deployment'
 	for unit in "${all_writer_units[@]}"; do
 		original_unit_states["$unit"]="$(systemd_active_state "$unit")"
-		original_unit_enabled_states["$unit"]="$(
-			systemctl --user is-enabled "$unit" 2>/dev/null || true
-		)"
-		# `is-enabled` prints nothing for a unit this host has never installed.
-		# Record it as disabled so a newly shipped writer unit is installed by
-		# this deployment and left switched off, which is the only safe default:
-		# enabling a job that deletes data on a timer is a deliberate decision,
-		# not a side effect of a deployment.
-		if [[ -z "${original_unit_enabled_states[$unit]}" ]]; then
-			original_unit_enabled_states["$unit"]=disabled
-		fi
+		record_original_unit_enablement "$unit"
 		[[ "${original_unit_enabled_states[$unit]}" =~ ^[a-z-]+$ ]] ||
 			die "Unable to record the enabled state for $unit"
 		if is_writer_timer "$unit"; then

--- a/scripts/catalog-cutover-guard.test.mjs
+++ b/scripts/catalog-cutover-guard.test.mjs
@@ -4091,12 +4091,55 @@ systemd_active_state veud-production-retention-cleanup.service
 	}
 })
 
-test('a never-installed writer unit is recorded as disabled, not enabled', () => {
-	// `is-enabled` prints nothing for a unit that does not exist. Recording it as
-	// disabled is what leaves a newly shipped timer switched off: a deployment
-	// must never start a job that deletes user data on a schedule.
-	assert.match(
-		productionDeploy,
-		/if \[\[ -z "\$\{original_unit_enabled_states\[\$unit\]\}" \]\]; then\n\t{3}original_unit_enabled_states\["\$unit"\]=disabled\n/,
-	)
+test('a never-installed writer unit records its post-install enablement', () => {
+	// `is-enabled` prints the literal `not-found` (exit 4) for a unit that does
+	// not exist — not an empty string. Both the enablement restore and the final
+	// unchanged-comparison read this recorded value, and that comparison runs
+	// AFTER the database is migrated, so recording the wrong value fails the
+	// deployment at its most expensive point.
+	const source = `
+die() { printf 'ERROR: %s\\n' "$*" >&2; exit 1; }
+${/^writer_timers=\([^)]*\)/m.exec(productionDeploy)[0]}
+${extractShellFunction(productionDeploy, 'is_writer_timer')}
+systemctl() { printf '%s' "$IS_ENABLED"; return 4; }
+${extractShellFunction(productionDeploy, 'record_original_unit_enablement')}
+declare -A original_unit_enabled_states=()
+record_original_unit_enablement "$1"
+printf '%s' "\${original_unit_enabled_states[$1]}"
+`
+	// A timer lands installed but switched off.
+	const timer = runBash(source, {
+		args: ['veud-production-retention-cleanup.timer'],
+		env: { IS_ENABLED: 'not-found' },
+	})
+	expectAllowed(timer)
+	assert.equal(timer.stdout, 'disabled')
+
+	// These writer services carry no [Install] section, so systemd calls them
+	// `static` once installed.
+	const service = runBash(source, {
+		args: ['veud-production-retention-cleanup.service'],
+		env: { IS_ENABLED: 'not-found' },
+	})
+	expectAllowed(service)
+	assert.equal(service.stdout, 'static')
+
+	// An empty reading is treated the same way, so a systemd that prints nothing
+	// behaves identically.
+	const empty = runBash(source, {
+		args: ['veud-production-notification-digests.timer'],
+		env: { IS_ENABLED: '' },
+	})
+	expectAllowed(empty)
+	assert.equal(empty.stdout, 'disabled')
+
+	// A real enablement reading is never overwritten.
+	for (const state of ['enabled', 'disabled', 'enabled-runtime']) {
+		const real = runBash(source, {
+			args: ['veud-production-mal-trending.timer'],
+			env: { IS_ENABLED: state },
+		})
+		expectAllowed(real)
+		assert.equal(real.stdout, state)
+	}
 })


### PR DESCRIPTION
Promotes the third layer of the writer-unit bootstrap fix.

`is-enabled` prints the literal `not-found` for a unit that does not exist, and the recorded value is read by the final unchanged-comparison that runs **after** the database is migrated. A never-installed timer is now recorded as `disabled` and a never-installed service as `static`, matching what systemd reports once this deployment installs them — so a newly shipped unit lands installed and switched off.