### PR TITLE
Promote absent writer unit capture

### DIFF
--- a/ops/catalog-cutover-common.sh
+++ b/ops/catalog-cutover-common.sh
@@ -701,6 +701,24 @@ cutover_capture_unit_definitions() {
 		exec_start="$(
 			systemctl --user show "$unit" --property=ExecStart --value
 		)"
+		# A unit this host has never installed has no effective definition at all:
+		# no fragment, no ExecStart. That state is already supported everywhere
+		# else — the absent marker above is recorded for it, capture verification
+		# accepts that branch, and restore removes the file again — so record
+		# empty metadata rather than refusing. Without this, a unit the release
+		# ships but the host has never had could never be installed, because the
+		# only installer is the deployment that dies here first.
+		#
+		# Systemd must agree the unit is unknown. If it reports any state for a
+		# unit with no file, something else is managing it and that is a genuine
+		# conflict, not a bootstrap.
+		if [[ ! -e "$target" && ! -L "$target" && -z "$fragment" ]]; then
+			[[ -z "$exec_start" && -z "$dropins" ]] ||
+				die "Systemd reports state for an uninstalled unit: $unit"
+			: >"$metadata/FragmentPath"
+			: >"$metadata/ExecStart"
+			continue
+		fi
 		[[ -n "$fragment" &&
 			"$fragment" != *$'\n'* &&
 			"$exec_start" != *$'\n'* ]] ||
@@ -792,6 +810,13 @@ cutover_verify_restored_unit_definitions() {
 		exec_start="$(
 			systemctl --user show "$unit" --property=ExecStart --value
 		)" || return 1
+		# A unit captured as uninstalled must be uninstalled again after a restore,
+		# so there is no fragment to stat. Requiring one here would fail every
+		# restore that touched such a unit.
+		if [[ -z "$expected_fragment" ]]; then
+			[[ -z "$fragment" && -z "$exec_start" && -z "$dropins" ]] || return 1
+			continue
+		fi
 		[[ -z "$dropins" &&
 			"$fragment" == "$expected_fragment" &&
 			"$exec_start" == "$expected_exec" &&

--- a/scripts/catalog-cutover-guard.test.mjs
+++ b/scripts/catalog-cutover-guard.test.mjs
@@ -4143,3 +4143,85 @@ printf '%s' "\${original_unit_enabled_states[$1]}"
 		assert.equal(real.stdout, state)
 	}
 })
+
+test('a unit the host has never installed captures and restores as absent', () => {
+	// The state that made a newly shipped writer unit impossible to install: no
+	// unit file, and systemd knows nothing about it. The absent marker, capture
+	// verification, and restore all already supported this; only the effective
+	// definition assertion refused it, and it runs first.
+	const root = temporaryRoot('cutover-absent-unit')
+	const unitDir = path.join(root, 'units')
+	const state = path.join(root, 'state')
+	fs.mkdirSync(unitDir, { recursive: true })
+	const source = `set -Eeuo pipefail
+source "$1"
+die() { printf 'ERROR: %s\\n' "$*" >&2; exit 1; }
+unit_dir="$2"
+systemctl() {
+	[[ "$*" == "--user daemon-reload" ]] && return 0
+	local property='' argument
+	for argument in "$@"; do
+		[[ "$argument" == --property=* ]] && property="\${argument#--property=}"
+	done
+	case "$property" in
+	FragmentPath) printf '%s' "$FRAGMENT" ;;
+	DropInPaths) printf '%s' "$DROPINS" ;;
+	ExecStart) printf '%s' "$EXEC_START" ;;
+	esac
+}
+cutover_capture_unit_definitions "$3" "$unit_dir" writer.timer
+cutover_verify_captured_unit_definitions "$3" writer.timer ||
+	die 'capture verification rejected an absent unit'
+[[ -f "$3/unit-files-absent/writer.timer" ]] || die 'absent marker missing'
+[[ ! -s "$3/unit-effective/writer.timer/FragmentPath" ]] ||
+	die 'absent unit recorded a fragment'
+cutover_restore_unit_definitions "$3" "$unit_dir" writer.timer ||
+	die 'restore rejected an absent unit'
+[[ ! -e "$unit_dir/writer.timer" ]] || die 'restore left a unit file behind'
+printf captured-and-restored`
+	const result = runBash(source, {
+		args: [catalogCutoverCommon, unitDir, state],
+		env: { FRAGMENT: '', DROPINS: '', EXEC_START: '' },
+	})
+	expectAllowed(result)
+	assert.match(result.stdout, /captured-and-restored/)
+})
+
+test('systemd reporting state for a unit with no file is a conflict, not a bootstrap', () => {
+	// The bootstrap allowance must not become a blanket escape: if a unit has no
+	// managed file yet systemd still reports an ExecStart or a drop-in, something
+	// else is managing it and the cutover has to stop.
+	const root = temporaryRoot('cutover-phantom-unit')
+	const unitDir = path.join(root, 'units')
+	fs.mkdirSync(unitDir, { recursive: true })
+	const source = `set -Eeuo pipefail
+source "$1"
+die() { printf 'ERROR: %s\\n' "$*" >&2; exit 1; }
+systemctl() {
+	local property='' argument
+	for argument in "$@"; do
+		[[ "$argument" == --property=* ]] && property="\${argument#--property=}"
+	done
+	case "$property" in
+	FragmentPath) printf '' ;;
+	DropInPaths) printf '%s' "$DROPINS" ;;
+	ExecStart) printf '%s' "$EXEC_START" ;;
+	esac
+}
+cutover_capture_unit_definitions "$3" "$2" writer.timer`
+	for (const env of [
+		{ DROPINS: '', EXEC_START: '/somewhere/else' },
+		{ DROPINS: '/etc/x.conf', EXEC_START: '' },
+	]) {
+		const result = runBash(source, {
+			args: [
+				catalogCutoverCommon,
+				unitDir,
+				path.join(root, `state-${env.EXEC_START ? 'exec' : 'dropin'}`),
+			],
+			env,
+		})
+		assert.notEqual(result.status, 0, JSON.stringify(env))
+		assert.match(result.stderr, /reports state for an uninstalled unit/)
+	}
+})


### PR DESCRIPTION
Promotes the final layer of the writer-unit bootstrap fix, so a deployment can install a writer unit the host has never had. The allowance applies only when the managed file is absent and systemd reports nothing; systemd reporting state for an unmanaged unit is now an explicit conflict.