### PR TITLE
Promote listen address and runtime state checks

### DIFF
--- a/scripts/preflight-production.mjs
+++ b/scripts/preflight-production.mjs
@@ -29,6 +29,9 @@ const PRODUCTION_SECRETS = [
 	'HONEYPOT_SECRET',
 	'INTERNAL_COMMAND_TOKEN',
 ]
+const EXPECTED_LISTEN_HOST = '127.0.0.1'
+const EXPECTED_LISTEN_PORT = '4021'
+const STAGING_LISTEN_PORT = '4022'
 
 const failures = []
 const notes = []
@@ -171,6 +174,84 @@ function checkActivatedRelease(productionRoot) {
 	}
 }
 
+/**
+ * The listen address decides whether production can bind at all, and it comes
+ * from the same file that has twice been found holding staging's values. The
+ * launcher defaults to 4021, but `${PORT:-4021}` cannot override a value that is
+ * already set — so a copied staging PORT wins silently and production fails at
+ * the health check with EADDRINUSE against the running staging app.
+ */
+function checkListenAddress(application) {
+	const port = (application.get('PORT') ?? '').trim()
+	if (!port) {
+		notes.push(
+			`PORT is unset, so the launcher default ${EXPECTED_LISTEN_PORT} applies`,
+		)
+	} else if (port !== EXPECTED_LISTEN_PORT) {
+		fail(
+			`application.env PORT must be ${EXPECTED_LISTEN_PORT}; found ${port}` +
+				(port === STAGING_LISTEN_PORT
+					? '. That is the staging port: this file was copied from staging, and production cannot bind it while staging is running.'
+					: '.'),
+		)
+	}
+	const host = (application.get('HOST') ?? '').trim()
+	if (host && host !== EXPECTED_LISTEN_HOST) {
+		fail(
+			`application.env HOST must be ${EXPECTED_LISTEN_HOST} so only the reverse proxy can reach production; found ${host}`,
+		)
+	}
+}
+
+/**
+ * The catalog-writer lifetime lock is only meaningful if no other account can
+ * write it, so the runtime guard refuses any lock with group or world write
+ * bits. That is not hypothetical: `run/` was mode 0777 with a default ACL
+ * granting `other` rwx, every lock created there inherited 0666, and the guard
+ * correctly blocked a production deployment mid-cutover.
+ */
+function checkRuntimeStateDirectory(productionRoot) {
+	const runDir = path.join(productionRoot, 'run')
+	let dirStat
+	try {
+		dirStat = fs.lstatSync(runDir)
+	} catch {
+		notes.push(`no runtime state directory yet: ${runDir}`)
+		return
+	}
+	if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
+		fail(`Production runtime state path must be a real directory: ${runDir}`)
+		return
+	}
+	if ((dirStat.mode & 0o077) !== 0) {
+		fail(
+			`Production runtime state directory is group or world accessible (mode ${(dirStat.mode & 0o777).toString(8)}): ${runDir}. ` +
+				'Files created there inherit the exposure, and the catalog-writer guard refuses a writable lock.',
+		)
+	}
+	let entries
+	try {
+		entries = fs.readdirSync(runDir)
+	} catch {
+		return
+	}
+	for (const entry of entries.filter(name => name.endsWith('.lock'))) {
+		const file = path.join(runDir, entry)
+		let lockStat
+		try {
+			lockStat = fs.lstatSync(file)
+		} catch {
+			continue
+		}
+		if ((lockStat.mode & 0o022) !== 0) {
+			fail(
+				`Runtime lock is group or world writable (mode ${(lockStat.mode & 0o777).toString(8)}): ${file}. ` +
+					'The catalog-writer lifetime-lock guard requires no group or world write bits and will refuse to start a writer.',
+			)
+		}
+	}
+}
+
 function checkBlockingCutoverState(productionRoot) {
 	for (const name of [
 		'catalog-release-preparation.state',
@@ -283,6 +364,7 @@ export function runProductionPreflight({
 	checkNodeRuntime()
 	checkActivatedRelease(productionRoot)
 	checkBlockingCutoverState(productionRoot)
+	checkRuntimeStateDirectory(productionRoot)
 
 	const configDir = path.join(productionRoot, 'config')
 	const application = readEnvFile(
@@ -301,6 +383,7 @@ export function runProductionPreflight({
 			EXPECTED_APPLICATION_ROLE,
 			EXPECTED_APPLICATION_DATABASE,
 		)
+		checkListenAddress(application)
 		for (const secret of PRODUCTION_SECRETS) {
 			const value = application.get(secret) ?? ''
 			if (value.trim().length < MINIMUM_PRODUCTION_SECRET_LENGTH) {

--- a/scripts/preflight-production.test.mjs
+++ b/scripts/preflight-production.test.mjs
@@ -35,12 +35,22 @@ function productionRoot({
 	activate = true,
 	blockingState = undefined,
 	applicationMode = 0o600,
+	port = '4021',
+	host = '127.0.0.1',
+	runMode = undefined,
+	lockMode = undefined,
 } = {}) {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'veud-preflight-'))
 	roots.push(root)
 	fs.mkdirSync(path.join(root, 'config'), { recursive: true })
 	fs.mkdirSync(path.join(root, 'run'), { recursive: true })
-	const applicationLines = [`DATABASE_URL="${applicationUrl}"`]
+	// A correctly provisioned production root keeps its runtime state private.
+	fs.chmodSync(path.join(root, 'run'), 0o700)
+	const applicationLines = [
+		`DATABASE_URL="${applicationUrl}"`,
+		`PORT="${port}"`,
+		`HOST="${host}"`,
+	]
 	for (const [key, value] of Object.entries(secrets)) {
 		applicationLines.push(`${key}="${value}"`)
 	}
@@ -72,6 +82,12 @@ function productionRoot({
 	} else {
 		fs.mkdirSync(path.join(root, 'app'), { recursive: true })
 	}
+	if (lockMode !== undefined) {
+		const lock = path.join(root, 'run/catalog-writer-lifetime.lock')
+		fs.writeFileSync(lock, '')
+		fs.chmodSync(lock, lockMode)
+	}
+	if (runMode !== undefined) fs.chmodSync(path.join(root, 'run'), runMode)
 	if (blockingState) {
 		fs.writeFileSync(path.join(root, 'run', blockingState), 'blocked\n')
 	}
@@ -307,4 +323,72 @@ test('a missing pm2 process is a note, not a failure', () => {
 	const result = preflight(root, () => [])
 	expect(result.failures).toEqual([])
 	expect(result.notes.join('\n')).toContain('no saved veud-backup process yet')
+})
+
+test('the staging port in application.env is refused with its cause named', () => {
+	// The exact failure that stopped the recovery deployment at its health check:
+	// production carried staging's port, and `${PORT:-4021}` cannot override a
+	// value that is already set, so production tried to bind the port the running
+	// staging app already held.
+	const result = run({ port: '4022' })
+	const report = result.failures.join('\n')
+	expect(report).toContain('application.env PORT must be 4021')
+	expect(report).toContain('found 4022')
+	expect(report).toContain('staging port')
+})
+
+test('any other wrong port is refused without claiming it came from staging', () => {
+	const result = run({ port: '8080' })
+	const report = result.failures.join('\n')
+	expect(report).toContain('found 8080')
+	expect(report).not.toContain('staging port')
+})
+
+test('an unset port is a note, because the launcher default applies', () => {
+	const root = productionRoot()
+	const file = path.join(root, 'config/application.env')
+	fs.writeFileSync(
+		file,
+		fs
+			.readFileSync(file, 'utf8')
+			.split('\n')
+			.filter(line => !line.startsWith('PORT='))
+			.join('\n'),
+		{ mode: 0o600 },
+	)
+	const result = preflight(root)
+	expect(result.failures).toEqual([])
+	expect(result.notes.join(' ')).toContain('PORT is unset')
+})
+
+test('a host that would expose production beyond the proxy is refused', () => {
+	const result = run({ host: '0.0.0.0' })
+	expect(result.failures.join('\n')).toContain('application.env HOST must be')
+	expect(result.failures.join('\n')).toContain('found 0.0.0.0')
+})
+
+test('a group or world accessible runtime state directory is refused', () => {
+	// `run/` was mode 0777 with a default ACL granting other rwx, so every lock
+	// created there inherited 0666 and the writer guard blocked the deployment.
+	const result = run({ runMode: 0o777 })
+	const report = result.failures.join('\n')
+	expect(report).toContain(
+		'runtime state directory is group or world accessible',
+	)
+	expect(report).toContain('777')
+})
+
+test('a group or world writable runtime lock is refused', () => {
+	// The catalog-writer runtime guard requires (mode & 0o022) === 0, so the
+	// preflight has to reject exactly what the guard would reject — otherwise it
+	// passes and the writer fails later, mid-cutover.
+	const result = run({ lockMode: 0o666 })
+	const report = result.failures.join('\n')
+	expect(report).toContain('catalog-writer-lifetime.lock')
+	expect(report).toContain('group or world writable')
+})
+
+test('a private runtime lock passes', () => {
+	const result = run({ lockMode: 0o600 })
+	expect(result.failures).toEqual([])
 })


### PR DESCRIPTION
Promotes the preflight checks for the two host misconfigurations that stopped the recovery deployment after the database had already been migrated: production carrying staging's `PORT=4022` (unbindable while staging runs), and `run/` at 0777 with a default ACL that made every lock 0666, which the catalog-writer guard correctly refused.