### PR TITLE
Stop deployments wiping catalog data that lacks trusted provenance

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,6 +67,27 @@ the working directory instead of the activated release, which is the same drift
 the saved definition caused in the first place. The commands above are for
 restarting an already-deployed release.
 
+### Catalog provenance quarantine
+
+A deployment reports how much of the catalog lacks trusted provider provenance,
+but it does **not** wipe it. Quarantining clears title, type, description,
+genres, artwork, scores and release dates on every unattributed media row, and
+the denormalised copies of those on user list entries and favourites.
+
+That matters because the provenance epoch migration defaults every pre-existing
+row to untrusted. The first deployment carrying it quarantined the whole catalog
+— 1,569,263 rows — and only provider re-hydration restores it, which is weeks at
+provider rate limits. The live site showed no posters, titles or types
+throughout.
+
+Enable it deliberately, once `npm run catalog:status` shows re-hydration has
+actually attributed the catalog:
+
+```sh
+VEUD_PRODUCTION_CATALOG_QUARANTINE=enforce \
+  bash ops/local-production/deploy-catalog-release.sh
+```
+
 ### Deploying over an outage
 
 A deployment normally opens a maintenance window on a _running_ system, because

--- a/ops/local-production/deploy-catalog-release.sh
+++ b/ops/local-production/deploy-catalog-release.sh
@@ -1380,14 +1380,40 @@ write_maintenance_state migrating
 		migrate deploy \
 		--schema="$destination/prisma/postgresql/schema.prisma"
 	DATABASE_URL="$DATABASE_URL" "$NPM_BIN" run db:verify:postgres
+	# The provenance report always runs, so a deployment still says exactly how
+	# much of the catalog lacks trusted provenance.
 	DATABASE_URL="$DATABASE_URL" "$NODE_BIN" --import tsx \
 		"$destination/scripts/quarantine-media-catalog-provenance.ts" \
 		--batch-size 100
-	DATABASE_URL="$DATABASE_URL" "$NODE_BIN" --import tsx \
-		"$destination/scripts/quarantine-media-catalog-provenance.ts" \
-		--commit \
-		--confirm QUARANTINE_UNTRUSTED_MEDIA_CATALOG \
-		--batch-size 100
+	# Quarantining CLEARS the catalog columns of every media row that is not
+	# attributed to a trusted provider source: title, type, description, genres,
+	# artwork, scores, release dates, and the denormalised copies of those on user
+	# list entries and favourites.
+	#
+	# The provenance epoch migration defaults every pre-existing row to untrusted,
+	# so the first deployment carrying it wipes the entire catalog — 1,569,263 rows
+	# here — and only provider re-hydration can restore it. At provider rate limits
+	# that is weeks, during which the live site shows no posters, titles, or types.
+	#
+	# So this stays OFF until the first re-hydration has attributed the catalog.
+	# Turn it on deliberately, once `npm run catalog:status` shows hydration has
+	# actually covered the catalog:
+	#
+	#     VEUD_PRODUCTION_CATALOG_QUARANTINE=enforce
+	#
+	# `--require-clean` is gated with it: it fails when untrusted media remain,
+	# which is the expected state while the quarantine is off.
+	if [[ "${VEUD_PRODUCTION_CATALOG_QUARANTINE:-skip}" == enforce ]]; then
+		DATABASE_URL="$DATABASE_URL" "$NODE_BIN" --import tsx \
+			"$destination/scripts/quarantine-media-catalog-provenance.ts" \
+			--commit \
+			--confirm QUARANTINE_UNTRUSTED_MEDIA_CATALOG \
+			--batch-size 100
+	else
+		printf '%s\n' \
+			'Catalog quarantine SKIPPED: untrusted media keep their catalog data.' \
+			'Set VEUD_PRODUCTION_CATALOG_QUARANTINE=enforce once re-hydration has attributed the catalog.' >&2
+	fi
 	DATABASE_URL="$DATABASE_URL" "$NODE_BIN" --import tsx \
 		"$destination/scripts/backfill-next-release-at.ts" \
 		--commit
@@ -1395,10 +1421,12 @@ write_maintenance_state migrating
 		"$destination/scripts/sync-watchlist-metadata.ts" \
 		--commit \
 		--batch-size 100
-	DATABASE_URL="$DATABASE_URL" "$NODE_BIN" --import tsx \
-		"$destination/scripts/quarantine-media-catalog-provenance.ts" \
-		--batch-size 100 \
-		--require-clean
+	if [[ "${VEUD_PRODUCTION_CATALOG_QUARANTINE:-skip}" == enforce ]]; then
+		DATABASE_URL="$DATABASE_URL" "$NODE_BIN" --import tsx \
+			"$destination/scripts/quarantine-media-catalog-provenance.ts" \
+			--batch-size 100 \
+			--require-clean
+	fi
 )
 write_maintenance_state database-compatible
 }

--- a/scripts/catalog-cutover-guard.test.mjs
+++ b/scripts/catalog-cutover-guard.test.mjs
@@ -4363,3 +4363,48 @@ test('guard-asserting scripts never run through the bare tsx CLI', () => {
 		}
 	}
 })
+
+test('a deployment does not wipe untrusted catalog data unless quarantine is enforced', () => {
+	// The provenance epoch migration defaults every pre-existing row to untrusted,
+	// so the first deployment carrying it quarantined the entire catalog: 1,569,263
+	// rows lost title, type, description, genres, artwork, scores and dates, along
+	// with the denormalised copies on user list entries. Only provider re-hydration
+	// restores that, which is weeks at provider rate limits.
+	const mutate = extractShellFunction(productionDeploy, 'production_mutate')
+
+	// The destructive commit and the --require-clean gate are both conditional.
+	const destructive = mutate
+		.split('\n')
+		.filter(line =>
+			line.includes('--confirm QUARANTINE_UNTRUSTED_MEDIA_CATALOG'),
+		)
+	assert.equal(destructive.length, 1, 'expected exactly one quarantine commit')
+	assert.match(
+		mutate,
+		/if \[\[ "\$\{VEUD_PRODUCTION_CATALOG_QUARANTINE:-skip\}" == enforce \]\]; then\n(?:.*\n)*?\t*--confirm QUARANTINE_UNTRUSTED_MEDIA_CATALOG/,
+		'the quarantine commit must be gated behind an explicit enforce',
+	)
+	assert.match(
+		mutate,
+		/if \[\[ "\$\{VEUD_PRODUCTION_CATALOG_QUARANTINE:-skip\}" == enforce \]\]; then\n(?:.*\n)*?\t*--require-clean/,
+		'--require-clean must be gated too; it fails while untrusted media remain',
+	)
+
+	// The default must be skip, never enforce.
+	assert.doesNotMatch(
+		mutate,
+		/VEUD_PRODUCTION_CATALOG_QUARANTINE:-enforce/,
+		'the default must not enforce the destructive quarantine',
+	)
+
+	// The read-only report still runs unconditionally, so a deployment always
+	// states how much of the catalog lacks trusted provenance.
+	const reportOnly = mutate
+		.split('\n')
+		.some(
+			line =>
+				line.includes('quarantine-media-catalog-provenance.ts') &&
+				!line.includes('--confirm'),
+		)
+	assert.ok(reportOnly, 'the provenance report must still run')
+})


### PR DESCRIPTION
The provenance epoch migration defaults every pre-existing media row to untrusted, so the first deployment carrying it quarantined **the entire catalog — 1,569,263 rows**. Quarantining clears title, type, description, genres, artwork, scores and release dates, plus the denormalised copies on user list entries and favourites.

Only provider re-hydration restores that, and at provider rate limits it is weeks — hydration sat at 0% across all four provider surfaces while the live site showed no posters, no titles and no types, and user lists rendered as empty pickers.

The destructive commit is now gated behind an explicit `VEUD_PRODUCTION_CATALOG_QUARANTINE=enforce`, defaulting to skip. `--require-clean` is gated with it, since it fails while untrusted media remain. The read-only provenance report still runs every deployment, so a release always reports how much of the catalog is unattributed.

This **defers** a real provenance boundary rather than removing it — enable it once re-hydration has attributed the catalog. Mutation-verified that the default cannot silently flip to enforce and that the commit cannot become unconditional.