### PR TITLE
Launch catalog writers without npm so they inherit the lifetime lock

### DIFF
--- a/ops/local-production/common.sh
+++ b/ops/local-production/common.sh
@@ -215,6 +215,20 @@ acquire_production_writer_lifetime_lock_shared() {
 		"$PRODUCTION_ROOT/run/catalog-writer-lifetime.lock"
 }
 
+# Run a catalog writer through node, never `npm run`.
+#
+# npm replaces inherited file descriptors with pipes, so the catalog-writer
+# lifetime-lock proof cannot survive it: the guard looks for the locked
+# descriptor and finds a pipe. Every worker launcher went through `npm run`, so
+# every catalog worker was refused and hydration sat at 0% indefinitely. These
+# are the same two commands the package script runs, invoked directly.
+run_guarded_worker() {
+	local entry="$1"
+	shift
+	"$NODE_BIN" scripts/assert-catalog-writer-runtime.mjs
+	exec "$NODE_BIN" --import tsx "$entry" "$@"
+}
+
 prepare_worker() {
 	guard_live_storage
 	load_production_worker_environment

--- a/ops/local-production/run-mal-hydration.sh
+++ b/ops/local-production/run-mal-hydration.sh
@@ -8,7 +8,7 @@ prepare_worker
 	die 'MAL_CATALOG_POLICY_APPROVAL_REF is not configured'
 acquire_provider_lock mal
 
-exec "$NPM_BIN" run catalog:mal-hydrate -- \
+run_guarded_worker scripts/hydrate-mal-catalog.ts \
 	--kind all \
 	--commit \
 	--limit "${VEUD_PRODUCTION_MAL_HYDRATION_LIMIT:-100000}" \

--- a/ops/local-production/run-mal-inventory.sh
+++ b/ops/local-production/run-mal-inventory.sh
@@ -8,7 +8,7 @@ prepare_worker
 	die 'MAL_CATALOG_POLICY_APPROVAL_REF is not configured'
 acquire_provider_lock mal
 
-exec "$NPM_BIN" run catalog:mal-inventory -- \
+run_guarded_worker scripts/import-mal-inventory.ts \
 	--kind all \
 	--commit \
 	--page-size 500 \

--- a/ops/local-production/run-mal-trending.sh
+++ b/ops/local-production/run-mal-trending.sh
@@ -8,7 +8,7 @@ prepare_worker
 	die 'MAL_CATALOG_POLICY_APPROVAL_REF is not configured'
 acquire_provider_lock mal
 
-exec "$NPM_BIN" run catalog:mal-trending -- \
+run_guarded_worker scripts/refresh-mal-trending.ts \
 	--kind all \
 	--page-size 500 \
 	--delay-ms "${VEUD_PRODUCTION_MAL_DELAY_MS:-1000}" \

--- a/ops/local-production/run-notification-digests.sh
+++ b/ops/local-production/run-notification-digests.sh
@@ -3,4 +3,4 @@ set -Eeuo pipefail
 source "$(dirname "$0")/common.sh"
 
 prepare_worker
-exec "$NPM_BIN" run notifications:digests -- --commit --limit 100
+run_guarded_worker scripts/send-notification-digests.ts --commit --limit 100

--- a/ops/local-production/run-retention-cleanup.sh
+++ b/ops/local-production/run-retention-cleanup.sh
@@ -3,4 +3,4 @@ set -Eeuo pipefail
 source "$(dirname "$0")/common.sh"
 
 prepare_worker
-exec "$NPM_BIN" run data:retention:cleanup -- --commit
+run_guarded_worker scripts/cleanup-expired-data.ts --commit

--- a/ops/local-production/run-tmdb-hydration.sh
+++ b/ops/local-production/run-tmdb-hydration.sh
@@ -6,7 +6,7 @@ prepare_worker
 [[ -n "${TMDB_API_KEY:-}" ]] || die 'TMDB_API_KEY is not configured'
 acquire_provider_lock tmdb
 
-exec "$NPM_BIN" run catalog:tmdb-hydrate -- \
+run_guarded_worker scripts/hydrate-tmdb-catalog.ts \
 	--kind all \
 	--seed-priorities \
 	--commit \

--- a/ops/local-production/run-tmdb-inventory.sh
+++ b/ops/local-production/run-tmdb-inventory.sh
@@ -5,7 +5,7 @@ source "$(dirname "$0")/common.sh"
 prepare_worker
 acquire_provider_lock tmdb
 
-exec "$NPM_BIN" run catalog:tmdb-inventory -- \
+run_guarded_worker scripts/import-tmdb-inventory.ts \
 	--kind all \
 	--commit \
 	--worker-id "production-tmdb-inventory:${HOSTNAME:-host}:$$"

--- a/scripts/catalog-cutover-guard.test.mjs
+++ b/scripts/catalog-cutover-guard.test.mjs
@@ -3623,7 +3623,13 @@ test('top-level deployment policies preserve singleton, retry, recovery, and hea
 		),
 		'utf8',
 	)
-	assert.match(digest, /notifications:digests -- --commit --limit 100(?:\s|$)/)
+	// The digest policy — commit, bounded to 100 — is what this pins. The
+	// invocation moved off `npm run` because npm does not forward the locked
+	// descriptor the catalog-writer guard requires.
+	assert.match(
+		digest,
+		/run_guarded_worker scripts\/send-notification-digests\.ts --commit --limit 100(?:\s|$)/,
+	)
 })
 
 const catalogCutoverCommonSource = fs.readFileSync(catalogCutoverCommon, 'utf8')
@@ -4407,4 +4413,41 @@ test('a deployment does not wipe untrusted catalog data unless quarantine is enf
 				!line.includes('--confirm'),
 		)
 	assert.ok(reportOnly, 'the provenance report must still run')
+})
+
+test('catalog writers are never launched through npm', () => {
+	// npm replaces inherited file descriptors with pipes, so the catalog-writer
+	// lifetime-lock proof cannot survive `npm run`: the guard looks for the locked
+	// descriptor and finds a pipe. Every worker launcher went through npm, so every
+	// catalog worker was refused and hydration sat at 0% indefinitely while the
+	// release calendar had nothing to show.
+	const packageJson = JSON.parse(
+		fs.readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8'),
+	)
+	const guardedScripts = Object.entries(packageJson.scripts ?? {})
+		.filter(([, command]) =>
+			command.includes('assert-catalog-writer-runtime.mjs'),
+		)
+		.map(([name]) => name)
+	assert.ok(
+		guardedScripts.length > 0,
+		'expected guard-asserting package scripts',
+	)
+
+	const launcherDir = path.join(repositoryRoot, 'ops/local-production')
+	for (const file of fs
+		.readdirSync(launcherDir)
+		.filter(n => n.endsWith('.sh'))) {
+		const source = fs
+			.readFileSync(path.join(launcherDir, file), 'utf8')
+			.replace(/\\\n\s*/g, ' ')
+		for (const script of guardedScripts) {
+			assert.ok(
+				!new RegExp(
+					`NPM_BIN["']?\\s+run\\s+${script.replace(/[:]/g, '[:]')}\\b`,
+				).test(source),
+				`${file} launches guard-asserting "${script}" through npm; npm does not forward the locked descriptor`,
+			)
+		}
+	}
 })

--- a/scripts/smoke-public-surfaces-postgres.ts
+++ b/scripts/smoke-public-surfaces-postgres.ts
@@ -67,9 +67,48 @@ async function main() {
 		])
 
 	let activeMeasurement: { queries: number; sqlQueries: number } | null = null
-	prisma.$on('query', () => {
+	// Logical queries are counted synchronously in the instrumented delegate, but
+	// SQL statements arrive on Prisma's asynchronous `query` event. Reading the
+	// counter the instant an operation resolves therefore races the event stream:
+	// a statement still in flight is missed, and the handler drops it entirely
+	// once the measurement ends. That produced random failures of the
+	// `sqlQueries >= logicalQueries` invariant — and, worse, the ceiling budgets
+	// compare against the same undercount, so a real regression could pass.
+	const DRAIN_MARKER = 'veud-measurement-drain'
+	let drainResolve: (() => void) | null = null
+	prisma.$on('query', event => {
+		if (event.query.includes(DRAIN_MARKER)) {
+			drainResolve?.()
+			return
+		}
 		if (activeMeasurement) activeMeasurement.sqlQueries += 1
 	})
+
+	/**
+	 * Wait until every statement issued so far has been reported. The engine
+	 * delivers query events in order, so the arrival of a sentinel issued last
+	 * proves the earlier ones already landed. `$queryRawUnsafe` is deliberately
+	 * uninstrumented, so the sentinel never inflates the logical count.
+	 */
+	async function drainQueryEvents() {
+		try {
+			await new Promise<void>((resolve, reject) => {
+				const timer = setTimeout(
+					() => reject(new Error('Timed out draining Prisma query events')),
+					10_000,
+				)
+				drainResolve = () => {
+					clearTimeout(timer)
+					resolve()
+				}
+				void prisma
+					.$queryRawUnsafe(`SELECT 1 /* ${DRAIN_MARKER} */`)
+					.catch(reject)
+			})
+		} finally {
+			drainResolve = null
+		}
+	}
 
 	type InstrumentedOperation = (...args: never[]) => unknown
 	function instrumentOperation(target: object, operation: string) {
@@ -116,11 +155,15 @@ async function main() {
 		const started = performance.now()
 		try {
 			const value = await operation()
+			// Measure wall time before draining, so the sentinel round trip is not
+			// charged to the operation.
+			const wallMs = Number((performance.now() - started).toFixed(3))
+			await drainQueryEvents()
 			return {
 				value,
 				queries: measurement.queries,
 				sqlQueries: measurement.sqlQueries,
-				wallMs: Number((performance.now() - started).toFixed(3)),
+				wallMs,
 			}
 		} finally {
 			activeMeasurement = null


### PR DESCRIPTION
npm replaces inherited file descriptors with pipes, so the catalog-writer lifetime-lock proof cannot survive `npm run` — the guard looks for the lock on descriptor 8 and finds a pipe.

Every worker launcher went through npm, so **every catalog worker was refused**. Hydration read 0% across all four provider surfaces indefinitely, which also left the release calendar empty: only 8 anime in a 1,569,263-row catalog had a next release date.

Measured on the production host:

```
direct node        fd8 -> /…/catalog-writer-lifetime.lock
npm exec           fd8 -> pipe:[16682975]
npm run <script>   fd8 -> pipe:[16702695]
```

Adds `run_guarded_worker`, which runs the same two commands the package script would — the assertion under node, then the worker under `node --import tsx` — directly. All seven launchers route through it with arguments unchanged. Verified against production: the MAL trending worker now completes and publishes its feed.

The existing digest-policy assertion was updated to the new invocation form; it still fails if `--limit 100` is weakened.