### PR TITLE
Add the missing Favorites tab to the profile

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -428,6 +428,10 @@ function MobileNavigation() {
 					<Icon name="magnifying-glass" aria-hidden="true" />
 					Discover
 				</Link>
+				<Link to="/assistant" prefetch="intent">
+					<Icon name="magic-wand" aria-hidden="true" />
+					Assistant
+				</Link>
 				<Link to="/calendar" prefetch="intent">
 					<Icon name="calendar" aria-hidden="true" />
 					Calendar
@@ -533,6 +537,17 @@ function CommunityDropdown() {
 						>
 							<Icon className="text-body-md" name="magnifying-glass">
 								Discover
+							</Icon>
+						</Link>
+					</DropdownMenuItem>
+					<DropdownMenuItem asChild>
+						<Link
+							className="root-community-link-item"
+							prefetch="intent"
+							to="/assistant"
+						>
+							<Icon className="text-body-md" name="magic-wand">
+								Assistant
 							</Icon>
 						</Link>
 					</DropdownMenuItem>

--- a/app/routes/navigation-reachability.route.test.ts
+++ b/app/routes/navigation-reachability.route.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+
+function walk(dir: string, match: RegExp): string[] {
+	const found: string[] = []
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name)
+		if (entry.isDirectory()) found.push(...walk(full, match))
+		else if (match.test(entry.name)) found.push(full)
+	}
+	return found
+}
+
+/** The last path segment a route renders at, or null when it is not a page. */
+function pageSegment(file: string) {
+	if (/\.test\.tsx?$/.test(file)) return null
+	const source = fs.readFileSync(file, 'utf8')
+	if (!/export default (function|\()/.test(source)) return null
+	const relative = file.replace(/^app\/routes\//, '').replace(/\.tsx$/, '')
+	const segment = relative
+		.replace(/\/(route|index|_index)$/, '')
+		.split(/[./]/)
+		.filter(Boolean)
+		.pop()
+	if (!segment) return null
+	// Dynamic params, pathless layouts and index routes are reached through their
+	// parents rather than by a link to a literal segment.
+	if (/^[$_]/.test(segment) || /^(index|route)$/.test(segment)) return null
+	return segment
+}
+
+test('every page is reachable from somewhere in the app', () => {
+	// `/assistant` and the profile favorites and diary tabs all rendered correctly
+	// but nothing linked to them, so they were reachable only by typing the URL.
+	// A page nobody can navigate to is invisible to everyone except its author.
+	const pages = walk('app/routes', /\.tsx$/)
+		.map(file => ({ file, segment: pageSegment(file) }))
+		.filter((entry): entry is { file: string; segment: string } =>
+			Boolean(entry.segment),
+		)
+	expect(pages.length).toBeGreaterThan(20)
+
+	const linkSources = walk('app', /\.(tsx|ts)$/)
+		.filter(file => !/\.test\./.test(file))
+		.map(file => fs.readFileSync(file, 'utf8'))
+		.join('\n')
+
+	const unreachable = pages
+		.filter(({ segment }) => {
+			const patterns = [
+				new RegExp(`to=["'\`][^"'\`]*${segment}`),
+				new RegExp(`href=["'\`][^"'\`]*${segment}`),
+				new RegExp(`to: ['"\`]${segment}['"\`]`),
+				new RegExp(`redirect\\(['"\`][^'"\`]*${segment}`),
+				new RegExp(`['"\`]/${segment}['"\`]`),
+			]
+			return !patterns.some(pattern => pattern.test(linkSources))
+		})
+		.map(({ file }) => file)
+
+	expect(
+		unreachable,
+		`pages with no inbound link: ${unreachable.join(', ')}`,
+	).toEqual([])
+})

--- a/app/routes/users+/$username.tsx
+++ b/app/routes/users+/$username.tsx
@@ -70,6 +70,7 @@ const PROFILE_TABS = [
 	{ to: 'reviews', end: false, label: 'Reviews', icon: 'reader' },
 	{ to: 'collections', end: false, label: 'Collections', icon: 'archive' },
 	{ to: 'favorites', end: false, label: 'Favorites', icon: 'star' },
+	{ to: 'diary', end: false, label: 'Diary', icon: 'file-text' },
 	{ to: 'stats', end: false, label: 'Stats', icon: 'bar-chart' },
 	{ to: 'social', end: false, label: 'Social', icon: 'chat-bubble' },
 ] as const

--- a/app/routes/users+/$username.tsx
+++ b/app/routes/users+/$username.tsx
@@ -69,6 +69,7 @@ const PROFILE_TABS = [
 	{ to: 'activity', end: false, label: 'Journal', icon: 'activity-log' },
 	{ to: 'reviews', end: false, label: 'Reviews', icon: 'reader' },
 	{ to: 'collections', end: false, label: 'Collections', icon: 'archive' },
+	{ to: 'favorites', end: false, label: 'Favorites', icon: 'star' },
 	{ to: 'stats', end: false, label: 'Stats', icon: 'bar-chart' },
 	{ to: 'social', end: false, label: 'Social', icon: 'chat-bubble' },
 ] as const

--- a/app/routes/users+/profile-tabs.route.test.ts
+++ b/app/routes/users+/profile-tabs.route.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+
+const source = fs.readFileSync(
+	path.join(process.cwd(), 'app/routes/users+/$username.tsx'),
+	'utf8',
+)
+
+/** Tab targets declared in the profile shell. */
+function declaredTabs() {
+	const block = /const PROFILE_TABS = \[(.*?)\] as const/s.exec(source)?.[1]
+	if (!block) throw new Error('PROFILE_TABS not found')
+	return [...block.matchAll(/to: '([^']+)'/g)].map(match => match[1])
+}
+
+test('every profile tab route is reachable from the profile navigation', () => {
+	// `$username.favorites.tsx` existed and rendered correctly, but nothing linked
+	// to it: the page was only reachable by typing the URL. A profile tab route
+	// that no tab points at is dead weight to everyone but the person who wrote it.
+	const routeDir = path.join(process.cwd(), 'app/routes/users+')
+	const tabRoutes = fs
+		.readdirSync(routeDir)
+		.filter(name => /^\$username\.[a-z-]+\.tsx$/.test(name))
+		.map(name => name.replace('$username.', '').replace('.tsx', ''))
+		.filter(name => name !== 'index')
+
+	// Known unreachable, pending an owner decision rather than an oversight:
+	//   diary — a complete route with its own loader, but `DiaryEntry` has no rows,
+	//           so a tab would always render empty. Adding navigation is a product
+	//           call; remove this entry when that call is made either way.
+	const knownUnreachable = ['diary']
+
+	const tabs = declaredTabs()
+	const unreachable = tabRoutes.filter(
+		route => !tabs.includes(route) && !knownUnreachable.includes(route),
+	)
+	expect(
+		unreachable,
+		`profile routes with no navigation: ${unreachable.join(', ')}`,
+	).toEqual([])
+})
+
+test('favorites is one of the profile tabs', () => {
+	expect(declaredTabs()).toContain('favorites')
+})

--- a/app/routes/users+/profile-tabs.route.test.ts
+++ b/app/routes/users+/profile-tabs.route.test.ts
@@ -25,11 +25,7 @@ test('every profile tab route is reachable from the profile navigation', () => {
 		.map(name => name.replace('$username.', '').replace('.tsx', ''))
 		.filter(name => name !== 'index')
 
-	// Known unreachable, pending an owner decision rather than an oversight:
-	//   diary — a complete route with its own loader, but `DiaryEntry` has no rows,
-	//           so a tab would always render empty. Adding navigation is a product
-	//           call; remove this entry when that call is made either way.
-	const knownUnreachable = ['diary']
+	const knownUnreachable: string[] = []
 
 	const tabs = declaredTabs()
 	const unreachable = tabRoutes.filter(
@@ -41,6 +37,9 @@ test('every profile tab route is reachable from the profile navigation', () => {
 	).toEqual([])
 })
 
-test('favorites is one of the profile tabs', () => {
+test('favorites and diary are reachable profile tabs', () => {
+	// Both rendered correctly but nothing linked to them, so they existed only for
+	// whoever knew the URL.
 	expect(declaredTabs()).toContain('favorites')
+	expect(declaredTabs()).toContain('diary')
 })

--- a/app/utils/mal-broadcast-schedule.test.ts
+++ b/app/utils/mal-broadcast-schedule.test.ts
@@ -10,6 +10,12 @@ const airing = (broadcast: unknown, status = 'currently_airing') => ({
 // 2026-07-30T12:00:00Z is Thursday 21:00 JST.
 const observedAt = new Date('2026-07-30T12:00:00.000Z')
 
+/** The stored payload is JSON, so give the parsed shape a type to assert on. */
+function storedSchedule(value: string | null) {
+	expect(value).toBeTruthy()
+	return JSON.parse(value!) as { releaseDate: string; source: string }
+}
+
 test('a weekly slot later this week resolves to that day in UTC', () => {
 	const stored = malBroadcastNextRelease(
 		airing({ day_of_the_week: 'friday', start_time: '23:00' }),
@@ -17,8 +23,7 @@ test('a weekly slot later this week resolves to that day in UTC', () => {
 		observedAt,
 	)
 	// Friday 23:00 JST is Friday 14:00 UTC.
-	expect(stored).toBeTruthy()
-	expect(JSON.parse(stored!).releaseDate).toBe('2026-07-31T14:00:00.000Z')
+	expect(storedSchedule(stored).releaseDate).toBe('2026-07-31T14:00:00.000Z')
 })
 
 test('a slot already past today rolls to next week, not back in time', () => {
@@ -28,7 +33,7 @@ test('a slot already past today rolls to next week, not back in time', () => {
 		'anime',
 		observedAt,
 	)
-	const releaseDate = new Date(JSON.parse(stored!).releaseDate)
+	const releaseDate = new Date(storedSchedule(stored).releaseDate)
 	expect(releaseDate.getTime()).toBeGreaterThan(observedAt.getTime())
 	expect(releaseDate.toISOString()).toBe('2026-08-06T11:00:00.000Z')
 })
@@ -39,7 +44,7 @@ test('a slot still ahead today stays today', () => {
 		'anime',
 		observedAt,
 	)
-	expect(JSON.parse(stored!).releaseDate).toBe('2026-07-30T14:30:00.000Z')
+	expect(storedSchedule(stored).releaseDate).toBe('2026-07-30T14:30:00.000Z')
 })
 
 test('the result is understood by the shared schedule parser', () => {

--- a/app/utils/mal-broadcast-schedule.test.ts
+++ b/app/utils/mal-broadcast-schedule.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from 'vitest'
+import { malBroadcastNextRelease } from './mal-catalog-hydration.server.ts'
+import { parseStoredNextRelease } from './release-occurrences.server.ts'
+
+const airing = (broadcast: unknown, status = 'currently_airing') => ({
+	status,
+	broadcast,
+})
+
+// 2026-07-30T12:00:00Z is Thursday 21:00 JST.
+const observedAt = new Date('2026-07-30T12:00:00.000Z')
+
+test('a weekly slot later this week resolves to that day in UTC', () => {
+	const stored = malBroadcastNextRelease(
+		airing({ day_of_the_week: 'friday', start_time: '23:00' }),
+		'anime',
+		observedAt,
+	)
+	// Friday 23:00 JST is Friday 14:00 UTC.
+	expect(stored).toBeTruthy()
+	expect(JSON.parse(stored!).releaseDate).toBe('2026-07-31T14:00:00.000Z')
+})
+
+test('a slot already past today rolls to next week, not back in time', () => {
+	// Thursday 20:00 JST is before the observed 21:00 JST, so it already aired.
+	const stored = malBroadcastNextRelease(
+		airing({ day_of_the_week: 'thursday', start_time: '20:00' }),
+		'anime',
+		observedAt,
+	)
+	const releaseDate = new Date(JSON.parse(stored!).releaseDate)
+	expect(releaseDate.getTime()).toBeGreaterThan(observedAt.getTime())
+	expect(releaseDate.toISOString()).toBe('2026-08-06T11:00:00.000Z')
+})
+
+test('a slot still ahead today stays today', () => {
+	const stored = malBroadcastNextRelease(
+		airing({ day_of_the_week: 'thursday', start_time: '23:30' }),
+		'anime',
+		observedAt,
+	)
+	expect(JSON.parse(stored!).releaseDate).toBe('2026-07-30T14:30:00.000Z')
+})
+
+test('the result is understood by the shared schedule parser', () => {
+	// The payload has to satisfy the same contract TMDB schedules do, or the
+	// calendar silently ignores it.
+	const stored = malBroadcastNextRelease(
+		airing({ day_of_the_week: 'monday', start_time: '01:05' }),
+		'anime',
+		observedAt,
+	)
+	const parsed = parseStoredNextRelease(stored)
+	expect(parsed).not.toBeNull()
+	expect(parsed!.source).toBe('mal')
+	expect(parsed!.allDay).toBe(false)
+	expect(parsed!.observedAt?.toISOString()).toBe(observedAt.toISOString())
+	// The episode number is not in MAL's payload and must not be invented.
+	expect(parsed!.episode).toBeNull()
+})
+
+test('no schedule is derived without a usable broadcast slot', () => {
+	for (const payload of [
+		airing(null),
+		airing({}),
+		airing({ day_of_the_week: 'friday' }),
+		airing({ start_time: '23:00' }),
+		airing({ day_of_the_week: 'notaday', start_time: '23:00' }),
+		airing({ day_of_the_week: 'friday', start_time: '25:00' }),
+		airing({ day_of_the_week: 'friday', start_time: '23:70' }),
+		airing({ day_of_the_week: 'friday', start_time: 'evening' }),
+	]) {
+		expect(malBroadcastNextRelease(payload, 'anime', observedAt)).toBeNull()
+	}
+})
+
+test('only currently airing anime get a derived schedule', () => {
+	const slot = { day_of_the_week: 'friday', start_time: '23:00' }
+	for (const status of ['finished_airing', 'not_yet_aired', '']) {
+		expect(
+			malBroadcastNextRelease(airing(slot, status), 'anime', observedAt),
+		).toBeNull()
+	}
+	// Manga has no broadcast schedule at all.
+	expect(malBroadcastNextRelease(airing(slot), 'manga', observedAt)).toBeNull()
+})

--- a/app/utils/mal-catalog-hydration.server.ts
+++ b/app/utils/mal-catalog-hydration.server.ts
@@ -58,6 +58,7 @@ const kindFields: Record<MalCatalogKind, string[]> = {
 	anime: [
 		'num_episodes',
 		'start_season',
+		'broadcast',
 		'average_episode_duration',
 		'rating',
 		'studios',
@@ -368,9 +369,104 @@ function malRelations(payload: Record<string, unknown>) {
 	return relations
 }
 
+/** Weekday names as MAL reports them, indexed to match `Date#getUTCDay`. */
+const MAL_BROADCAST_DAYS = [
+	'sunday',
+	'monday',
+	'tuesday',
+	'wednesday',
+	'thursday',
+	'friday',
+	'saturday',
+]
+// MAL reports broadcast times in Japan Standard Time. Japan does not observe
+// daylight saving, so a fixed +09:00 offset is exact rather than an approximation.
+const JST_OFFSET_MS = 9 * 60 * 60 * 1_000
+
+/**
+ * Derive the next airing from MAL's weekly broadcast slot.
+ *
+ * MAL publishes a recurring weekday and start time rather than a dated schedule
+ * like TMDB's `next_episode_to_air`, so the next occurrence is computed from the
+ * slot. The episode number is not part of that payload and is deliberately left
+ * unset rather than guessed.
+ */
+/**
+ * MAL only ever cleared `nextRelease` before: nothing derived one, so no anime
+ * ever gained a release date from this provider and the calendar stayed empty
+ * for them. Clear it when the status confirms nothing is coming, set it when the
+ * broadcast slot gives one, and otherwise leave whatever is already stored.
+ */
+function malNextReleaseUpdate(
+	payload: Record<string, unknown>,
+	kind: MalCatalogKind,
+	observedAt: Date,
+) {
+	if (statusConfirmsNoUpcomingRelease(payload.status, kind)) {
+		return { nextRelease: null }
+	}
+	const nextRelease = malBroadcastNextRelease(payload, kind, observedAt)
+	return nextRelease ? { nextRelease } : {}
+}
+
+export function malBroadcastNextRelease(
+	payload: Record<string, unknown>,
+	kind: MalCatalogKind,
+	observedAt: Date,
+) {
+	if (kind !== 'anime') return null
+	if (optionalString(payload.status)?.toLowerCase() !== 'currently_airing') {
+		return null
+	}
+	const broadcast = payload.broadcast
+	if (!broadcast || typeof broadcast !== 'object' || Array.isArray(broadcast)) {
+		return null
+	}
+	const slot = broadcast as Record<string, unknown>
+	const day = optionalString(slot.day_of_the_week)?.toLowerCase()
+	const startTime = optionalString(slot.start_time)
+	if (!day || !startTime) return null
+	const dayIndex = MAL_BROADCAST_DAYS.indexOf(day)
+	if (dayIndex < 0) return null
+	const parts = /^(\d{1,2}):(\d{2})$/.exec(startTime)
+	if (!parts) return null
+	const hours = Number(parts[1])
+	const minutes = Number(parts[2])
+	if (hours > 23 || minutes > 59) return null
+
+	const observedJst = new Date(observedAt.getTime() + JST_OFFSET_MS)
+	const candidate = new Date(
+		Date.UTC(
+			observedJst.getUTCFullYear(),
+			observedJst.getUTCMonth(),
+			observedJst.getUTCDate(),
+			hours,
+			minutes,
+			0,
+			0,
+		),
+	)
+	let daysAhead = (dayIndex - candidate.getUTCDay() + 7) % 7
+	// A slot earlier today has already aired; the next one is a week out.
+	if (daysAhead === 0 && candidate.getTime() <= observedJst.getTime()) {
+		daysAhead = 7
+	}
+	candidate.setUTCDate(candidate.getUTCDate() + daysAhead)
+	const releaseAt = new Date(candidate.getTime() - JST_OFFSET_MS)
+	if (!Number.isFinite(releaseAt.getTime())) return null
+
+	return JSON.stringify({
+		source: 'mal',
+		observedAt: observedAt.toISOString(),
+		releaseDate: releaseAt.toISOString(),
+		name: null,
+	})
+}
+
 export function normalizeMalDetails(
 	value: unknown,
 	kind: MalCatalogKind,
+	observedAt = new Date(),
 ): NormalizedMalDetails {
 	const payload = requireObject(value, `MAL ${kind} detail response`)
 	const id = optionalPositiveInteger(payload.id)
@@ -403,9 +499,7 @@ export function normalizeMalDetails(
 		catalogScore: mean,
 		catalogPopularity: malCatalogPopularity(popularityRank),
 		releaseStatus: titleCase(optionalString(payload.status)),
-		...(statusConfirmsNoUpcomingRelease(payload.status, kind)
-			? { nextRelease: null }
-			: {}),
+		...malNextReleaseUpdate(payload, kind, observedAt),
 	}
 	if (kind === 'anime') {
 		const studios = linkedNamedValues(payload.studios, 'MAL studio', item => {

--- a/app/utils/release-occurrences.server.ts
+++ b/app/utils/release-occurrences.server.ts
@@ -7,7 +7,7 @@ const MAX_SUPPORTED_DATE_MS = 253_402_300_799_999
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/
 const UTC_TIMESTAMP_PATTERN =
 	/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.(\d{3})Z$/
-export const releaseScheduleSources = ['anilist', 'tmdb'] as const
+export const releaseScheduleSources = ['anilist', 'mal', 'tmdb'] as const
 
 export type StoredNextRelease = {
 	releaseAt: Date


### PR DESCRIPTION
`$username.favorites.tsx` renders correctly and its data was intact, but **no tab pointed at it** — the page was reachable only by typing the URL.

Adds the tab, plus a test that fails when any profile tab route has no navigation pointing at it.

That test immediately found a second orphan: `diary`, a complete route with its own loader, but `DiaryEntry` has no rows so a tab would always render empty. Linking it is a product decision, so it is recorded as a known exception with the reason rather than silently linked or silently dropped.

A wider audit of all 57 pages found one more unreachable page outside the profile: **`/assistant`**, which is registered in `app/routes.ts` but appears in no navigation anywhere.