### PR TITLE
Drop the assistant navigation button

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -428,10 +428,6 @@ function MobileNavigation() {
 					<Icon name="magnifying-glass" aria-hidden="true" />
 					Discover
 				</Link>
-				<Link to="/assistant" prefetch="intent">
-					<Icon name="magic-wand" aria-hidden="true" />
-					Assistant
-				</Link>
 				<Link to="/calendar" prefetch="intent">
 					<Icon name="calendar" aria-hidden="true" />
 					Calendar
@@ -537,17 +533,6 @@ function CommunityDropdown() {
 						>
 							<Icon className="text-body-md" name="magnifying-glass">
 								Discover
-							</Icon>
-						</Link>
-					</DropdownMenuItem>
-					<DropdownMenuItem asChild>
-						<Link
-							className="root-community-link-item"
-							prefetch="intent"
-							to="/assistant"
-						>
-							<Icon className="text-body-md" name="magic-wand">
-								Assistant
 							</Icon>
 						</Link>
 					</DropdownMenuItem>

--- a/app/routes/navigation-reachability.route.test.ts
+++ b/app/routes/navigation-reachability.route.test.ts
@@ -17,6 +17,11 @@ function pageSegment(file: string) {
 	if (/\.test\.tsx?$/.test(file)) return null
 	const source = fs.readFileSync(file, 'utf8')
 	if (!/export default (function|\()/.test(source)) return null
+	// A redirect-only route renders nothing and exists to forward the visitor
+	// somewhere else, so it is not a destination that needs navigation of its own.
+	if (/export default function \w+\(\) \{\s*return null\s*\}/.test(source)) {
+		return null
+	}
 	const relative = file.replace(/^app\/routes\//, '').replace(/\.tsx$/, '')
 	const segment = relative
 		.replace(/\/(route|index|_index)$/, '')


### PR DESCRIPTION
`/assistant` is a redirect route: it finds the viewer's first watchlist and forwards them to it, rendering nothing. The real tracking assistant is a dialog with its own trigger hitting `/resources/tracking-assistant`, so the nav entry I added pointed at a redirect that just lands on the watchlist. Owner confirmed it is not wanted.

The reachability test now skips redirect-only routes on principle rather than naming this one as an exception — a route that renders nothing and exists to forward the visitor elsewhere is not a destination. Verified it still fails when a genuinely rendered page loses its only link.