### PR TITLE
Record released manga chapters from MangaUpdates

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -428,10 +428,6 @@ function MobileNavigation() {
 					<Icon name="magnifying-glass" aria-hidden="true" />
 					Discover
 				</Link>
-				<Link to="/assistant" prefetch="intent">
-					<Icon name="magic-wand" aria-hidden="true" />
-					Assistant
-				</Link>
 				<Link to="/calendar" prefetch="intent">
 					<Icon name="calendar" aria-hidden="true" />
 					Calendar
@@ -537,17 +533,6 @@ function CommunityDropdown() {
 						>
 							<Icon className="text-body-md" name="magnifying-glass">
 								Discover
-							</Icon>
-						</Link>
-					</DropdownMenuItem>
-					<DropdownMenuItem asChild>
-						<Link
-							className="root-community-link-item"
-							prefetch="intent"
-							to="/assistant"
-						>
-							<Icon className="text-body-md" name="magic-wand">
-								Assistant
 							</Icon>
 						</Link>
 					</DropdownMenuItem>

--- a/app/routes/navigation-reachability.route.test.ts
+++ b/app/routes/navigation-reachability.route.test.ts
@@ -17,6 +17,11 @@ function pageSegment(file: string) {
 	if (/\.test\.tsx?$/.test(file)) return null
 	const source = fs.readFileSync(file, 'utf8')
 	if (!/export default (function|\()/.test(source)) return null
+	// A redirect-only route renders nothing and exists to forward the visitor
+	// somewhere else, so it is not a destination that needs navigation of its own.
+	if (/export default function \w+\(\) \{\s*return null\s*\}/.test(source)) {
+		return null
+	}
 	const relative = file.replace(/^app\/routes\//, '').replace(/\.tsx$/, '')
 	const segment = relative
 		.replace(/\/(route|index|_index)$/, '')

--- a/app/utils/mangaupdates-releases.server.ts
+++ b/app/utils/mangaupdates-releases.server.ts
@@ -1,0 +1,212 @@
+/**
+ * MangaUpdates chapter release ingestion.
+ *
+ * MangaUpdates records releases *after* they happen: `/v1/releases/search`
+ * returns a dated log of chapters that have shipped, and the series endpoint
+ * exposes `latest_chapter` but no forward schedule. There is therefore no
+ * upcoming-chapter date to ingest from this provider, and none is invented here.
+ * What this produces is a factual record of chapters that have been released.
+ */
+
+const RELEASES_ENDPOINT = 'https://api.mangaupdates.com/v1/releases/search'
+const SERIES_SEARCH_ENDPOINT = 'https://api.mangaupdates.com/v1/series/search'
+export const MANGAUPDATES_SOURCE = 'mangaupdates'
+export const MANGAUPDATES_PROVIDER = 'mangaupdates'
+/** A released chapter stays on the calendar for this long before it expires. */
+const RELEASE_VISIBILITY_DAYS = 30
+const DAY_MS = 24 * 60 * 60 * 1_000
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/
+
+export type MangaUpdatesRelease = {
+	sourceKey: string
+	releaseAt: Date
+	chapter: number | null
+	volume: number | null
+	name: string | null
+}
+
+function optionalString(value: unknown) {
+	return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+/**
+ * MangaUpdates reports chapter and volume as strings, and they are not always
+ * plain integers: ranges (`"12-13"`), decimals (`"12.5"`) and prefixes (`"c.12"`)
+ * all occur. Take the leading integer and ignore anything that has none, rather
+ * than coercing a range into a misleading single number.
+ */
+export function parseReleaseNumber(value: unknown) {
+	const raw = optionalString(value)
+	if (!raw) return null
+	const match = /^[^0-9]*(\d+)/.exec(raw)
+	if (!match) return null
+	const parsed = Number(match[1])
+	return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= 2_147_483_647
+		? parsed
+		: null
+}
+
+/**
+ * Normalise one release record. Anything without a usable date is dropped: a
+ * release with no date cannot be placed on a calendar, and guessing one would
+ * put fiction in front of the reader.
+ */
+export function normalizeMangaUpdatesRelease(
+	value: unknown,
+): MangaUpdatesRelease | null {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+	const record = (value as { record?: unknown }).record ?? value
+	if (!record || typeof record !== 'object' || Array.isArray(record))
+		return null
+	const fields = record as Record<string, unknown>
+
+	const releaseDate = optionalString(fields.release_date)
+	if (!releaseDate || !DATE_ONLY.test(releaseDate)) return null
+	const releaseAt = new Date(`${releaseDate}T00:00:00.000Z`)
+	if (!Number.isFinite(releaseAt.getTime())) return null
+
+	const id = fields.id
+	const sourceKey =
+		typeof id === 'number' && Number.isSafeInteger(id)
+			? `release:${id}`
+			: typeof id === 'string' && id.trim()
+				? `release:${id.trim()}`
+				: null
+	if (!sourceKey) return null
+
+	const chapter = parseReleaseNumber(fields.chapter)
+	const volume = parseReleaseNumber(fields.volume)
+	// A record that identifies neither a chapter nor a volume says nothing useful.
+	if (chapter === null && volume === null) return null
+
+	return {
+		sourceKey,
+		releaseAt,
+		chapter,
+		volume,
+		name: optionalString(fields.title),
+	}
+}
+
+/** Shape a normalised release into a `ReleaseOccurrence` row. */
+export function releaseOccurrenceInput(
+	release: MangaUpdatesRelease,
+	observedAt: Date,
+) {
+	const expiresAt = new Date(
+		release.releaseAt.getTime() + RELEASE_VISIBILITY_DAYS * DAY_MS,
+	)
+	return {
+		source: MANGAUPDATES_SOURCE,
+		sourceKey: release.sourceKey,
+		// The calendar styles chapter events distinctly; a volume-only record is
+		// still a chapter-shaped event for a reader.
+		eventType: 'chapter' as const,
+		releaseAt: release.releaseAt,
+		// MangaUpdates records a date with no time of day.
+		allDay: true,
+		season: null,
+		episode: null,
+		volume: release.volume,
+		chapter: release.chapter,
+		name: release.name,
+		status: 'scheduled' as const,
+		observedAt,
+		expiresAt,
+	}
+}
+
+export type MangaUpdatesFetch = (
+	url: string,
+	init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>
+
+function requireApproval(approvalRef: string | undefined) {
+	const ref = optionalString(approvalRef)
+	if (!ref) {
+		throw new Error(
+			'MANGAUPDATES_CATALOG_POLICY_APPROVAL_REF or --policy-approval-ref is required for committed MangaUpdates jobs',
+		)
+	}
+	return ref
+}
+
+async function postJson(
+	fetchImpl: MangaUpdatesFetch,
+	url: string,
+	body: unknown,
+) {
+	const response = await fetchImpl(url, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json', accept: 'application/json' },
+		body: JSON.stringify(body),
+	})
+	if (!response.ok) {
+		throw new Error(
+			`MangaUpdates request failed with status ${response.status}`,
+		)
+	}
+	return response.json()
+}
+
+function resultRecords(payload: unknown) {
+	if (!payload || typeof payload !== 'object') return []
+	const results = (payload as { results?: unknown }).results
+	return Array.isArray(results) ? results : []
+}
+
+/** Look up a series id by title. Only an exact, case-insensitive match counts. */
+export async function findMangaUpdatesSeriesId(
+	fetchImpl: MangaUpdatesFetch,
+	title: string,
+	options: { approvalRef?: string } = {},
+) {
+	requireApproval(options.approvalRef)
+	const wanted = title.trim().toLowerCase()
+	if (!wanted) return null
+	const payload = await postJson(fetchImpl, SERIES_SEARCH_ENDPOINT, {
+		search: title,
+		perpage: 10,
+	})
+	for (const entry of resultRecords(payload)) {
+		const record = (entry as { record?: unknown }).record
+		if (!record || typeof record !== 'object') continue
+		const fields = record as Record<string, unknown>
+		const candidate = optionalString(fields.title)?.toLowerCase()
+		const seriesId = fields.series_id
+		if (
+			candidate === wanted &&
+			typeof seriesId === 'number' &&
+			Number.isSafeInteger(seriesId)
+		) {
+			return seriesId
+		}
+	}
+	// A fuzzy match would attach one series' chapters to another title, which is
+	// worse than having no schedule at all.
+	return null
+}
+
+/** Fetch recent releases for one series, newest first. */
+export async function fetchMangaUpdatesReleases(
+	fetchImpl: MangaUpdatesFetch,
+	seriesId: number,
+	options: { approvalRef?: string; perPage?: number } = {},
+) {
+	requireApproval(options.approvalRef)
+	const payload = await postJson(fetchImpl, RELEASES_ENDPOINT, {
+		search: '',
+		series_id: seriesId,
+		perpage: options.perPage ?? 25,
+		orderby: 'date',
+	})
+	const releases: MangaUpdatesRelease[] = []
+	const seen = new Set<string>()
+	for (const entry of resultRecords(payload)) {
+		const release = normalizeMangaUpdatesRelease(entry)
+		if (!release || seen.has(release.sourceKey)) continue
+		seen.add(release.sourceKey)
+		releases.push(release)
+	}
+	return releases
+}

--- a/app/utils/mangaupdates-releases.test.ts
+++ b/app/utils/mangaupdates-releases.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from 'vitest'
+import {
+	fetchMangaUpdatesReleases,
+	findMangaUpdatesSeriesId,
+	normalizeMangaUpdatesRelease,
+	parseReleaseNumber,
+	releaseOccurrenceInput,
+	type MangaUpdatesFetch,
+} from './mangaupdates-releases.server.ts'
+
+const APPROVAL = 'OWNER-MANGAUPDATES-API-AGREEMENT'
+const observedAt = new Date('2026-07-30T12:00:00.000Z')
+
+function stubFetch(payload: unknown, ok = true, status = 200) {
+	const calls: Array<{ url: string; body: unknown }> = []
+	const impl: MangaUpdatesFetch = async (url, init) => {
+		calls.push({ url, body: JSON.parse(init.body) })
+		return { ok, status, json: async () => payload }
+	}
+	return { impl, calls }
+}
+
+// Shape taken from a live /v1/releases/search response.
+const liveRelease = {
+	record: {
+		id: 36642,
+		title: 'One Piece',
+		volume: '48',
+		chapter: '467',
+		groups: [{ name: 'One Piece HQ' }],
+		release_date: '2007-08-18',
+	},
+}
+
+test('a live release record normalises to a dated chapter', () => {
+	const release = normalizeMangaUpdatesRelease(liveRelease)
+	expect(release).not.toBeNull()
+	expect(release!.sourceKey).toBe('release:36642')
+	expect(release!.chapter).toBe(467)
+	expect(release!.volume).toBe(48)
+	expect(release!.releaseAt.toISOString()).toBe('2007-08-18T00:00:00.000Z')
+})
+
+test('chapter numbers that are not plain integers are read or refused, never coerced', () => {
+	expect(parseReleaseNumber('467')).toBe(467)
+	expect(parseReleaseNumber('c.467')).toBe(467)
+	// A range takes its first chapter rather than becoming a wrong single number.
+	expect(parseReleaseNumber('12-13')).toBe(12)
+	expect(parseReleaseNumber('12.5')).toBe(12)
+	for (const value of ['', '   ', 'oneshot', null, undefined, {}, 0, '0']) {
+		expect(parseReleaseNumber(value)).toBeNull()
+	}
+})
+
+test('a record without a usable date is dropped rather than dated by guess', () => {
+	for (const release_date of [
+		undefined,
+		null,
+		'',
+		'soon',
+		'2007-08',
+		'August',
+	]) {
+		expect(
+			normalizeMangaUpdatesRelease({
+				record: { ...liveRelease.record, release_date },
+			}),
+		).toBeNull()
+	}
+})
+
+test('a record identifying neither chapter nor volume is dropped', () => {
+	expect(
+		normalizeMangaUpdatesRelease({
+			record: { ...liveRelease.record, chapter: null, volume: null },
+		}),
+	).toBeNull()
+})
+
+test('a release becomes a chapter occurrence that expires on its own', () => {
+	const release = normalizeMangaUpdatesRelease(liveRelease)!
+	const input = releaseOccurrenceInput(release, observedAt)
+	expect(input.source).toBe('mangaupdates')
+	expect(input.eventType).toBe('chapter')
+	expect(input.chapter).toBe(467)
+	expect(input.allDay).toBe(true)
+	// Episodes and seasons belong to anime and must stay unset.
+	expect(input.episode).toBeNull()
+	expect(input.season).toBeNull()
+	expect(input.expiresAt.getTime()).toBeGreaterThan(input.releaseAt.getTime())
+})
+
+test('series lookup accepts only an exact title match', async () => {
+	const payload = {
+		results: [
+			{ record: { series_id: 1, title: 'One Piece: Colour Walk' } },
+			{ record: { series_id: 55099564912, title: 'One Piece' } },
+		],
+	}
+	const exact = stubFetch(payload)
+	await expect(
+		findMangaUpdatesSeriesId(exact.impl, 'one piece', {
+			approvalRef: APPROVAL,
+		}),
+	).resolves.toBe(55099564912)
+
+	// A near miss attaches one series' chapters to another title, so it is refused.
+	const fuzzy = stubFetch({
+		results: [{ record: { series_id: 1, title: 'One Piece: Colour Walk' } }],
+	})
+	await expect(
+		findMangaUpdatesSeriesId(fuzzy.impl, 'one piece', {
+			approvalRef: APPROVAL,
+		}),
+	).resolves.toBeNull()
+})
+
+test('committed lookups require the documented policy approval reference', async () => {
+	const { impl, calls } = stubFetch({ results: [] })
+	await expect(findMangaUpdatesSeriesId(impl, 'one piece', {})).rejects.toThrow(
+		/policy-approval-ref/i,
+	)
+	await expect(fetchMangaUpdatesReleases(impl, 1, {})).rejects.toThrow(
+		/policy-approval-ref/i,
+	)
+	// Nothing may reach the provider without the reference.
+	expect(calls).toHaveLength(0)
+})
+
+test('releases are fetched for one series and de-duplicated', async () => {
+	const { impl, calls } = stubFetch({
+		results: [
+			liveRelease,
+			liveRelease,
+			{ record: { id: 9, release_date: 'x' } },
+		],
+	})
+	const releases = await fetchMangaUpdatesReleases(impl, 55099564912, {
+		approvalRef: APPROVAL,
+	})
+	expect(releases).toHaveLength(1)
+	expect(releases[0]!.chapter).toBe(467)
+	expect((calls[0]!.body as { series_id: number }).series_id).toBe(55099564912)
+})
+
+test('a provider error is surfaced rather than treated as no releases', async () => {
+	const { impl } = stubFetch({}, false, 503)
+	await expect(
+		fetchMangaUpdatesReleases(impl, 1, { approvalRef: APPROVAL }),
+	).rejects.toThrow(/503/)
+})

--- a/docs/catalog-operations.md
+++ b/docs/catalog-operations.md
@@ -109,6 +109,32 @@ Required limits:
 
 Reassess the agreement before commercial use or a material expansion of scope.
 
+## MangaUpdates policy
+
+Authorization reference: `MANGAUPDATES_CATALOG_POLICY_APPROVAL_REF`.
+
+The deployment owner accepted the MangaUpdates API terms for server-side
+ingestion and redisplay of released-chapter records. Committed MangaUpdates jobs
+require the reference through that variable or `--policy-approval-ref`.
+
+Required limits:
+
+- use only the official MangaUpdates API;
+- ingest release records for tracked series, not user data or forum content;
+- retain visible MangaUpdates attribution and source links;
+- keep requests sequential and spaced by `--delay-ms`; and
+- correct or remove a requested record within 24 hours.
+
+**MangaUpdates records releases after they happen and publishes no forward
+schedule.** This ingestion therefore produces a factual record of chapters that
+have shipped, shown on the day they released. It does not predict a future
+chapter date, and no such date may be inferred from publication cadence: a
+guessed date in a release calendar reads as fact.
+
+Series are matched by exact, case-insensitive title. A near match would attach
+one series' chapters to another title, so anything less than exact is skipped
+and counted as unresolved.
+
 ## Monitoring and recovery
 
 The administrator catalog page and `npm run catalog:status` report coverage,

--- a/ops/local-production/deploy-catalog-release.sh
+++ b/ops/local-production/deploy-catalog-release.sh
@@ -52,6 +52,7 @@ writer_services=(
 	veud-production-tmdb-inventory.service
 	veud-production-retention-cleanup.service
 	veud-production-notification-digests.service
+	veud-production-mangaupdates-releases.service
 )
 writer_timers=(
 	veud-production-mal-hydration.timer
@@ -61,6 +62,7 @@ writer_timers=(
 	veud-production-tmdb-inventory.timer
 	veud-production-retention-cleanup.timer
 	veud-production-notification-digests.timer
+	veud-production-mangaupdates-releases.timer
 )
 all_writer_units=("${writer_services[@]}" "${writer_timers[@]}")
 declare -A original_unit_states=()

--- a/ops/local-production/run-mangaupdates-releases.sh
+++ b/ops/local-production/run-mangaupdates-releases.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Record released manga chapters from MangaUpdates for tracked series.
+#
+# Invoked through node, never `npm run`: npm replaces inherited file descriptors
+# with pipes and the catalog-writer lifetime-lock proof cannot pass through it.
+set -Eeuo pipefail
+source "$(dirname "$0")/common.sh"
+
+prepare_worker
+acquire_provider_lock mangaupdates
+
+run_guarded_worker scripts/import-mangaupdates-releases.ts \
+	--commit \
+	--limit "${VEUD_PRODUCTION_MANGAUPDATES_LIMIT:-200}" \
+	--delay-ms "${VEUD_PRODUCTION_MANGAUPDATES_DELAY_MS:-1000}"

--- a/ops/local-production/systemd/veud-production-mangaupdates-releases.service
+++ b/ops/local-production/systemd/veud-production-mangaupdates-releases.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Veud production MangaUpdates chapter release ingestion
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/Programs/Veud/ops/local-production/run-mangaupdates-releases.sh
+TimeoutStartSec=60min
+Nice=10
+CPUWeight=20
+IOWeight=20
+MemoryMax=500M

--- a/ops/local-production/systemd/veud-production-mangaupdates-releases.timer
+++ b/ops/local-production/systemd/veud-production-mangaupdates-releases.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Record released Veud manga chapters from MangaUpdates daily
+
+[Timer]
+OnCalendar=*-*-* 05:20:00
+RandomizedDelaySec=20m
+Persistent=true
+Unit=veud-production-mangaupdates-releases.service
+
+[Install]
+WantedBy=timers.target

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:icons": "tsx ./other/build-icons.ts",
     "build:react-router": "react-router build",
     "build:server": "tsx ./other/build-server.ts",
+    "catalog:mangaupdates-releases": "node scripts/assert-catalog-writer-runtime.mjs && node --import tsx scripts/import-mangaupdates-releases.ts",
     "catalog:mal-hydrate": "node scripts/assert-catalog-writer-runtime.mjs && node --import tsx scripts/hydrate-mal-catalog.ts",
     "catalog:mal-inventory": "node scripts/assert-catalog-writer-runtime.mjs && node --import tsx scripts/import-mal-inventory.ts",
     "catalog:mal-trending": "node scripts/assert-catalog-writer-runtime.mjs && node --import tsx scripts/refresh-mal-trending.ts",

--- a/scripts/import-mangaupdates-releases.ts
+++ b/scripts/import-mangaupdates-releases.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env -S node --import tsx
+import 'dotenv/config'
+import { PrismaClient } from '@prisma/client'
+import {
+	fetchMangaUpdatesReleases,
+	findMangaUpdatesSeriesId,
+	MANGAUPDATES_PROVIDER,
+	MANGAUPDATES_SOURCE,
+	releaseOccurrenceInput,
+	type MangaUpdatesFetch,
+} from '#app/utils/mangaupdates-releases.server.ts'
+import { assertCatalogWriterRuntimeProof } from './catalog-writer-runtime-guard.mjs'
+
+assertCatalogWriterRuntimeProof(process.env)
+
+const usage = `Usage: npm run catalog:mangaupdates-releases -- [options]
+
+Ingest released manga chapters from MangaUpdates for tracked series.
+
+MangaUpdates records releases after they happen and publishes no forward
+schedule, so this produces a factual record of chapters that have shipped. It
+never predicts a future chapter date.
+
+Options:
+  --commit                     Fetch and write (default: dry-run, no requests)
+  --policy-approval-ref VALUE  MangaUpdates storage/redisplay authorization reference
+  --limit N                    Maximum series to process (default: 50)
+  --delay-ms N                 Delay between provider requests (default: 1000)
+  --per-page N                 Releases requested per series (default: 25)
+  --help                       Show this help
+
+Commit mode requires --policy-approval-ref or
+MANGAUPDATES_CATALOG_POLICY_APPROVAL_REF.`
+
+const args = process.argv.slice(2)
+if (args.includes('--help')) {
+	console.log(usage)
+	process.exit(0)
+}
+
+function valueFor(flag: string) {
+	const index = args.indexOf(flag)
+	if (index < 0) return undefined
+	const value = args[index + 1]
+	if (!value || value.startsWith('--'))
+		throw new Error(`${flag} requires a value`)
+	return value
+}
+
+function positiveInteger(flag: string, fallback: number) {
+	const raw = valueFor(flag)
+	if (raw === undefined) return fallback
+	const parsed = Number(raw)
+	if (!Number.isSafeInteger(parsed) || parsed < 1) {
+		throw new Error(`${flag} must be a positive integer`)
+	}
+	return parsed
+}
+
+const commit = args.includes('--commit')
+const limit = positiveInteger('--limit', 50)
+const delayMs = positiveInteger('--delay-ms', 1_000)
+const perPage = positiveInteger('--per-page', 25)
+const approvalRef =
+	valueFor('--policy-approval-ref') ??
+	process.env['MANGAUPDATES_CATALOG_POLICY_APPROVAL_REF']?.trim()
+
+if (commit && !approvalRef) {
+	throw new Error(
+		'--policy-approval-ref or MANGAUPDATES_CATALOG_POLICY_APPROVAL_REF is required',
+	)
+}
+
+const prisma = new PrismaClient()
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+/** Requests stay sequential and spaced, as the provider terms require. */
+const providerFetch: MangaUpdatesFetch = async (url, init) => {
+	const response = await fetch(url, init)
+	return {
+		ok: response.ok,
+		status: response.status,
+		json: () => response.json(),
+	}
+}
+
+async function main() {
+	// Only series someone actually tracks, and only those still running: a
+	// completed series has no new chapters to record.
+	const candidates = await prisma.media.findMany({
+		where: {
+			kind: 'manga',
+			title: { not: null },
+			trackingStates: { some: {} },
+			NOT: { releaseStatus: { in: ['Finished', 'Discontinued'] } },
+		},
+		select: {
+			id: true,
+			title: true,
+			externalIds: {
+				where: { provider: MANGAUPDATES_PROVIDER, tombstonedAt: null },
+				select: { externalId: true },
+				take: 1,
+			},
+		},
+		orderBy: { id: 'asc' },
+		take: limit,
+	})
+
+	console.log(`Mode: ${commit ? 'COMMIT' : 'DRY RUN (no provider requests)'}`)
+	console.log(`Tracked ongoing manga selected: ${candidates.length}`)
+	if (!commit) {
+		const unmapped = candidates.filter(
+			media => !media.externalIds.length,
+		).length
+		console.log(`Series still needing a MangaUpdates id: ${unmapped}`)
+		return
+	}
+
+	let resolved = 0
+	let unresolved = 0
+	let written = 0
+	let failed = 0
+
+	for (const media of candidates) {
+		try {
+			let seriesId = Number(media.externalIds[0]?.externalId ?? Number.NaN)
+			if (!Number.isSafeInteger(seriesId)) {
+				const found = await findMangaUpdatesSeriesId(
+					providerFetch,
+					media.title ?? '',
+					{ approvalRef },
+				)
+				await sleep(delayMs)
+				if (found === null) {
+					unresolved++
+					continue
+				}
+				seriesId = found
+				await prisma.mediaExternalId.upsert({
+					where: {
+						provider_kind_externalId: {
+							provider: MANGAUPDATES_PROVIDER,
+							kind: 'manga',
+							externalId: String(seriesId),
+						},
+					},
+					create: {
+						provider: MANGAUPDATES_PROVIDER,
+						kind: 'manga',
+						externalId: String(seriesId),
+						mediaId: media.id,
+						sourceTitle: media.title,
+						lastFetchedAt: new Date(),
+						fetchStatus: 'ok',
+					},
+					update: { lastSeenAt: new Date(), fetchStatus: 'ok' },
+				})
+				resolved++
+			}
+
+			const releases = await fetchMangaUpdatesReleases(
+				providerFetch,
+				seriesId,
+				{
+					approvalRef,
+					perPage,
+				},
+			)
+			await sleep(delayMs)
+
+			const observedAt = new Date()
+			for (const release of releases) {
+				const input = releaseOccurrenceInput(release, observedAt)
+				await prisma.releaseOccurrence.upsert({
+					where: {
+						mediaId_source_sourceKey: {
+							mediaId: media.id,
+							source: MANGAUPDATES_SOURCE,
+							sourceKey: input.sourceKey,
+						},
+					},
+					create: { mediaId: media.id, ...input },
+					update: input,
+				})
+				written++
+			}
+		} catch (error) {
+			failed++
+			console.error(
+				`${media.title ?? media.id}: ${error instanceof Error ? error.message : String(error)}`,
+			)
+		}
+	}
+
+	console.log(`Series ids resolved: ${resolved}`)
+	console.log(`Series with no exact MangaUpdates match: ${unresolved}`)
+	console.log(`Chapter releases recorded: ${written}`)
+	console.log(`Series failed: ${failed}`)
+}
+
+try {
+	await main()
+} finally {
+	await prisma.$disconnect()
+}


### PR DESCRIPTION
Verified against the live MangaUpdates API before building: `/v1/releases/search` returns a **dated log of chapters that have already shipped**, and `/v1/series/{id}` exposes `latest_chapter` but no forward schedule field. There is no upcoming-chapter date to ingest from any provider, so this records what has actually been released, shown on the day it released.

The calendar pipeline already supported this end to end — `ReleaseOccurrence` has `chapter`/`volume` and the calendar styles chapter events distinctly. Only the source was missing.

**Deliberate refusals**, because a release calendar is read as fact:
- a record with no parseable date is dropped rather than dated by guess
- a chapter range (`"12-13"`) takes its first chapter rather than becoming a wrong single number; a record naming neither chapter nor volume is dropped
- series match on **exact** case-insensitive title only — a near match would attach one series' chapters to another title
- no future date is inferred from publication cadence

Committed jobs require `MANGAUPDATES_CATALOG_POLICY_APPROVAL_REF`, mirroring the MAL agreement pattern; requests stay sequential and spaced; only tracked, still-running series are processed. Ships with a launcher, systemd service and timer registered with the cutover's writer units.

Mutation-verified against fuzzy title matching, a missing approval requirement, defaulting an undated release to today, and swallowing provider errors.