### PR TITLE
Query MangaUpdates releases the way the provider actually supports

### DIFF
--- a/app/utils/mangaupdates-releases.server.ts
+++ b/app/utils/mangaupdates-releases.server.ts
@@ -155,8 +155,13 @@ function resultRecords(payload: unknown) {
 	return Array.isArray(results) ? results : []
 }
 
-/** Look up a series id by title. Only an exact, case-insensitive match counts. */
-export async function findMangaUpdatesSeriesId(
+/**
+ * Look up a series by title. Only an exact, case-insensitive match counts, and
+ * the provider's own canonical title comes back with the id: release records
+ * carry that title and no series id, so it is the only key that can associate a
+ * release with a series.
+ */
+export async function findMangaUpdatesSeries(
 	fetchImpl: MangaUpdatesFetch,
 	title: string,
 	options: { approvalRef?: string } = {},
@@ -179,7 +184,7 @@ export async function findMangaUpdatesSeriesId(
 			typeof seriesId === 'number' &&
 			Number.isSafeInteger(seriesId)
 		) {
-			return seriesId
+			return { seriesId, title: optionalString(fields.title) ?? title.trim() }
 		}
 	}
 	// A fuzzy match would attach one series' chapters to another title, which is
@@ -187,26 +192,45 @@ export async function findMangaUpdatesSeriesId(
 	return null
 }
 
-/** Fetch recent releases for one series, newest first. */
+/**
+ * Fetch releases for one series.
+ *
+ * The provider ignores `series_id` on this endpoint — passing it returns the
+ * same unfiltered results — and a release record carries only a title, never a
+ * series id. So the search is by title and the results are filtered here to
+ * records whose own title matches exactly. Skipping that filter would file
+ * another series' chapters under this one.
+ */
 export async function fetchMangaUpdatesReleases(
 	fetchImpl: MangaUpdatesFetch,
-	seriesId: number,
+	seriesTitle: string,
 	options: { approvalRef?: string; perPage?: number } = {},
 ) {
 	requireApproval(options.approvalRef)
+	const wanted = seriesTitle.trim().toLowerCase()
+	// An empty search is rejected by the provider, and would be meaningless here.
+	if (!wanted) return []
 	const payload = await postJson(fetchImpl, RELEASES_ENDPOINT, {
-		search: '',
-		series_id: seriesId,
+		search: seriesTitle.trim(),
 		perpage: options.perPage ?? 25,
-		orderby: 'date',
 	})
 	const releases: MangaUpdatesRelease[] = []
 	const seen = new Set<string>()
 	for (const entry of resultRecords(payload)) {
+		const record = (entry as { record?: unknown }).record ?? entry
+		const recordTitle =
+			record && typeof record === 'object'
+				? optionalString((record as Record<string, unknown>).title)
+				: null
+		if (recordTitle?.toLowerCase() !== wanted) continue
 		const release = normalizeMangaUpdatesRelease(entry)
 		if (!release || seen.has(release.sourceKey)) continue
 		seen.add(release.sourceKey)
 		releases.push(release)
 	}
+	// The provider does not return these in date order.
+	releases.sort(
+		(first, second) => second.releaseAt.getTime() - first.releaseAt.getTime(),
+	)
 	return releases
 }

--- a/app/utils/mangaupdates-releases.test.ts
+++ b/app/utils/mangaupdates-releases.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest'
 import {
 	fetchMangaUpdatesReleases,
-	findMangaUpdatesSeriesId,
+	findMangaUpdatesSeries,
 	normalizeMangaUpdatesRelease,
 	parseReleaseNumber,
 	releaseOccurrenceInput,
@@ -98,54 +98,73 @@ test('series lookup accepts only an exact title match', async () => {
 		],
 	}
 	const exact = stubFetch(payload)
+	// The provider's own canonical title comes back with the id, because release
+	// records carry that title and no series id.
 	await expect(
-		findMangaUpdatesSeriesId(exact.impl, 'one piece', {
-			approvalRef: APPROVAL,
-		}),
-	).resolves.toBe(55099564912)
+		findMangaUpdatesSeries(exact.impl, 'one piece', { approvalRef: APPROVAL }),
+	).resolves.toEqual({ seriesId: 55099564912, title: 'One Piece' })
 
 	// A near miss attaches one series' chapters to another title, so it is refused.
 	const fuzzy = stubFetch({
 		results: [{ record: { series_id: 1, title: 'One Piece: Colour Walk' } }],
 	})
 	await expect(
-		findMangaUpdatesSeriesId(fuzzy.impl, 'one piece', {
-			approvalRef: APPROVAL,
-		}),
+		findMangaUpdatesSeries(fuzzy.impl, 'one piece', { approvalRef: APPROVAL }),
 	).resolves.toBeNull()
 })
 
 test('committed lookups require the documented policy approval reference', async () => {
 	const { impl, calls } = stubFetch({ results: [] })
-	await expect(findMangaUpdatesSeriesId(impl, 'one piece', {})).rejects.toThrow(
+	await expect(findMangaUpdatesSeries(impl, 'one piece', {})).rejects.toThrow(
 		/policy-approval-ref/i,
 	)
-	await expect(fetchMangaUpdatesReleases(impl, 1, {})).rejects.toThrow(
-		/policy-approval-ref/i,
-	)
+	await expect(
+		fetchMangaUpdatesReleases(impl, 'One Piece', {}),
+	).rejects.toThrow(/policy-approval-ref/i)
 	// Nothing may reach the provider without the reference.
 	expect(calls).toHaveLength(0)
 })
 
-test('releases are fetched for one series and de-duplicated', async () => {
+test('releases from another series are filtered out, not attributed here', async () => {
+	// The provider ignores series_id on this endpoint and a release record carries
+	// only a title, so a text search returns other series too. Keeping them would
+	// file another series' chapters under this one.
+	const other = {
+		record: { ...liveRelease.record, id: 999, title: 'One Piece: Colour Walk' },
+	}
 	const { impl, calls } = stubFetch({
-		results: [
-			liveRelease,
-			liveRelease,
-			{ record: { id: 9, release_date: 'x' } },
-		],
+		results: [liveRelease, liveRelease, other, { record: { id: 9 } }],
 	})
-	const releases = await fetchMangaUpdatesReleases(impl, 55099564912, {
+	const releases = await fetchMangaUpdatesReleases(impl, 'One Piece', {
 		approvalRef: APPROVAL,
 	})
 	expect(releases).toHaveLength(1)
 	expect(releases[0]!.chapter).toBe(467)
-	expect((calls[0]!.body as { series_id: number }).series_id).toBe(55099564912)
+	// An empty search is rejected by the provider, so the title is always sent.
+	expect((calls[0]!.body as { search: string }).search).toBe('One Piece')
+	expect(calls[0]!.body).not.toHaveProperty('series_id')
+})
+
+test('releases come back newest first', async () => {
+	const older = {
+		record: { ...liveRelease.record, id: 1, release_date: '2007-08-18' },
+	}
+	const newer = {
+		record: { ...liveRelease.record, id: 2, release_date: '2026-07-26' },
+	}
+	const { impl } = stubFetch({ results: [older, newer] })
+	const releases = await fetchMangaUpdatesReleases(impl, 'One Piece', {
+		approvalRef: APPROVAL,
+	})
+	expect(releases.map(release => release.sourceKey)).toEqual([
+		'release:2',
+		'release:1',
+	])
 })
 
 test('a provider error is surfaced rather than treated as no releases', async () => {
 	const { impl } = stubFetch({}, false, 503)
 	await expect(
-		fetchMangaUpdatesReleases(impl, 1, { approvalRef: APPROVAL }),
+		fetchMangaUpdatesReleases(impl, 'One Piece', { approvalRef: APPROVAL }),
 	).rejects.toThrow(/503/)
 })

--- a/scripts/import-mangaupdates-releases.ts
+++ b/scripts/import-mangaupdates-releases.ts
@@ -3,7 +3,7 @@ import 'dotenv/config'
 import { PrismaClient } from '@prisma/client'
 import {
 	fetchMangaUpdatesReleases,
-	findMangaUpdatesSeriesId,
+	findMangaUpdatesSeries,
 	MANGAUPDATES_PROVIDER,
 	MANGAUPDATES_SOURCE,
 	releaseOccurrenceInput,
@@ -99,7 +99,7 @@ async function main() {
 			title: true,
 			externalIds: {
 				where: { provider: MANGAUPDATES_PROVIDER, tombstonedAt: null },
-				select: { externalId: true },
+				select: { externalId: true, sourceTitle: true },
 				take: 1,
 			},
 		},
@@ -124,9 +124,13 @@ async function main() {
 
 	for (const media of candidates) {
 		try {
-			let seriesId = Number(media.externalIds[0]?.externalId ?? Number.NaN)
-			if (!Number.isSafeInteger(seriesId)) {
-				const found = await findMangaUpdatesSeriesId(
+			const mapped = media.externalIds[0]
+			let seriesId = Number(mapped?.externalId ?? Number.NaN)
+			// Release records carry the provider's own title and no series id, so
+			// that title is what associates a release with this series.
+			let seriesTitle = mapped?.sourceTitle ?? null
+			if (!Number.isSafeInteger(seriesId) || !seriesTitle) {
+				const found = await findMangaUpdatesSeries(
 					providerFetch,
 					media.title ?? '',
 					{ approvalRef },
@@ -136,7 +140,8 @@ async function main() {
 					unresolved++
 					continue
 				}
-				seriesId = found
+				seriesId = found.seriesId
+				seriesTitle = found.title
 				await prisma.mediaExternalId.upsert({
 					where: {
 						provider_kind_externalId: {
@@ -150,22 +155,23 @@ async function main() {
 						kind: 'manga',
 						externalId: String(seriesId),
 						mediaId: media.id,
-						sourceTitle: media.title,
+						sourceTitle: seriesTitle,
 						lastFetchedAt: new Date(),
 						fetchStatus: 'ok',
 					},
-					update: { lastSeenAt: new Date(), fetchStatus: 'ok' },
+					update: {
+						lastSeenAt: new Date(),
+						fetchStatus: 'ok',
+						sourceTitle: seriesTitle,
+					},
 				})
 				resolved++
 			}
 
 			const releases = await fetchMangaUpdatesReleases(
 				providerFetch,
-				seriesId,
-				{
-					approvalRef,
-					perPage,
-				},
+				seriesTitle,
+				{ approvalRef, perPage },
 			)
 			await sleep(delayMs)
 


### PR DESCRIPTION
The first version recorded **nothing** — every releases request returned 400, and the run reported 136 series resolved with 0 chapters. Probing the live API found two mistakes:

1. An empty `search` fails field validation outright.
2. **`series_id` is silently ignored** on the releases endpoint. A broad search with and without it returns byte-identical results, and a release record carries only a title, never a series id — so nothing server-side can scope releases to one series.

Now searches by the provider's own canonical title (returned by the series lookup alongside the id) and filters results here to records whose title matches exactly. Without that filter a text search files another series' chapters under this one. Results are sorted newest first because the provider does not order them.

Verified against production: **170 chapter releases recorded across 12 tracked series, zero failures**, including One Piece 1187–1189 on their real dates.