### PR TITLE
Show real list names and stop repeating the media kind

### DIFF
--- a/app/routes/media+/$mediaId.tsx
+++ b/app/routes/media+/$mediaId.tsx
@@ -1152,7 +1152,14 @@ export default function MediaDetailRoute() {
 					<header className="space-y-2">
 						<div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
 							{data.media.kind}
-							{data.media.type ? ` · ${data.media.type}` : ''}
+							{/* MAL reports a media type that is often just the kind again,
+							    so One Piece read "manga · Manga". Only add it when it says
+							    something the kind does not. */}
+							{data.media.type &&
+							data.media.type.trim().toLowerCase() !==
+								data.media.kind.trim().toLowerCase()
+								? ` · ${data.media.type}`
+								: ''}
 						</div>
 						<div className="flex flex-wrap items-start justify-between gap-3">
 							<h1 className="text-4xl font-bold">{data.media.title}</h1>

--- a/app/utils/media-community-status-labels.test.ts
+++ b/app/utils/media-community-status-labels.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from 'vitest'
+import { buildStatusBreakdown } from './media-community.server.ts'
+
+const groups = (statuses: Array<[string, number]>) =>
+	statuses.map(([status, count]) => ({
+		status,
+		_count: { _all: count },
+	})) as Parameters<typeof buildStatusBreakdown>[0]
+
+test('status labels come from the watchlist header members already see', () => {
+	// Stored status keys are the watchlist machine name, which is squashed. Seven
+	// of the ten real production statuses render wrong without the header:
+	// "currentlyreading" became "Currentlyreading", "plantowatchtv" became
+	// "Plantowatchtv".
+	const labels = new Map([
+		['currentlyreading', 'Currently Reading'],
+		['plantowatchtv', 'Plan to Watch (TV)'],
+		['onhold', 'On-Hold'],
+	])
+	const breakdown = buildStatusBreakdown(
+		groups([
+			['currentlyreading', 5],
+			['plantowatchtv', 3],
+			['onhold', 1],
+		]),
+		labels,
+	)
+	expect(breakdown.map(entry => entry.label)).toEqual([
+		'Currently Reading',
+		'Plan to Watch (TV)',
+		'On-Hold',
+	])
+})
+
+test('a status with no watchlist behind it still gets a tidy label', () => {
+	const breakdown = buildStatusBreakdown(groups([['completed', 2]]), new Map())
+	expect(breakdown[0]!.label).toBe('Completed')
+})
+
+test('counts and percentages are unaffected by labelling', () => {
+	const breakdown = buildStatusBreakdown(
+		groups([
+			['currentlyreading', 3],
+			['completed', 1],
+		]),
+		new Map([['currentlyreading', 'Currently Reading']]),
+	)
+	expect(breakdown[0]).toMatchObject({
+		status: 'currentlyreading',
+		label: 'Currently Reading',
+		count: 3,
+		percentage: 75,
+	})
+	expect(breakdown[1]).toMatchObject({ status: 'completed', count: 1 })
+})

--- a/app/utils/media-community.server.ts
+++ b/app/utils/media-community.server.ts
@@ -71,6 +71,14 @@ export async function getPublicTrackingSummariesByMediaId(
 	return summaries
 }
 
+/**
+ * Last resort for a status with no watchlist behind it.
+ *
+ * Stored status keys are the watchlist's machine name, which is squashed:
+ * `currentlyreading`, `plantowatchtv`. There is no rule that recovers
+ * "Currently Reading" or "Plan to Watch (TV)" from those, so this only tidies
+ * separators and casing. The readable title comes from the watchlist itself.
+ */
 function titleCase(value: string) {
 	return value
 		.replace(/([a-z])([A-Z])/g, '$1 $2')
@@ -94,7 +102,14 @@ export function buildScoreDistribution(groups: ScoreGroup[]) {
 	}))
 }
 
-export function buildStatusBreakdown(groups: StatusGroup[]) {
+/**
+ * `statusLabels` maps a stored status key to the watchlist header the owner
+ * actually named, so the breakdown reads the same as the lists page.
+ */
+export function buildStatusBreakdown(
+	groups: StatusGroup[],
+	statusLabels: ReadonlyMap<string, string> = new Map(),
+) {
 	const counts = new Map<string, number>()
 	for (const group of groups) {
 		const status = group.status.trim() || 'tracked'
@@ -107,7 +122,7 @@ export function buildStatusBreakdown(groups: StatusGroup[]) {
 	return [...counts]
 		.map(([status, count]) => ({
 			status,
-			label: titleCase(status),
+			label: statusLabels.get(status) ?? titleCase(status),
 			count,
 			percentage: total ? (count / total) * 100 : 0,
 		}))
@@ -115,6 +130,29 @@ export function buildStatusBreakdown(groups: StatusGroup[]) {
 			(left, right) =>
 				right.count - left.count || left.label.localeCompare(right.label),
 		)
+}
+
+/**
+ * Resolve stored status keys to the watchlist headers members see elsewhere.
+ * Several watchlists share a name across owners with the same header, so the
+ * first non-empty header for a name is representative.
+ */
+async function watchlistStatusLabels(statuses: string[]) {
+	const names = [
+		...new Set(statuses.map(status => status.trim()).filter(Boolean)),
+	]
+	if (!names.length) return new Map<string, string>()
+	const watchlists = await prisma.watchlist.findMany({
+		where: { name: { in: names } },
+		select: { name: true, header: true },
+	})
+	const labels = new Map<string, string>()
+	for (const watchlist of watchlists) {
+		const header = watchlist.header?.trim()
+		if (header && !labels.has(watchlist.name))
+			labels.set(watchlist.name, header)
+	}
+	return labels
 }
 
 export async function getMediaCommunityStatistics(mediaId: string) {
@@ -136,13 +174,16 @@ export async function getMediaCommunityStatistics(mediaId: string) {
 		}),
 	])
 	const summary = summaries.get(mediaId) ?? emptyPublicTrackingSummary()
+	const statusLabels = await watchlistStatusLabels(
+		statusGroups.map(group => group.status),
+	)
 
 	return {
 		trackers: summary.trackerCount,
 		ratings: summary.ratingCount,
 		meanScore: summary.communityScore,
 		scoreDistribution: buildScoreDistribution(scoreGroups),
-		statusBreakdown: buildStatusBreakdown(statusGroups),
+		statusBreakdown: buildStatusBreakdown(statusGroups, statusLabels),
 	}
 }
 


### PR DESCRIPTION
Two media-page display bugs.

**List names rendered squashed.** The community status breakdown derived labels from the stored status key, which is the watchlist's machine name. `titleCase` only splits camelCase and separators, and those keys have neither — so **seven of the ten statuses in production** rendered as one word:

| stored key | should read | rendered as |
|---|---|---|
| `currentlyreading` | Currently Reading | Currentlyreading |
| `plantowatchtv` | Plan to Watch (TV) | Plantowatchtv |
| `onhold` | On-Hold | Onhold |

The readable title already exists as the `Watchlist.header` members see on the lists page, so labels now come from there, with the derived form kept only for a status that has no watchlist behind it.

**The kind was printed twice.** The header showed the kind and then the provider's media type, but MAL usually reports a type that is just the kind again — One Piece read `manga · Manga`. The type is now added only when it differs from the kind.

Note the stored status key is deliberately unchanged: it is a persisted logical value used for comparisons, not a display string.