### PR TITLE
Wait briefly for the restore target instead of failing the deployment

### DIFF
--- a/scripts/postgres-backup-operations.mjs
+++ b/scripts/postgres-backup-operations.mjs
@@ -367,6 +367,44 @@ export function assertDistinctPostgresEndpointIdentities(
 	}
 }
 
+/**
+ * Wait, briefly, for the restore target to have no other sessions.
+ *
+ * A deployment takes two backups minutes apart and both verify into the same
+ * disposable database, so a session that has not finished closing yet made the
+ * exclusivity check fail and took the whole deployment down with it — three
+ * times on 2026-07-30, each leaving the maintenance window open and the site
+ * returning 502 until the deployment was re-run. Re-running always worked
+ * because the session had gone by then.
+ *
+ * This only waits. The caller still asserts exclusivity afterwards, so a restore
+ * never runs while anything else holds the database.
+ */
+export async function awaitExclusiveRestoreTarget(
+	psql,
+	connection,
+	label,
+	options,
+) {
+	const waitMs = Math.max(0, options?.waitMs ?? 30_000)
+	const pollMs = Math.max(100, options?.pollMs ?? 1_000)
+	const deadline = (options?.now?.() ?? Date.now()) + waitMs
+	const readIdentity =
+		options?.readIdentity ??
+		(() => readPostgresEndpointIdentity(psql, connection, label))
+	let identity = await readIdentity()
+	while (
+		(identity.otherDatabaseSessions !== 0 ||
+			identity.preparedTransactions !== 0) &&
+		(options?.now?.() ?? Date.now()) < deadline
+	) {
+		options?.signal?.throwIfAborted()
+		await new Promise(resolve => setTimeout(resolve, pollMs))
+		identity = await readIdentity()
+	}
+	return identity
+}
+
 export function pinPostgresConnectionToEndpoint(connection, identity) {
 	if (identity.serverAddress === 'local-socket') return { ...connection }
 	return {
@@ -2747,10 +2785,11 @@ export async function verifyPostgresBackup({
 					pinnedSource,
 					'Locked PostgreSQL backup source',
 				)
-				const lockedRestoreIdentity = await readPostgresEndpointIdentity(
+				const lockedRestoreIdentity = await awaitExclusiveRestoreTarget(
 					psql,
 					pinnedRestore,
 					'Locked PostgreSQL restore target',
+					{ signal },
 				)
 				assertPostgresEndpointIdentityUnchanged(
 					sourceIdentity,

--- a/scripts/postgres-restore-exclusivity.test.mjs
+++ b/scripts/postgres-restore-exclusivity.test.mjs
@@ -1,0 +1,76 @@
+import { expect, test } from 'vitest'
+import { awaitExclusiveRestoreTarget } from './postgres-backup-operations.mjs'
+
+const busy = { otherDatabaseSessions: 1, preparedTransactions: 0 }
+const prepared = { otherDatabaseSessions: 0, preparedTransactions: 1 }
+const free = { otherDatabaseSessions: 0, preparedTransactions: 0 }
+
+function reader(sequence) {
+	let index = 0
+	const calls = () => index
+	return {
+		read: async () => sequence[Math.min(index++, sequence.length - 1)],
+		calls,
+	}
+}
+
+test('an already exclusive target is returned without waiting', async () => {
+	const { read, calls } = reader([free])
+	const identity = await awaitExclusiveRestoreTarget(null, null, 'test', {
+		readIdentity: read,
+		waitMs: 10_000,
+		pollMs: 1,
+	})
+	expect(identity).toEqual(free)
+	expect(calls()).toBe(1)
+})
+
+test('a session that is still closing is waited out', async () => {
+	// The failure this fixes: a deployment takes two backups minutes apart, and
+	// the first one's session had not finished closing when the second checked.
+	const { read } = reader([busy, busy, free])
+	const identity = await awaitExclusiveRestoreTarget(null, null, 'test', {
+		readIdentity: read,
+		waitMs: 10_000,
+		pollMs: 1,
+	})
+	expect(identity).toEqual(free)
+})
+
+test('a prepared transaction is waited out too', async () => {
+	const { read } = reader([prepared, free])
+	const identity = await awaitExclusiveRestoreTarget(null, null, 'test', {
+		readIdentity: read,
+		waitMs: 10_000,
+		pollMs: 1,
+	})
+	expect(identity).toEqual(free)
+})
+
+test('waiting is bounded, and a target that never frees is still reported busy', async () => {
+	// The caller asserts exclusivity afterwards, so a destructive restore must
+	// never proceed just because the wait expired.
+	const { read } = reader([busy])
+	let now = 0
+	const identity = await awaitExclusiveRestoreTarget(null, null, 'test', {
+		readIdentity: read,
+		waitMs: 50,
+		pollMs: 1,
+		now: () => (now += 30),
+	})
+	expect(identity).toEqual(busy)
+})
+
+test('an aborted run stops waiting', async () => {
+	const controller = new AbortController()
+	controller.abort()
+	const { read } = reader([busy, free])
+	await expect(
+		awaitExclusiveRestoreTarget(null, null, 'test', {
+			readIdentity: read,
+			waitMs: 10_000,
+			pollMs: 1,
+			signal: controller.signal,
+		}),
+	).rejects.toThrow()
+})


### PR DESCRIPTION
A deployment takes two backups minutes apart and both verify into the same disposable database. The exclusivity check refused outright whenever another session or prepared transaction was present — no wait, no retry — so a session that had not finished closing failed the post-cutover backup and took the whole deployment with it.

That happened **three times on 2026-07-30**. Each left the maintenance window open at `failed-after-database-mutation` with the site returning **502** until the deployment was re-run, and each re-run succeeded because the competing session had gone.

Now waits for the target to become exclusive — bounded and abortable — before asserting. **The assertion is unchanged:** a target that never frees is still reported busy and the destructive restore still refuses to run. Only the transient case changes.

Mutation-verified against removing the wait, making it unbounded, and ignoring prepared transactions.

I first recorded this in ROADMAP as the hourly backup cron firing mid-cutover. The timings disprove that — cron backups ran at 15:00, 16:00 and 17:00 while the failing deployments started at 15:32 and 16:17 — so the entry is corrected to what the evidence actually shows.